### PR TITLE
Remove Explicit Module Dependencies

### DIFF
--- a/infrastructure/workload-agent-pool.tf
+++ b/infrastructure/workload-agent-pool.tf
@@ -13,10 +13,6 @@ module "devops_agent_pool" {
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network.vnet_subnets
 
-  depends_on = [
-    module.synapse_network
-  ]
-
   tags = local.tags
 }
 
@@ -34,10 +30,6 @@ module "devops_agent_pool_failover" {
   devops_agent_subnet_name  = local.compute_subnet_name
   devops_agent_vm_sku       = var.devops_agent_vm_sku
   vnet_subnet_ids           = module.synapse_network_failover.vnet_subnets
-
-  depends_on = [
-    module.synapse_network_failover
-  ]
 
   tags = local.tags
 }

--- a/infrastructure/workload-data-lake.tf
+++ b/infrastructure/workload-data-lake.tf
@@ -40,11 +40,6 @@ module "synapse_data_lake" {
   vnet_subnet_ids                        = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover               = module.synapse_network_failover.vnet_subnets
 
-  depends_on = [
-    module.synapse_network,
-    module.synapse_network_failover
-  ]
-
   tags = local.tags
 }
 
@@ -75,11 +70,6 @@ module "synapse_data_lake_failover" {
   tenant_id                              = var.tenant_id
   vnet_subnet_ids                        = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover               = module.synapse_network.vnet_subnets
-
-  depends_on = [
-    module.synapse_network,
-    module.synapse_network_failover
-  ]
 
   tags = local.tags
 }

--- a/infrastructure/workload-ingestion.tf
+++ b/infrastructure/workload-ingestion.tf
@@ -46,9 +46,5 @@ module "synapse_ingestion_failover" {
   synapse_workspace_failover_principal_id = try(module.synapse_workspace_private_failover.synapse_workspace_principal_id, null)
   synapse_workspace_principal_id          = module.synapse_workspace_private.synapse_workspace_principal_id
 
-  depends_on = [
-    module.synapse_ingestion
-  ]
-
   tags = local.tags
 }

--- a/infrastructure/workload-management.tf
+++ b/infrastructure/workload-management.tf
@@ -32,11 +32,6 @@ module "synapse_management" {
   vnet_subnet_ids                        = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover               = module.synapse_network_failover.vnet_subnets
 
-  depends_on = [
-    module.synapse_network,
-    module.synapse_network_failover
-  ]
-
   tags = local.tags
 }
 
@@ -59,11 +54,6 @@ module "synapse_management_failover" {
   synapse_private_endpoint_subnet_name   = module.synapse_network_failover.synapse_private_endpoint_subnet_name
   vnet_subnet_ids                        = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover               = module.synapse_network.vnet_subnets
-
-  depends_on = [
-    module.synapse_network,
-    module.synapse_network_failover
-  ]
 
   tags = local.tags
 }
@@ -88,11 +78,6 @@ module "bastion_host" {
   synapse_vnet_subnet_names    = module.synapse_network.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network.vnet_subnet_prefixes
 
-  depends_on = [
-    module.synapse_network,
-    module.synapse_management
-  ]
-
   tags = local.tags
 }
 
@@ -115,11 +100,6 @@ module "bastion_host_failover" {
   synapse_vnet_security_groups = module.synapse_network_failover.vnet_security_groups
   synapse_vnet_subnet_names    = module.synapse_network_failover.vnet_subnets
   synapse_vnet_subnet_prefixes = module.synapse_network_failover.vnet_subnet_prefixes
-
-  depends_on = [
-    module.synapse_network_failover,
-    module.synapse_management_failover
-  ]
 
   tags = local.tags
 }

--- a/infrastructure/workload-monitoring.tf
+++ b/infrastructure/workload-monitoring.tf
@@ -38,13 +38,6 @@ module "synapse_monitoring" {
   synapse_workspace_id                     = module.synapse_workspace_private.synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network.vnet_id
 
-  depends_on = [
-    module.synapse_data_lake,
-    module.synapse_ingestion,
-    module.synapse_network,
-    module.synapse_workspace_private
-  ]
-
   tags = local.tags
 }
 
@@ -73,13 +66,6 @@ module "synapse_monitoring_failover" {
   synapse_sql_pool_id                      = module.synapse_workspace_private_failover[0].synapse_sql_pool_id
   synapse_workspace_id                     = module.synapse_workspace_private_failover[0].synapse_workspace_id
   synapse_vnet_id                          = module.synapse_network_failover.vnet_id
-
-  depends_on = [
-    module.synapse_data_lake_failover,
-    module.synapse_ingestion_failover,
-    module.synapse_network_failover,
-    module.synapse_workspace_private_failover
-  ]
 
   tags = local.tags
 }

--- a/infrastructure/workload-shir.tf
+++ b/infrastructure/workload-shir.tf
@@ -26,11 +26,6 @@ module "synapse_shir" {
   synapse_workspace_id     = module.synapse_workspace_private.synapse_workspace_id
   vnet_subnet_ids          = module.synapse_network.vnet_subnets
 
-  depends_on = [
-    module.synapse_network,
-    module.synapse_workspace_private
-  ]
-
   tags = local.tags
 }
 
@@ -47,11 +42,6 @@ module "synapse_shir_failover" {
   devops_agent_subnet_name = local.compute_subnet_name
   synapse_workspace_id     = module.synapse_workspace_private_failover[0].synapse_workspace_id
   vnet_subnet_ids          = module.synapse_network_failover.vnet_subnets
-
-  depends_on = [
-    module.synapse_network_failover,
-    module.synapse_workspace_private_failover
-  ]
 
   tags = local.tags
 }

--- a/infrastructure/workload-sql-server.tf
+++ b/infrastructure/workload-sql-server.tf
@@ -35,11 +35,6 @@ module "synapse_sql_server" {
   vnet_subnet_ids                   = module.synapse_network.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network_failover.vnet_subnets
 
-  depends_on = [
-    module.synapse_data_lake,
-    module.synapse_workspace_private
-  ]
-
   tags = local.tags
 }
 
@@ -61,11 +56,6 @@ module "synapse_sql_server_failover" {
   synapse_workspace_id              = module.synapse_workspace_private_failover[0].synapse_workspace_id
   vnet_subnet_ids                   = module.synapse_network_failover.vnet_subnets
   vnet_subnet_ids_failover          = module.synapse_network.vnet_subnets
-
-  depends_on = [
-    module.synapse_data_lake_failover,
-    module.synapse_workspace_private_failover
-  ]
 
   tags = local.tags
 }

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -35,13 +35,6 @@ module "synapse_workspace_private" {
   synapse_role_assignments              = var.synapse_role_assignments
   tenant_id                             = var.tenant_id
 
-  depends_on = [
-    module.synapse_data_lake,
-    module.synapse_data_lake_failover,
-    module.synapse_network,
-    module.synapse_management
-  ]
-
   tags = local.tags
 }
 
@@ -83,13 +76,6 @@ module "synapse_workspace_private_failover" {
   synapse_sql_administrator_username    = var.synapse_sql_administrator_username
   synapse_role_assignments              = var.synapse_role_assignments
   tenant_id                             = var.tenant_id
-
-  depends_on = [
-    module.synapse_data_lake,
-    module.synapse_data_lake_failover,
-    module.synapse_network_failover,
-    module.synapse_management_failover
-  ]
 
   tags = local.tags
 }


### PR DESCRIPTION
- Remove `depends_on` block from modules to prevent automatic recalculation of dependent module data sources on every apply. 