### PR TITLE
Mvg/fix/leavers merge

### DIFF
--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2f76d010-5fe0-47b8-8970-eb3953ce8d31"
+				"spark.autotune.trackingId": "c76f1b9e-8da2-4792-af38-7aea7ebac83f"
 			}
 		},
 		"metadata": {
@@ -461,7 +461,7 @@
 					"        Source.IsActive) ;  \r\n",
 					""
 				],
-				"execution_count": 14
+				"execution_count": 38
 			},
 			{
 				"cell_type": "markdown",
@@ -524,7 +524,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 33
+				"execution_count": 40
 			},
 			{
 				"cell_type": "markdown",
@@ -706,7 +706,7 @@
 					"%%sql\n",
 					"SELECT * FROM odw_harmonised_db.hr_employee_leavers_dim WHERE EmployeeID LIKE '%500483' ORDER BY IngestionDate;"
 				],
-				"execution_count": 20
+				"execution_count": 41
 			}
 		]
 	}

--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "038b758d-9833-4946-ace0-00a89fb1edd4"
+				"spark.autotune.trackingId": "c01325f8-841a-4fa6-8e5e-1c26405d24aa"
 			}
 		},
 		"metadata": {
@@ -148,7 +148,7 @@
 					"    END  = 'Y')\r\n",
 					";"
 				],
-				"execution_count": 22
+				"execution_count": 43
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +178,7 @@
 					"\n",
 					"-- SELECT * FROM odw_standardised_db.hr_leavers WHERE Pers_No LIKE '%500483' ORDER BY expected_from, Leaving;"
 				],
-				"execution_count": 27
+				"execution_count": 42
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8256f913-d44c-4493-ba82-4434da5b9a95"
+				"spark.autotune.trackingId": "2f76d010-5fe0-47b8-8970-eb3953ce8d31"
 			}
 		},
 		"metadata": {
@@ -148,7 +148,37 @@
 					"    END  = 'Y')\r\n",
 					";"
 				],
-				"execution_count": 44
+				"execution_count": 22
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_harmonised_db.hr_employee_leavers_dim WHERE EmployeeID LIKE '%500483' ORDER BY IngestionDate;\n",
+					"\n",
+					"SELECT * FROM odw_standardised_db.vw_leavers WHERE Pers_No LIKE '%500483' ORDER BY expected_from, Leaving;\n",
+					"\n",
+					"SELECT * FROM hr_employee_leavers_dim_new WHERE EmployeeID LIKE '%500483' ;\n",
+					"\n",
+					"-- SELECT * FROM odw_standardised_db.hr_leavers WHERE Pers_No LIKE '%500483' ORDER BY expected_from, Leaving;"
+				],
+				"execution_count": 27
 			},
 			{
 				"cell_type": "markdown",
@@ -229,9 +259,37 @@
 					"    T1.RowID,\r\n",
 					"    T1.IsActive\r\n",
 					"FROM odw_harmonised_db.hr_employee_leavers_dim T1\r\n",
-					"WHERE EmployeeID IN (SELECT EmployeeID FROM hr_employee_leavers_dim_new WHERE EmployeeLeaversID IS NULL) AND IsActive = 'Y';"
+					"WHERE EmployeeID IN (SELECT EmployeeID FROM hr_employee_leavers_dim_new WHERE EmployeeLeaversID IS NULL) AND\r\n",
+					"    EmploymentEndDate IN (SELECT EmploymentEndDate FROM hr_employee_leavers_dim_new WHERE EmployeeLeaversID IS NULL) AND\r\n",
+					"    IsActive = 'Y';"
 				],
-				"execution_count": 46
+				"execution_count": 29
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM hr_employee_leavers_dim_changed_rows WHERE EmployeeID LIKE '%500483' \n",
+					"\n",
+					""
+				],
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -289,7 +347,32 @@
 					"FROM hr_employee_leavers_dim_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 47
+				"execution_count": 31
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM hr_employee_leavers_dim_changed_rows_final WHERE EmployeeID LIKE '%500483' \n",
+					""
+				],
+				"execution_count": 32
 			},
 			{
 				"cell_type": "markdown",
@@ -332,7 +415,7 @@
 					"MERGE INTO odw_harmonised_db.hr_employee_leavers_dim AS Target\r\n",
 					"USING hr_employee_leavers_dim_changed_rows_final AS Source\r\n",
 					"\r\n",
-					"ON Source.EmployeeLeaversID = Target.EmployeeLeaversID AND Target.IsActive = 'Y'\r\n",
+					"ON Source.EmployeeLeaversID = Target.EmployeeLeaversID AND Source.EmploymentEndDate = Target.EmploymentEndDate AND Target.IsActive = 'Y'\r\n",
 					"\r\n",
 					"-- For Updates existing rows\r\n",
 					"\r\n",
@@ -378,7 +461,7 @@
 					"        Source.IsActive) ;  \r\n",
 					""
 				],
-				"execution_count": 48
+				"execution_count": 14
 			},
 			{
 				"cell_type": "markdown",
@@ -441,7 +524,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 49
+				"execution_count": 33
 			},
 			{
 				"cell_type": "markdown",
@@ -489,7 +572,7 @@
 					"WHERE SUBSTRING(EmploymentENDDate, 0, 7) = (SELECT SUBSTRING(MAX(EXPECTED_FROM), 0, 7) FROM odw_standardised_db.vw_leavers)\n",
 					"AND EmployeeLeaversID IS NULL"
 				],
-				"execution_count": 50
+				"execution_count": 34
 			},
 			{
 				"cell_type": "code",
@@ -526,7 +609,7 @@
 					"    Target.ValidTo = to_timestamp(ClosingDate),\n",
 					"    Target.IsActive = 'N'"
 				],
-				"execution_count": 51
+				"execution_count": 35
 			},
 			{
 				"cell_type": "code",
@@ -563,7 +646,7 @@
 					"    Target.ValidTo = to_timestamp(ClosingDate),\n",
 					"    Target.IsActive = 'N'"
 				],
-				"execution_count": 52
+				"execution_count": 36
 			},
 			{
 				"cell_type": "code",
@@ -600,7 +683,7 @@
 					"    Target.ValidTo = to_timestamp(ClosingDate),\n",
 					"    Target.IsActive = 'N'"
 				],
-				"execution_count": 53
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -616,13 +699,14 @@
 					},
 					"microsoft": {
 						"language": "sparksql"
-					}
+					},
+					"collapsed": false
 				},
 				"source": [
 					"%%sql\n",
 					"SELECT * FROM odw_harmonised_db.hr_employee_leavers_dim WHERE EmployeeID LIKE '%500483' ORDER BY IngestionDate;"
 				],
-				"execution_count": null
+				"execution_count": 20
 			}
 		]
 	}

--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cfe9efb9-8ef9-4519-9ef2-e7e99ee4e4d3"
+				"spark.autotune.trackingId": "3a07cf80-e1a3-4917-bd78-7c1e81907a78"
 			}
 		},
 		"metadata": {
@@ -255,32 +255,6 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"SELECT * FROM hr_employee_leavers_dim_changed_rows WHERE EmployeeID LIKE '%500483' \n",
-					"\n",
-					""
-				],
-				"execution_count": 49
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
 					"CREATE OR REPLACE TEMPORARY VIEW Loading_month\n",
 					"\n",
 					"    AS\n",
@@ -318,31 +292,6 @@
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
 				"execution_count": 50
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM hr_employee_leavers_dim_changed_rows_final WHERE EmployeeID LIKE '%500483' \n",
-					""
-				],
-				"execution_count": 51
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c01325f8-841a-4fa6-8e5e-1c26405d24aa"
+				"spark.autotune.trackingId": "cfe9efb9-8ef9-4519-9ef2-e7e99ee4e4d3"
 			}
 		},
 		"metadata": {
@@ -148,37 +148,7 @@
 					"    END  = 'Y')\r\n",
 					";"
 				],
-				"execution_count": 43
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM odw_standardised_db.vw_leavers WHERE Pers_No LIKE '%500483' ORDER BY expected_from, Leaving;\n",
-					"\n",
-					"SELECT * FROM odw_harmonised_db.hr_employee_leavers_dim WHERE EmployeeID LIKE '%500483' ORDER BY IngestionDate;\n",
-					"\n",
-					"SELECT * FROM hr_employee_leavers_dim_new WHERE EmployeeID LIKE '%500483' ;\n",
-					"\n",
-					"-- SELECT * FROM odw_standardised_db.hr_leavers WHERE Pers_No LIKE '%500483' ORDER BY expected_from, Leaving;"
-				],
-				"execution_count": 42
+				"execution_count": 46
 			},
 			{
 				"cell_type": "markdown",
@@ -263,7 +233,7 @@
 					"    EmploymentEndDate IN (SELECT EmploymentEndDate FROM hr_employee_leavers_dim_new WHERE EmployeeLeaversID IS NULL) AND\r\n",
 					"    IsActive = 'Y';"
 				],
-				"execution_count": 29
+				"execution_count": 48
 			},
 			{
 				"cell_type": "code",
@@ -289,7 +259,7 @@
 					"\n",
 					""
 				],
-				"execution_count": 30
+				"execution_count": 49
 			},
 			{
 				"cell_type": "code",
@@ -347,7 +317,7 @@
 					"FROM hr_employee_leavers_dim_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 31
+				"execution_count": 50
 			},
 			{
 				"cell_type": "code",
@@ -372,7 +342,7 @@
 					"SELECT * FROM hr_employee_leavers_dim_changed_rows_final WHERE EmployeeID LIKE '%500483' \n",
 					""
 				],
-				"execution_count": 32
+				"execution_count": 51
 			},
 			{
 				"cell_type": "markdown",
@@ -461,7 +431,7 @@
 					"        Source.IsActive) ;  \r\n",
 					""
 				],
-				"execution_count": 38
+				"execution_count": 52
 			},
 			{
 				"cell_type": "markdown",
@@ -524,7 +494,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 40
+				"execution_count": 53
 			},
 			{
 				"cell_type": "markdown",
@@ -572,7 +542,7 @@
 					"WHERE SUBSTRING(EmploymentENDDate, 0, 7) = (SELECT SUBSTRING(MAX(EXPECTED_FROM), 0, 7) FROM odw_standardised_db.vw_leavers)\n",
 					"AND EmployeeLeaversID IS NULL"
 				],
-				"execution_count": 34
+				"execution_count": 54
 			},
 			{
 				"cell_type": "code",
@@ -609,7 +579,7 @@
 					"    Target.ValidTo = to_timestamp(ClosingDate),\n",
 					"    Target.IsActive = 'N'"
 				],
-				"execution_count": 35
+				"execution_count": 55
 			},
 			{
 				"cell_type": "code",
@@ -646,7 +616,7 @@
 					"    Target.ValidTo = to_timestamp(ClosingDate),\n",
 					"    Target.IsActive = 'N'"
 				],
-				"execution_count": 36
+				"execution_count": 56
 			},
 			{
 				"cell_type": "code",
@@ -683,30 +653,7 @@
 					"    Target.ValidTo = to_timestamp(ClosingDate),\n",
 					"    Target.IsActive = 'N'"
 				],
-				"execution_count": 19
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"SELECT * FROM odw_harmonised_db.hr_employee_leavers_dim WHERE EmployeeID LIKE '%500483' ORDER BY IngestionDate;"
-				],
-				"execution_count": 41
+				"execution_count": 57
 			}
 		]
 	}

--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c76f1b9e-8da2-4792-af38-7aea7ebac83f"
+				"spark.autotune.trackingId": "038b758d-9833-4946-ace0-00a89fb1edd4"
 			}
 		},
 		"metadata": {
@@ -170,9 +170,9 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"SELECT * FROM odw_harmonised_db.hr_employee_leavers_dim WHERE EmployeeID LIKE '%500483' ORDER BY IngestionDate;\n",
-					"\n",
 					"SELECT * FROM odw_standardised_db.vw_leavers WHERE Pers_No LIKE '%500483' ORDER BY expected_from, Leaving;\n",
+					"\n",
+					"SELECT * FROM odw_harmonised_db.hr_employee_leavers_dim WHERE EmployeeID LIKE '%500483' ORDER BY IngestionDate;\n",
 					"\n",
 					"SELECT * FROM hr_employee_leavers_dim_new WHERE EmployeeID LIKE '%500483' ;\n",
 					"\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
