### PR TITLE
adding new protobuf requirement

### DIFF
--- a/infrastructure/configuration/spark-pool/requirements.txt
+++ b/infrastructure/configuration/spark-pool/requirements.txt
@@ -9,7 +9,7 @@ azure-storage-file-share
 mypy
 
 # Machine Learning
-tensorflow==2.10.0
+protobuf==3.19.6
 
 # Time
 croniter


### PR DESCRIPTION
Abdullah identified change to protobuf version fixed Spark Pool package dependency issue on Spark 3.2 and Spark 3.3.
Manually tested this change on both Azure Spark Pools in Dev so good to PR into main and redeploy