### PR TITLE
Add linked service for datalab storage account

### DIFF
--- a/workspace/linkedService/ls_datalab.json
+++ b/workspace/linkedService/ls_datalab.json
@@ -1,0 +1,22 @@
+{
+	"name": "ls_datalab",
+	"properties": {
+		"annotations": [],
+		"type": "AzureFileStorage",
+		"typeProperties": {
+			"connectionString": {
+				"type": "AzureKeyVaultSecret",
+				"store": {
+					"referenceName": "ls_kv",
+					"type": "LinkedServiceReference"
+				},
+				"secretName": "datalab-connectionstring"
+			},
+			"fileShare": "datalab"
+		},
+		"connectVia": {
+			"referenceName": "AutoResolveIntegrationRuntime",
+			"type": "IntegrationRuntimeReference"
+		}
+	}
+}


### PR DESCRIPTION
- Links the datalab Storage Account to the development Synapse Workspace using a connection string from Key Vault.