### PR TITLE
Odw/ims json to csv

### DIFF
--- a/workspace/notebook/py_convert_json_to_csv.json
+++ b/workspace/notebook/py_convert_json_to_csv.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bb234344-abd3-4795-ac40-7c75816d13b7"
+				"spark.autotune.trackingId": "e288aa50-20f1-4061-9740-13d6603d4ec9"
 			}
 		},
 		"metadata": {
@@ -78,7 +78,7 @@
 					"{\"linkedService\":\"ls_storage\"} \r\n",
 					")   "
 				],
-				"execution_count": 14
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -101,7 +101,7 @@
 					"todaysdate = today.strftime(\"%Y%m%d\")\r\n",
 					"print(todaysdate)"
 				],
-				"execution_count": 15
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -132,7 +132,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -153,13 +153,13 @@
 					"conversion_ims(\"IMS_data_flow\")\r\n",
 					"conversion_ims(\"IMS_data_sharing\")\r\n",
 					"conversion_ims(\"IMS_dpia\")\r\n",
-					"conversion_ims(\"ims_information_assets\")\r\n",
-					"conversion_ims(\"ims_integration\")\r\n",
-					"conversion_ims(\"ims_master_data_map\")\r\n",
-					"conversion_ims(\"ims_ropa\")\r\n",
+					"conversion_ims(\"IMS_information_assets\")\r\n",
+					"conversion_ims(\"IMS_integration\")\r\n",
+					"conversion_ims(\"IMS_master_data_map\")\r\n",
+					"conversion_ims(\"IMS_ropa\")\r\n",
 					""
 				],
-				"execution_count": 1
+				"execution_count": 7
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
