### PR TITLE
fix/failover-notebook-variables-reference

### DIFF
--- a/workspace/pipeline/0_pln_source_to_raw_fileshare.json
+++ b/workspace/pipeline/0_pln_source_to_raw_fileshare.json
@@ -57,13 +57,6 @@
 							},
 							"type": "string"
 						},
-						"akv_name": {
-							"value": {
-								"value": "@pipeline().parameters.akv_name",
-								"type": "Expression"
-							},
-							"type": "string"
-						},
 						"secret_name": {
 							"value": {
 								"value": "@pipeline().parameters.secret_name",

--- a/workspace/pipeline/0_pln_source_to_raw_fileshare_copy_activity.json
+++ b/workspace/pipeline/0_pln_source_to_raw_fileshare_copy_activity.json
@@ -141,13 +141,6 @@
 										},
 										"type": "string"
 									},
-									"akv_name": {
-										"value": {
-											"value": "@pipeline().parameters.akv_name",
-											"type": "Expression"
-										},
-										"type": "string"
-									},
 									"secret_name": {
 										"value": {
 											"value": "@pipeline().parameters.secret_name",


### PR DESCRIPTION
validation failed due to akv_name being referenced without there being a value provided- variable reference has been removed as spark variables are now in use on a per environment basis