### PR TITLE
adding IMS JSONs

### DIFF
--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_attribute_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_attribute_dim.json
@@ -1,0 +1,274 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSAttributeID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "BDCAIDLegacy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "AttributeID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BDCAttributeName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BDCAttributeNumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BDCAttributeNumberContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BDCEntityNumberContainerC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BDCEntityNumberContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsPersonalData",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MinimiseAfterProcessingC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeHelp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsSpecialCategoryData",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RetentionPeriod",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSBDCAttribute",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSBDCAttributeName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSBDCAttributeIMSBDCEntityIDA",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCAttributeIMSMasterDataMap",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeUserIDC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeInformationOwnerC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeUserIDOneC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeInformationExpertC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributePriority",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeResolution",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeWorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeDateModified",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeSecurityGroups",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeAssignedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeAssignedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeAssignedUserName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeCreatedBy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeCreatedByLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeCreatedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeDateEntered",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeDeleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeDescription",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeModifiedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeModifiedByUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeModifiedByUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_dataflow_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_dataflow_dim.json
@@ -1,0 +1,328 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSDataflowID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DataflowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowIDCoded",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowDateEntered",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowDateModified",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowModifiedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowModifiedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowCreatedBy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowCreatedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowDescription",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowDeleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowCreatedByLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowModifiedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowAssignedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowAssignedUserName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowAssignedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowSecurityGroups",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowNumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowPriority",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowResolution",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowWorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataflowHelp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSDataflow1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSDataflowName1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSDataflowIMSInformationAssetsID1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSDataflow2",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSDataflowName2",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSDataflowIMSInformationAssetsID2",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSDataflow1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSDataflowName1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSDataflowNameIMSBDCEntityID1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSDataflow2",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSDataflowName2",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCEntityIMSDataflowNameIMSBDCEntityID2",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationIMSDataflow",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationIMSDataflowName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationIMSDataflowIMSIntegrationID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowInformationOwner",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowUser1ID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowInformationExpert",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowBCDEntitySourceID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowBCDEntityDestinationID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowInternalID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowInfoAssetSourceID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DataflowInfoAssetDestinationID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_dpia_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_dpia_dim.json
@@ -1,0 +1,370 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSDPIAID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DPIAIDLegacy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAIDCoded",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAAssignedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAAssignedUserName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDPIANumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAPM",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAContractOwner",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAOrganisationAreas",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIALinkDraft",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateRegistered",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateToMHCLG",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateToWelshGovernment",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateReturnedByMHCLG",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateReturnedByWelshGovernment",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateReturnedByToIAOpm",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateCompleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateSignedOffAtRisk",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateIAOAcceptedRisk",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAReviewPeriod",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIALastCurrentAndAccurateDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIANumberContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAHelp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateToSDPM",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAResidualRisks",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADisagreement",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IODecisionOutcome",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IOScreeningOutcome",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAIMSINtegration",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADocumentID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAControlledDocument",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateNextReview",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateImplementationRequirementsCommunication",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAInformationOwner",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAUser1ID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAInformationOwner1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAPersonResponsibleImplementation",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIADateModified",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SecurityGroups",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAAssignedUSerLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "CreatedBy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "CreatedByLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "CreatedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DateEntered",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "Deleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "Description",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ModifiedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ModifiedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ModifiedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAPriority",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAResolution",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "WorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_dsa_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_dsa_dim.json
@@ -1,0 +1,430 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSDSAID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAIDCoded",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAAssignedUserID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAAssignedUserName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSANumber",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAType",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAStatus",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAPriority",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADataBeingShared",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADirection",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAWhyShared",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAHowSharedSecurely",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAHowStoredSecurely",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAFrequency",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "LawfulBasis",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAPersonalData",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAPersonalCategoryData",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAPersonalCategoryBasis",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSARetention",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADestruction",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAWhoWillHaveAccess",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSATransfersOutsideUK",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DataSharingNumberContainer",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAHelp",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADataDiscloser",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADataReceiver",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSASchedules",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DocumentsIMSDataSharing",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DocumentsIMSDataSharingName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DocumentsIMSDataSharingDocumentsIDA",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAIMSIntegration",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAControllershipType",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADateNextReview",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAEndDate",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAParty1",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAParty1Contact",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAParty2",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAParty2Contact",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAParty3",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAParty3Contact",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAPersonalDataShared",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSASpecialCategoryData",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAStartDate",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAUserID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAInformationOwner",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAUser1ID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAInformationExpert",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "LastCurrentAndAccurateDC",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAPlanningLegislation",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAThirdPartyRecipients",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAReviewPeriod",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADateModified",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSASecurityGroups",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAAssignedUserLink",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSACreatedBy",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSACreatedByLink",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSACreatedByName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADateEntered",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSADeleted",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAModifiedByName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAModifiedByUserID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAModifiedByUserLink",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAResolution",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "DSAWorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "timestamp",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_entity_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_entity_dim.json
@@ -1,0 +1,250 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSEntityID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "BDCIDLegacy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BDCIDCoded",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityNumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityNameContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityNumberContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityBusinessArea",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityIMSDataFlow1",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityIMSDataFlow2",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityBDCAttribute",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityInformationOwner",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityUser1ID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityInformationExpert",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityPriority",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityResolution",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityWorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityBusinessCriticality",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityDateModified",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntitySecurityGroups",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityAssignedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityUserName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityCreatedBy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityCreatedByLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityDateEntered",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityDeleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityDescription",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityHelp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityModifiedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityModifiedByUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSEntityModifiedByUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_information_asset_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_information_asset_dim.json
@@ -1,0 +1,418 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetIDLegacy",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetIDCoded",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetAssignedUserID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetAssignedUserName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetNumber",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetPrimaryBusinessArea",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetLocation",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetContractedService",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetRegion",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetPurpose",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetFinancialValue",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetBusinessCritically",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDataDisposalRoutine",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetLastCurrentAccurateDate",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetReviewPeriod",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetInformationAsNumberContainer",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetHelp",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetUserLicenses",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetSuperUserLicenses",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetSysAdminLicenses",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetInfosecRiskRegister",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetCustodian",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDateLastDrCheck",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetBackUpLocation",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDrCheckFrequency",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetBackupFrequency",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetFormatList",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetManagementRegister",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetSoftwareVersion",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetAccessControlMethod",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetBackUpRequired",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDecommisionDate",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDrTestRequired",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetEncryptionAtRest",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetsIMSDataFlow1",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetsIMSDataFlow2",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetsIMSMasterDataMap1",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetsIMSINformationAssets1",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetsIMSINformationAssetsName1",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetsIda",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetsAOSContracts",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetStatus",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDateNextReview",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetOwner",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetRiskAssesmentType",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetLinkToRiskAssessment",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDateModified",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetSecurityGroups",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetAssignedUserLink",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetCreatedBy",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetCreatedByLink",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetCreatedByName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDateEntered",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDeleted",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetDescription",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetModifiedByName",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetModifiedByUserID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetModifiedByUserLink",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetPriority",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetResolution",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetType",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "InformationAssetWorkLog",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_integration_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_integration_dim.json
@@ -1,0 +1,244 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSIntegrationID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "IntegrationID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IntegrationIDCoded",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationDateEntered",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationDateModified",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationModifiedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationModifiedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationCreatedBy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationCreatedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationDescription",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationDeleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationCreatedByLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationModifiedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationAssignedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationAssignedUserName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationAssignedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationSecurityGroups",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationNumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationPriority",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationResolution",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationWorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationCommissionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationDecommissionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationFrequency",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationNumberContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationInternalExternal",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationHelp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationEncryptionInTransit",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSROPAIMSIntegration",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDPIAIMSIntegration",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSDataSharingIMSIntegration",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIntegrationIMSDataflow",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_masterdata_map_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_masterdata_map_dim.json
@@ -1,0 +1,238 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSMasterdataMapID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapIDLegacy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapCoded",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSMasterdataMapName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSMasterdataMapNumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BCDAttributeNumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BCDEntity",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BCDEntityNumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataTextContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsItIMSMasterdata",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataHelp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataVolumeOfRecords",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSMasterdataMap",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsIMSMasterdataMapName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSInformationAssetsID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeIMSMasterdataMap",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeIMSMasterdataMapName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSAttributeIMSMasterdataMapNameID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapInformationOwner",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapUser1ID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapInformationExpert",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapPriority",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapResolution",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapWorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSBDCAID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSIAID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSMasterdataMapDateModified",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapSecurityGroups",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapAssignedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapDescription",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "MasterdataMapModifiedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}

--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_ropa_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/IMS/ims_ropa_dim.json
@@ -1,0 +1,478 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "IMSROPAID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "ROPAID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAIDCoded",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAAssignedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAAssignedUserName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSROPANumber",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAPriority",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAOrganisationAreas",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPADataControllers",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAJointController",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPACategoriesPersonalData",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPACategoriesRecipients",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPASecurityMeasures",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ThirdCountryNames",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ThirdCountrySafeguards",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPALegitimateInterest",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAAutomatedDecisionMaking",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPADataSource",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPARecordsOfConsent",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPADataLocation",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIARequired",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPIAStatus",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPARetentionPolicy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPARetentionPolicyApplied",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPADataBreachRecord",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPARetentionNotAdhered",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAPrivacyNote",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPACategoriesIndividuals",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPANumberContainer",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAHelp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPARetentionSchedule",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPABusinessFunction",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPADPO",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPADataBreachOcurred",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPALastCurrentAccurateData",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "GDPRLawfulBasis",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "GDPRSpecialCategoryConditions",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPA2018Schedule1Condition",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RightsOfDataSubject",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BusinessFunctioinUnstructured",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "BDCEntityTemp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPACategoriesIndividualsTemp",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DocumentsIMSROPA",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DocumentsIMSROPAName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DocumentsIMSROPADocumentsIDA",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSROPAIMSIntegration",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "EstimatedNumberOperator",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAInformationOwner",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAUser1CID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ROPAInformationExpert",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSROPADocuments",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "GDPRLawfulBasisMS",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "GDPRSpecialCategoryConditionsMS",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DPA2018Schedule1ConditionMS",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IMSROPADateModified",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SecurityGroups",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "AssignedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "CreatedBy",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "CreatedByLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "CreatedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "DateEntered",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "Deleted",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "Description",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ModifiedByName",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ModifiedUserID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ModifiedUserLink",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "Resolution",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RightsOfDataSubjectTableC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RightsOfTheDataSubjectC",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "WorkLog",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "SourceSystemID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IngestionDate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "ValidTo",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "RowID",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "IsActive",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
