### PR TITLE
Mvg/fix/leavers august

### DIFF
--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3a07cf80-e1a3-4917-bd78-7c1e81907a78"
+				"spark.autotune.trackingId": "181c331d-8453-4d79-a361-8651f8ea6e4e"
 			}
 		},
 		"metadata": {
@@ -115,6 +115,7 @@
 					"    md5(concat(\r\n",
 					"        IFNULL(T3.EmployeeID,'.'),\r\n",
 					"        IFNULL(T1.Reason_For_Action,'.'),\r\n",
+					"        IFNULL(T1.Leaving,'.'),\r\n",
 					"        IFNULL(T1.Act,'.'),\r\n",
 					"        IFNULL(T1.ActR,'.'),\r\n",
 					"        IFNULL(T1.S,'.'),\r\n",
@@ -137,18 +138,19 @@
 					"            md5(concat(\r\n",
 					"                IFNULL(T3.EmployeeID,'.'),\r\n",
 					"                IFNULL(T1.Reason_For_Action,'.'),\r\n",
+					"                IFNULL(T1.Leaving,'.'),\r\n",
 					"                IFNULL(T1.Act,'.'),\r\n",
 					"                IFNULL(T1.ActR,'.'),\r\n",
 					"                IFNULL(T1.S,'.'),\r\n",
 					"                IFNULL(T1.User_ID,'.'))) <> T7.RowID  -- same employee, changed data\r\n",
 					"        THEN 'Y'\r\n",
-					"        WHEN T7.EmployeeID  IS NULL -- new employee\r\n",
+					"        WHEN T7.EmployeeID IS NULL -- new employee\r\n",
 					"        THEN 'Y'\r\n",
 					"        ELSE 'N'\r\n",
 					"    END  = 'Y')\r\n",
 					";"
 				],
-				"execution_count": 46
+				"execution_count": 19
 			},
 			{
 				"cell_type": "markdown",
@@ -233,7 +235,7 @@
 					"    EmploymentEndDate IN (SELECT EmploymentEndDate FROM hr_employee_leavers_dim_new WHERE EmployeeLeaversID IS NULL) AND\r\n",
 					"    IsActive = 'Y';"
 				],
-				"execution_count": 48
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -291,7 +293,7 @@
 					"FROM hr_employee_leavers_dim_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 50
+				"execution_count": 23
 			},
 			{
 				"cell_type": "markdown",
@@ -380,7 +382,7 @@
 					"        Source.IsActive) ;  \r\n",
 					""
 				],
-				"execution_count": 52
+				"execution_count": 25
 			},
 			{
 				"cell_type": "markdown",
@@ -443,7 +445,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 53
+				"execution_count": 26
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "181c331d-8453-4d79-a361-8651f8ea6e4e"
+				"spark.autotune.trackingId": "ccbbc317-6273-4c78-8a21-84f5bbd58dfc"
 			}
 		},
 		"metadata": {
@@ -115,7 +115,7 @@
 					"    md5(concat(\r\n",
 					"        IFNULL(T3.EmployeeID,'.'),\r\n",
 					"        IFNULL(T1.Reason_For_Action,'.'),\r\n",
-					"        IFNULL(T1.Leaving,'.'),\r\n",
+					"        IFNULL(CAST(T1.Leaving AS String),'.'),\r\n",
 					"        IFNULL(T1.Act,'.'),\r\n",
 					"        IFNULL(T1.ActR,'.'),\r\n",
 					"        IFNULL(T1.S,'.'),\r\n",
@@ -138,7 +138,7 @@
 					"            md5(concat(\r\n",
 					"                IFNULL(T3.EmployeeID,'.'),\r\n",
 					"                IFNULL(T1.Reason_For_Action,'.'),\r\n",
-					"                IFNULL(T1.Leaving,'.'),\r\n",
+					"                IFNULL(CAST(T1.Leaving AS String),'.'),\r\n",
 					"                IFNULL(T1.Act,'.'),\r\n",
 					"                IFNULL(T1.ActR,'.'),\r\n",
 					"                IFNULL(T1.S,'.'),\r\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
