### PR TITLE
Updating notebook: mipins_hr_measures

### DIFF
--- a/workspace/notebook/mipins_hr_measures.json
+++ b/workspace/notebook/mipins_hr_measures.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fbb401d3-4ade-426e-b75a-94d3fcfd1d27"
+				"spark.autotune.trackingId": "eadb31d7-428c-4541-9d30-e6ab78037b7c"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 				"source": [
 					"expected_from = ''"
 				],
-				"execution_count": 88
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -92,7 +92,7 @@
 					"    spark.sql(f\"SET EXPECTED_FROM_VAR = '{expected_from}'\")\n",
 					""
 				],
-				"execution_count": 89
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -137,13 +137,11 @@
 					"    \n",
 					"FROM odw_standardised_db.vw_saphr h\n",
 					"LEFT JOIN odw_harmonised_db.hr_leave_entitlement_dim le on h.pers_no = le.EmployeeID\n",
-
 					"WHERE\n",
 					"    le.AbsenceQuotaType = 'Annual Leave / P&P' \n",
-					"    AND LEFT(h.expected_from, 7) = LEFT(${EXPECTED_FROM_VAR}, 7) \n",
 					"    AND le.IsActive = 'Y'"
 				],
-				"execution_count": 90
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -192,7 +190,7 @@
 					"    le.AbsenceQuotaType = 'Brought Forward' \n",
 					"    AND le.IsActive = 'Y';"
 				],
-				"execution_count": 91
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -250,7 +248,7 @@
 					"ORDER BY\n",
 					"   EmployeeID, AbsenceStartDate"
 				],
-				"execution_count": 92
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -286,7 +284,7 @@
 					"ORDER BY\n",
 					"   EmployeeID"
 				],
-				"execution_count": 93
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -409,7 +407,7 @@
 					"where \n",
 					"\tright(cast(cast(${EXPECTED_FROM_VAR} as date) as varchar(10)),5) in ('01-31','02-28','02-29','03-31','04-30','05-31','06-30','07-31','08-31','09-30','10-31','11-30','12-31')"
 				],
-				"execution_count": 94
+				"execution_count": 18
 			},
 			{
 				"cell_type": "markdown",
@@ -586,7 +584,7 @@
 					"    END  = 'Y'\r\n",
 					";"
 				],
-				"execution_count": 95
+				"execution_count": 19
 			},
 			{
 				"cell_type": "markdown",
@@ -821,8 +819,7 @@
 					"FROM odw_curated_db.mipins_hr_measures\r\n",
 					"WHERE EmployeeID IN (SELECT EmployeeID FROM mipins_hr_measures_new WHERE MeasureID IS NULL) AND IsActive = 'Y';"
 				],
-
-				"execution_count": 96
+				"execution_count": 20
 			},
 			{
 				"cell_type": "markdown",
@@ -878,7 +875,7 @@
 					"WHEN NOT MATCHED \r\n",
 					"    THEN INSERT * ;   "
 				],
-				"execution_count": 97
+				"execution_count": 21
 			},
 			{
 				"cell_type": "markdown",
@@ -1011,7 +1008,7 @@
 					"    IsActive\r\n",
 					"FROM odw_curated_db.mipins_hr_measures;"
 				],
-				"execution_count": 98
+				"execution_count": 22
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
