### PR TITLE
Fail CI Pipeline on Validation Errors

### DIFF
--- a/pipelines/steps/checkov-validate.yaml
+++ b/pipelines/steps/checkov-validate.yaml
@@ -19,6 +19,7 @@ steps:
 
       if [[ $? -ne 0 ]]; then
         echo "##vso[task.logissue type=error]Checkov reported failures"
+        exit 1
       fi
     displayName: 'Checkov Validate'
     workingDirectory: ${{ parameters.workingDirectory }}

--- a/pipelines/steps/tflint-validate.yaml
+++ b/pipelines/steps/tflint-validate.yaml
@@ -28,6 +28,7 @@ steps:
 
       if [[ $? -ne 0 ]]; then
         echo "##vso[task.logissue type=error]TFLint reported failures"
+        exit 1
       fi
     displayName: 'TFLint Validate'
     workingDirectory: ${{ parameters.workingDirectory }}


### PR DESCRIPTION
- Exit the `TFLint` and `Checkov` pipeline steps on error.