### PR TITLE
Synapse release failover adjustments

### DIFF
--- a/pipelines/synapse-release.yaml
+++ b/pipelines/synapse-release.yaml
@@ -6,10 +6,6 @@ parameters:
     values:
     - Test
     - Prod
-  - name: failover_deployment
-    displayName: 'Failover Deployment'
-    type: boolean
-    default: false
   - name: source_workspace
     displayName: 'Published Artifact Source'
     type: string
@@ -17,6 +13,10 @@ parameters:
     values:
     - Primary
     - Secondary
+  - name: failover_deployment
+    displayName: 'Failover Deployment'
+    type: boolean
+    default: false
 
 variables:
 - group: Terraform ${{ parameters.environment }}


### PR DESCRIPTION
- Add missing `failoverDeployment` parameter to Terraform Plan step on release.
- Add pipeline variable with reference to the dev UK South workspace for retrieving release artifacts from the `workspace_publish` branch.