### PR TITLE
Add tzlocal python package to Spark pool

### DIFF
--- a/infrastructure/configuration/spark-pool/requirements.txt
+++ b/infrastructure/configuration/spark-pool/requirements.txt
@@ -11,5 +11,6 @@ mypy
 # Machine Learning
 tensorflow==2.10.0
 
-# Timezones
+# Time
+croniter
 tzlocal


### PR DESCRIPTION
- Add the `tzlocal` package to Spark for easier management of time zones. 