### PR TITLE
Update synapse-spark-pool.tf

### DIFF
--- a/infrastructure/modules/synapse-workspace-private/synapse-spark-pool.tf
+++ b/infrastructure/modules/synapse-workspace-private/synapse-spark-pool.tf
@@ -32,6 +32,7 @@ resource "azurerm_synapse_spark_pool" "synapse" {
       spark.executorEnv.keyVaultName ${var.key_vault_name}
       spark.microsoft.delta.merge.lowShuffle.enabled false
       spark.databricks.delta.optimize.repartition.enabled true
+      spark.sql.parquet.int96RebaseModeInWrite CORRECTED
       EOT
     filename = "configuration.txt"
   }


### PR DESCRIPTION
Log shows:

Job aborted due to stage failure: Task 160 in stage 75.0 failed 4 times, most recent failure: Lost task 160.3 in stage 75.0 (TID 1381) (vm-b4b03627 executor 2): org.apache.spark.SparkException: Task failed while writing rows.
	at org.apache.spark.sql.errors.QueryExecutionErrors$.taskFailedWhileWritingRowsError(QueryExecutionErrors.scala:500)
	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.executeTask(FileFormatWriter.scala:324)
	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.$anonfun$write$16(FileFormatWriter.scala:232)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1491)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: org.apache.spark.SparkUpgradeException: You may get a different result due to the upgrading of Spark 3.0: 
writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z into Parquet INT96
files can be dangerous, as the files may be read by Spark 2.x or legacy versions of Hive
later, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic
Gregorian calendar. See more details in SPARK-31404. You can set spark.sql.parquet.int96RebaseModeInWrite to 'LEGACY' to
rebase the datetime values w.r.t. the calendar difference during writing, to get maximum
interoperability. Or set spark.sql.parquet.int96RebaseModeInWrite to 'CORRECTED' to write the datetime values as it is,
if you are 100% sure that the written files will only be read by Spark 3.0+ or other
systems that use Proleptic Gregorian calendar.

See also:


https://spark.apache.org/docs/latest/sql-data-sources-parquet.html