### PR TITLE
Assign Key Vault RBAC to management Key Vault

### DIFF
--- a/infrastructure/workload.tf
+++ b/infrastructure/workload.tf
@@ -21,6 +21,8 @@ module "synapse_management" {
   location            = module.azure_region.location_cli
   service_name        = local.service_name
 
+  key_vault_role_assignments = var.key_vault_role_assignments
+
   tags = local.tags
 }
 


### PR DESCRIPTION
- Fixes an oversight where the RBAC groups were not being assigned to the management Key Vault.