### PR TITLE
Update Diagnostic Setting Resources

### DIFF
--- a/infrastructure/modules/synapse-monitoring/monitor-key-vault.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-key-vault.tf
@@ -13,9 +13,8 @@ resource "azurerm_monitor_diagnostic_setting" "key_vault" {
     }
   }
 
-  log {
+  enabled_log {
     category = "AuditEvent"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -23,9 +22,8 @@ resource "azurerm_monitor_diagnostic_setting" "key_vault" {
     }
   }
 
-  log {
+  enabled_log {
     category = "AzurePolicyEvaluationDetails"
-    enabled  = true
 
     retention_policy {
       days    = 0

--- a/infrastructure/modules/synapse-monitoring/monitor-network.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-network.tf
@@ -13,9 +13,8 @@ resource "azurerm_monitor_diagnostic_setting" "network" {
     }
   }
 
-  log {
+  enabled_log {
     category = "VMProtectionAlerts"
-    enabled  = true
 
     retention_policy {
       days    = 0

--- a/infrastructure/modules/synapse-monitoring/monitor-service-bus.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-service-bus.tf
@@ -13,9 +13,8 @@ resource "azurerm_monitor_diagnostic_setting" "service_bus_namespace" {
     }
   }
 
-  log {
+  enabled_log {
     category = "ApplicationMetricsLogs"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -23,9 +22,8 @@ resource "azurerm_monitor_diagnostic_setting" "service_bus_namespace" {
     }
   }
 
-  log {
+  enabled_log {
     category = "OperationalLogs"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -33,9 +31,8 @@ resource "azurerm_monitor_diagnostic_setting" "service_bus_namespace" {
     }
   }
 
-  log {
+  enabled_log {
     category = "RuntimeAuditLogs"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -43,9 +40,8 @@ resource "azurerm_monitor_diagnostic_setting" "service_bus_namespace" {
     }
   }
 
-  log {
+  enabled_log {
     category = "VNetAndIPFilteringLogs"
-    enabled  = true
 
     retention_policy {
       days    = 0

--- a/infrastructure/modules/synapse-monitoring/monitor-synapse-spark-pool.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-synapse-spark-pool.tf
@@ -15,9 +15,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_spark_pool" {
     }
   }
 
-  log {
+  enabled_log {
     category = "BigDataPoolAppsEnded"
-    enabled  = true
 
     retention_policy {
       days    = 0

--- a/infrastructure/modules/synapse-monitoring/monitor-synapse-sql-pool.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-synapse-sql-pool.tf
@@ -14,9 +14,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_sql_pool" {
     }
   }
 
-  log {
+  enabled_log {
     category = "DmsWorkers"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -24,9 +23,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_sql_pool" {
     }
   }
 
-  log {
+  enabled_log {
     category = "ExecRequests"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -34,9 +32,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_sql_pool" {
     }
   }
 
-  log {
+  enabled_log {
     category = "RequestSteps"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -44,9 +41,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_sql_pool" {
     }
   }
 
-  log {
+  enabled_log {
     category = "SQLSecurityAuditEvents"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -54,9 +50,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_sql_pool" {
     }
   }
 
-  log {
+  enabled_log {
     category = "SqlRequests"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -64,9 +59,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse_sql_pool" {
     }
   }
 
-  log {
+  enabled_log {
     category = "Waits"
-    enabled  = true
 
     retention_policy {
       days    = 0

--- a/infrastructure/modules/synapse-monitoring/monitor-synapse.tf
+++ b/infrastructure/modules/synapse-monitoring/monitor-synapse.tf
@@ -13,9 +13,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "BuiltinSqlReqsEnded"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -23,9 +22,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "GatewayApiRequests"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -33,9 +31,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "IntegrationActivityRuns"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -43,9 +40,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "IntegrationPipelineRuns"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -53,9 +49,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "IntegrationTriggerRuns"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -63,9 +58,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "SQLSecurityAuditEvents"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -73,9 +67,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "SynapseLinkEvent"
-    enabled  = true
 
     retention_policy {
       days    = 0
@@ -83,9 +76,8 @@ resource "azurerm_monitor_diagnostic_setting" "synapse" {
     }
   }
 
-  log {
+  enabled_log {
     category = "SynapseRbacOperations"
-    enabled  = true
 
     retention_policy {
       days    = 0


### PR DESCRIPTION
- Update all `azurerm_monitor_diagnostic_setting` resources to use `enabled_log` blocks instead of `log` blocks to due deprecation in upcoming Terraform versions. This change requires the removal of all `enabled` attributes as this is implicit in the new `enabled_log` blocks compared to the old `log` block format.  