### PR TITLE
Updating notebook: casework_master

### DIFF
--- a/workspace/notebook/casework_master.json
+++ b/workspace/notebook/casework_master.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "6",
 				"spark.dynamicAllocation.maxExecutors": "6",
-				"spark.autotune.trackingId": "b8db8bed-cec0-4028-a140-859c5f475fcd"
+				"spark.autotune.trackingId": "4abe5cfe-869c-4f2f-b038-547ac90d543e"
 			}
 		},
 		"metadata": {
@@ -57,62 +57,95 @@
 				"source": [
 					"from notebookutils import mssparkutils\r\n",
 					"\r\n",
-					"timeout = 3600\r\n",
+					"timeout_in_seconds = 60 * 30\r\n",
 					"\r\n",
 					"# Builds LPA FACT\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_planning_authority_fact',timeout) \r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_planning_authority_dim',timeout) \r\n",
-					"\r\n",
-					"# Builds DIMs dependant on LPA fact\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_all_appeals_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_lpa_resposability_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_picaso_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_high_hedges_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_plans_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_hedgerow_dim',timeout)\r\n",
-					"\r\n",
-					"# Builds Event\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_event_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_event_fact',timeout)\r\n",
-					"\r\n",
-					"# Builds DIMs for the Case_fact\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_project_info_internal_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_redactions_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_officer_additional_details_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_common_land_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_contact_information_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_contacts_organisation_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_decision_issue_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_plans_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_advice_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_examination_timetable_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_relevant_representation_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_inspector_cases_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_info_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_dates_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_advert_details_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_legacy_rights_of_way_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_enforcement_grounds_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_all_appeals_additional_data_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_all_application_sub_type_case_name_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_special_circumstance_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_additional_fields_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialism_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_case_dates_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_case_string_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_coastal_access_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_environment_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_high_court_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_modifications_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_purchase_notice_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_recharge_dim',timeout)\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_tpo_dim',timeout)\r\n",
-					"\r\n",
-					"# Builds case_fact\r\n",
-					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_fact',timeout) \r\n",
-					""
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_planning_authority_fact',timeout_in_seconds) \r\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_planning_authority_dim',timeout_in_seconds) "
 				],
 				"execution_count": 1
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"%run  /odw-harmonised/Casework/casework_all_appeals_dim"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Builds DIMs dependant on LPA fact\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_lpa_resposability_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_picaso_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_high_hedges_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_plans_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_hedgerow_dim',timeout_in_seconds)\n",
+					"\n",
+					"# Builds Event\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_event_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_event_fact',timeout_in_seconds)\n",
+					"\n",
+					"# Builds DIMs for the Case_fact\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_project_info_internal_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_redactions_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_officer_additional_details_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_common_land_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_contact_information_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_contacts_organisation_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_decision_issue_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_local_plans_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_advice_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_examination_timetable_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_nsip_relevant_representation_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_inspector_cases_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_info_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_dates_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_advert_details_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_legacy_rights_of_way_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_enforcement_grounds_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_all_appeals_additional_data_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_all_application_sub_type_case_name_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_special_circumstance_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_additional_fields_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialism_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_case_dates_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_case_string_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_coastal_access_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_environment_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_high_court_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_modifications_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_purchase_notice_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_specialist_recharge_dim',timeout_in_seconds)\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_tpo_dim',timeout_in_seconds)\n",
+					"\n",
+					"# Builds case_fact\n",
+					"mssparkutils.notebook.run('/odw-harmonised/Casework/casework_case_fact',timeout_in_seconds) \n",
+					""
+				],
+				"execution_count": null
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
