### PR TITLE
Fix: odw 334 pipeline filename reference

### DIFF
--- a/workspace/dataset/Contacts_Organisation_LPA.json
+++ b/workspace/dataset/Contacts_Organisation_LPA.json
@@ -16,6 +16,10 @@
 		"typeProperties": {
 			"location": {
 				"type": "AzureBlobFSLocation",
+				"fileName": {
+					"value": "@dataset().FileName",
+					"type": "Expression"
+				},
 				"folderPath": {
 					"value": "@concat('Horizon', '/', formatDateTime(utcnow(), 'yyyy-MM-dd'))",
 					"type": "Expression"


### PR DESCRIPTION
Dataset was missing a reference to use the filename from the pipeline when the dataset is called as part of the sink section of a copy activity 