### PR TITLE
Updating notebook: hr_employee_leavers_dim

### DIFF
--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0523555b-8da7-4817-9c1b-1ab39abae634"
+				"spark.autotune.trackingId": "9ab46c54-c9ef-4980-8072-ba7653f4f2b5"
 			}
 		},
 		"metadata": {
@@ -123,16 +123,14 @@
 					"LEFT JOIN odw_harmonised_db.main_sourcesystem_fact T2 ON \"SAP HR\" = T2.Description\r\n",
 					"LEFT JOIN odw_harmonised_db.hr_employee_fact T3 ON T1.Pers_No = T3.PersNumber AND T3.IsActive = 'Y'\r\n",
 					"FULL JOIN odw_harmonised_db.hr_employee_leavers_dim T7 ON   T3.EmployeeID = T7.EmployeeID AND \r\n",
-					"                                                        T1.Org_Start_Date = T7.EmploymentStartDate AND\r\n",
-					"                                                        T1.Leaving = T7.EmploymentEndDate AND \r\n",
+					"                                                        CAST(T1.Leaving AS DATE) = CAST(T7.EmploymentEndDate AS DATE) AND \r\n",
 					"                                                        T7.IsActive = 'Y'\r\n",
 					"\r\n",
 					"WHERE\r\n",
 					"    -- flags new data        \r\n",
 					"    CASE\r\n",
 					"        WHEN T3.EmployeeID = T7.EmployeeID AND \r\n",
-					"            T1.Org_Start_Date = T7.EmploymentStartDate AND\r\n",
-					"            T1.Leaving = T7.EmploymentEndDate AND\r\n",
+					"            CAST(T1.Leaving AS DATE) = CAST(T7.EmploymentEndDate AS DATE) AND\r\n",
 					"            md5(concat(\r\n",
 					"                IFNULL(T3.EmployeeID,'.'),\r\n",
 					"                IFNULL(T1.Reason_For_Action,'.'),\r\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
