### PR TITLE
Mvg/fix/case fact

### DIFF
--- a/workspace/notebook/casework_case_fact.json
+++ b/workspace/notebook/casework_case_fact.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b89d1b1e-177a-4c64-abb4-f296087ca545"
+				"spark.autotune.trackingId": "72db9fe8-250d-46ee-9747-02050f3b6e48"
 			}
 		},
 		"metadata": {
@@ -790,7 +790,7 @@
 					"    AdditionalFieldsID,\r\n",
 					"    EventID,\r\n",
 					"    InspectorCasesID,\r\n",
-					"    NSIPProjectInfoInternalID AS ProjectInfoInternalID,\r\n",
+					"    ProjectInfoInternalID,\r\n",
 					"    CaseInfoID,\r\n",
 					"    CaseDatesID,\r\n",
 					"    CaseOfficerAdditionalDetailsID,\r\n",
@@ -838,7 +838,7 @@
 					"FROM odw_harmonised_db.casework_case_fact;\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 60
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [x ] No

 2. Have any new tables been created in Standardised?

  	- [x ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ x] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [x ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ x] No - No scripts have run 
	
 
