### PR TITLE
Changed spark pool reference in notebooks to allow deletion of primary spark pool

### DIFF
--- a/workspace/notebook/HIST_Employee_HR_Hierarchy_Dim.json
+++ b/workspace/notebook/HIST_Employee_HR_Hierarchy_Dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_HR_record_fact.json
+++ b/workspace/notebook/HIST_HR_record_fact.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_OrganisationUnit_Dim.json
+++ b/workspace/notebook/HIST_OrganisationUnit_Dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_PINS_location_dim.json
+++ b/workspace/notebook/HIST_PINS_location_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_contract_dim.json
+++ b/workspace/notebook/HIST_contract_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_costcentre_dim.json
+++ b/workspace/notebook/HIST_costcentre_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_employee_dim.json
+++ b/workspace/notebook/HIST_employee_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_employee_fact.json
+++ b/workspace/notebook/HIST_employee_fact.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_employeegroup_dim.json
+++ b/workspace/notebook/HIST_employeegroup_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_payband_dim.json
+++ b/workspace/notebook/HIST_payband_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_payrollarea_dim.json
+++ b/workspace/notebook/HIST_payrollarea_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_personnelarea_dim.json
+++ b/workspace/notebook/HIST_personnelarea_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_personnelsubarea_dim.json
+++ b/workspace/notebook/HIST_personnelsubarea_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_position_dim.json
+++ b/workspace/notebook/HIST_position_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/HIST_sap_hr_master.json
+++ b/workspace/notebook/HIST_sap_hr_master.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/Leavers not in SAPHR.json
+++ b/workspace/notebook/Leavers not in SAPHR.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/Notebook 1.json
+++ b/workspace/notebook/Notebook 1.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/data-checks.json
+++ b/workspace/notebook/data-checks.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/delete-hr-harmonised.json
+++ b/workspace/notebook/delete-hr-harmonised.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/employeeLeavers_dim.json
+++ b/workspace/notebook/employeeLeavers_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/gather_data_quality_reports.json
+++ b/workspace/notebook/gather_data_quality_reports.json
@@ -4,7 +4,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_absence_dim.json
+++ b/workspace/notebook/hr_absence_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_contract_dim.json
+++ b/workspace/notebook/hr_contract_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_costcenter_dim.json
+++ b/workspace/notebook/hr_costcenter_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_disability_dim.json
+++ b/workspace/notebook/hr_disability_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_diversity_dim.json
+++ b/workspace/notebook/hr_diversity_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_employee_dim.json
+++ b/workspace/notebook/hr_employee_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_employee_fact.json
+++ b/workspace/notebook/hr_employee_fact.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_employee_hr_hierarchy_dim.json
+++ b/workspace/notebook/hr_employee_hr_hierarchy_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_employeegroup_dim.json
+++ b/workspace/notebook/hr_employeegroup_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_leave_entitlement_dim.json
+++ b/workspace/notebook/hr_leave_entitlement_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_organisation_unit_dim.json
+++ b/workspace/notebook/hr_organisation_unit_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_payband_dim.json
+++ b/workspace/notebook/hr_payband_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_payroll_area_dim.json
+++ b/workspace/notebook/hr_payroll_area_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_personnel_area_dim.json
+++ b/workspace/notebook/hr_personnel_area_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_personnel_sub_area_dim.json
+++ b/workspace/notebook/hr_personnel_sub_area_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_pins_location_dim.json
+++ b/workspace/notebook/hr_pins_location_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_position_dim.json
+++ b/workspace/notebook/hr_position_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_record_fact.json
+++ b/workspace/notebook/hr_record_fact.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_religion_dim.json
+++ b/workspace/notebook/hr_religion_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_secure_info_fact.json
+++ b/workspace/notebook/hr_secure_info_fact.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_specialism_dim.json
+++ b/workspace/notebook/hr_specialism_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_sxo_dim.json
+++ b/workspace/notebook/hr_sxo_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/hr_work_schedule_dim.json
+++ b/workspace/notebook/hr_work_schedule_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/lake database query.json
+++ b/workspace/notebook/lake database query.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/legacy_mrw_tables.json
+++ b/workspace/notebook/legacy_mrw_tables.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/main_sourcesystem_fact.json
+++ b/workspace/notebook/main_sourcesystem_fact.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/outstanding_files_add_entry.json
+++ b/workspace/notebook/outstanding_files_add_entry.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_0_log_copy_activity_output.json
+++ b/workspace/notebook/py_0_log_copy_activity_output.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_0_source_to_raw_hr_functions.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_functions.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_0_source_to_raw_hr_main.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_main.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_0_source_to_raw_hr_tests.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_tests.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_1_raw_to_standardised_hr_main.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_main.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_1_raw_to_standardised_hr_tests.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_tests.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_amend_tables.json
+++ b/workspace/notebook/py_amend_tables.json
@@ -8,7 +8,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_create_lake_databases.json
+++ b/workspace/notebook/py_create_lake_databases.json
@@ -8,7 +8,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_create_tables.json
+++ b/workspace/notebook/py_create_tables.json
@@ -8,7 +8,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_create_tables_new.json
+++ b/workspace/notebook/py_create_tables_new.json
@@ -8,7 +8,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_create_views_SAP_HR.json
+++ b/workspace/notebook/py_create_views_SAP_HR.json
@@ -4,7 +4,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_delete_outstanding_files_entry.json
+++ b/workspace/notebook/py_delete_outstanding_files_entry.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_delete_rows_raw_to_std_outstanding_files.json
+++ b/workspace/notebook/py_delete_rows_raw_to_std_outstanding_files.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_delete_table.json
+++ b/workspace/notebook/py_delete_table.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_delete_table_contents.json
+++ b/workspace/notebook/py_delete_table_contents.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_delta_table_cleanup.json
+++ b/workspace/notebook/py_delta_table_cleanup.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_employee_harmonised_layer2_transform.json
+++ b/workspace/notebook/py_employee_harmonised_layer2_transform.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_fail_activity_logging.json
+++ b/workspace/notebook/py_fail_activity_logging.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_generate_schema.json
+++ b/workspace/notebook/py_generate_schema.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_inspector_address_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_inspector_address_harmonised_layer1_transform.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_inspector_harmonised_to_curated_load.json
+++ b/workspace/notebook/py_inspector_harmonised_to_curated_load.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_inspector_raw_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_inspector_raw_harmonised_layer1_transform.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_load_standardised_to_harmonised.json
+++ b/workspace/notebook/py_load_standardised_to_harmonised.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_logging_decorator.json
+++ b/workspace/notebook/py_logging_decorator.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_odw_harmonised_table_creation.json
+++ b/workspace/notebook/py_odw_harmonised_table_creation.json
@@ -8,7 +8,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_populate_HR_dimension_tables.json
+++ b/workspace/notebook/py_populate_HR_dimension_tables.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_populate_HR_dimension_tables_protected_data.json
+++ b/workspace/notebook/py_populate_HR_dimension_tables_protected_data.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_process_raw_to_curated_table_for_reports.json
+++ b/workspace/notebook/py_process_raw_to_curated_table_for_reports.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_process_raw_to_standardised_delta_table.json
+++ b/workspace/notebook/py_process_raw_to_standardised_delta_table.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_process_raw_to_standardised_validate.json
+++ b/workspace/notebook/py_process_raw_to_standardised_validate.json
@@ -8,7 +8,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_sap_hr_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_sap_hr_harmonised_layer1_transform.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_standardised_to_harmonised_data_conversions.json
+++ b/workspace/notebook/py_standardised_to_harmonised_data_conversions.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_temp_syn_employee_to_curated.json
+++ b/workspace/notebook/py_temp_syn_employee_to_curated.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_utils_get_standardised_column_names.json
+++ b/workspace/notebook/py_utils_get_standardised_column_names.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_utils_get_storage_account.json
+++ b/workspace/notebook/py_utils_get_storage_account.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_versions.json
+++ b/workspace/notebook/py_versions.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_vw_SAP_HR_email_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_vw_SAP_HR_email_harmonised_layer1_transform.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_vw_SAP_HR_email_weekly_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_vw_SAP_HR_email_weekly_harmonised_layer1_transform.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/py_vw_SAP_PINS_email_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_vw_SAP_PINS_email_harmonised_layer1_transform.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/sap-hr-master.json
+++ b/workspace/notebook/sap-hr-master.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/sap-hr-views-historic.json
+++ b/workspace/notebook/sap-hr-views-historic.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/sap-hr-views.json
+++ b/workspace/notebook/sap-hr-views.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/template_notebook.json
+++ b/workspace/notebook/template_notebook.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/timesheets_master.json
+++ b/workspace/notebook/timesheets_master.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/timesheets_minutes_dim.json
+++ b/workspace/notebook/timesheets_minutes_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/timesheets_record_fact.json
+++ b/workspace/notebook/timesheets_record_fact.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/timesheets_record_fact_00.json
+++ b/workspace/notebook/timesheets_record_fact_00.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/timesheets_segment_type_reference_dim.json
+++ b/workspace/notebook/timesheets_segment_type_reference_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/timesheets_work_segment_dim.json
+++ b/workspace/notebook/timesheets_work_segment_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {

--- a/workspace/notebook/timesheets_work_segment_lock_dim.json
+++ b/workspace/notebook/timesheets_work_segment_lock_dim.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {


### PR DESCRIPTION
We need to repoint the notebooks to the Preview spark pool to allow the primary spark pool to be deleted and recreated