### PR TITLE
Updating notebook: ims_dpia_dim_historic

### DIFF
--- a/workspace/notebook/ims_dpia_dim_historic.json
+++ b/workspace/notebook/ims_dpia_dim_historic.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "de4f776d-a227-4c1f-b9d9-2339a23e1b0b"
+				"spark.autotune.trackingId": "e47717a7-eee2-4625-bbbb-09552bca25e6"
 			}
 		},
 		"metadata": {
@@ -128,13 +128,13 @@
 					")\r\n",
 					"\r\n",
 					"SELECT DISTINCT \r\n",
-					"    Row_Number() over (Order by T1.ims_dpia_number NULLS LAST) AS IMSDPIAID,\r\n",
+					"    Row_Number() over (Order by T1.id NULLS LAST) AS IMSDPIAID,\r\n",
 					"    T1.dpia_id AS DPIAIDLegacy,\r\n",
 					"    T1.id AS\tDPIAIDCoded,\r\n",
 					"    T1.name AS DPIAName,\r\n",
 					"    T1.assigned_user_id AS DPIAAssignedUserID,\r\n",
 					"    T1.assigned_user_name AS DPIAAssignedUserName,\r\n",
-					"    T1.ims_dpia_number AS IMSDPIANumber,\r\n",
+					"    IFNULL(T1.ims_dpia_number, TRIM('DIPA - ' FROM T1.dpia_num_container_c)) AS IMSDPIANumber,\r\n",
 					"    T1.pm_c AS DPIAPM,\r\n",
 					"    T1.contract_owner AS\tDPIAContractOwner,\r\n",
 					"    T1.organisation_areas_c AS DPIAOrganisationAreas,\r\n",
@@ -150,7 +150,7 @@
 					"    T1.date_iao_accepted_risks_c\t AS\tDPIADateIAOAcceptedRisk,\r\n",
 					"    T1.review_period\t AS\tDPIAReviewPeriod,\r\n",
 					"    T1.last_current_and_accurate_date AS\tDPIALastCurrentAndAccurateDate,\r\n",
-					"    IFNULL(T1.dpia_num_container_c, concat('DIPA - ',T1.ims_dpia_number)) AS\tDPIANumberContainer,\r\n",
+					"    IFNULL(T1.dpia_num_container_c, concat('DIPA - ', T1.ims_dpia_number)) AS\tDPIANumberContainer,\r\n",
 					"    T1.help\t AS\tDPIAHelp,\r\n",
 					"    T1.date_to_sdpm AS\tDPIADateToSDPM,\r\n",
 					"    T1.residual_risks AS\tDPIAResidualRisks,\r\n",
@@ -246,7 +246,7 @@
 					"    'Y'                                                                         AS IsActive\r\n",
 					"FROM odw_standardised_db.ims_dpia T1\r\n",
 					"LEFT JOIN odw_harmonised_db.main_sourcesystem_fact T2 ON \"IMS\" = T2.Description\r\n",
-					"WHERE T1.ims_dpia_number IS NOT NULL\r\n",
+					"WHERE T1.id IS NOT NULL\r\n",
 					"GROUP BY T1.dpia_id,\r\n",
 					"    T1.id,\r\n",
 					"    T1.name,\r\n",
@@ -289,7 +289,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 11
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -310,9 +310,9 @@
 				},
 				"source": [
 					"%%sql\r\n",
-					"SELECT * FROM odw_harmonised_db.ims_dpia_dim limit 10"
+					"SELECT * FROM odw_harmonised_db.ims_dpia_dim"
 				],
-				"execution_count": 13
+				"execution_count": 9
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
