### PR TITLE
Feat/pipelines and scheduling tidy up

### DIFF
--- a/workspace/pipeline/0_Listed_Buildings_API_to_RAW.json
+++ b/workspace/pipeline/0_Listed_Buildings_API_to_RAW.json
@@ -161,7 +161,7 @@
 			}
 		],
 		"folder": {
-			"name": "listed_buildings/layers/0-raw"
+			"name": "listed buildings/layers/0-raw"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/0_Raw_High_Court_Data_Copy.json
+++ b/workspace/pipeline/0_Raw_High_Court_Data_Copy.json
@@ -893,7 +893,7 @@
 			}
 		],
 		"folder": {
-			"name": "high_court/layers/0-raw"
+			"name": "high court/layers/0-raw"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/0_ZenDesk_Data_Transfer.json
+++ b/workspace/pipeline/0_ZenDesk_Data_Transfer.json
@@ -96,7 +96,7 @@
 			}
 		],
 		"folder": {
-			"name": "zendesk/layers/0-raw"
+			"name": "zendesk/layers/utils"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/pln_backup_odw_config.json
+++ b/workspace/pipeline/pln_backup_odw_config.json
@@ -85,7 +85,7 @@
 			}
 		],
 		"folder": {
-			"name": "distaster_recovery"
+			"name": "distaster recovery"
 		},
 		"annotations": [],
 		"lastPublishTime": "2023-01-19T12:58:18Z"

--- a/workspace/pipeline/pln_backup_odw_curated.json
+++ b/workspace/pipeline/pln_backup_odw_curated.json
@@ -85,7 +85,7 @@
 			}
 		],
 		"folder": {
-			"name": "distaster_recovery"
+			"name": "distaster recovery"
 		},
 		"annotations": [],
 		"lastPublishTime": "2023-01-19T12:58:25Z"

--- a/workspace/pipeline/pln_backup_odw_harmonised.json
+++ b/workspace/pipeline/pln_backup_odw_harmonised.json
@@ -85,7 +85,7 @@
 			}
 		],
 		"folder": {
-			"name": "distaster_recovery"
+			"name": "distaster recovery"
 		},
 		"annotations": [],
 		"lastPublishTime": "2023-01-19T12:58:33Z"

--- a/workspace/pipeline/pln_backup_odw_raw.json
+++ b/workspace/pipeline/pln_backup_odw_raw.json
@@ -85,7 +85,7 @@
 			}
 		],
 		"folder": {
-			"name": "distaster_recovery"
+			"name": "distaster recovery"
 		},
 		"annotations": [],
 		"lastPublishTime": "2023-01-19T12:58:40Z"

--- a/workspace/pipeline/pln_backup_odw_standardised.json
+++ b/workspace/pipeline/pln_backup_odw_standardised.json
@@ -85,7 +85,7 @@
 			}
 		],
 		"folder": {
-			"name": "distaster_recovery"
+			"name": "distaster recovery"
 		},
 		"annotations": [],
 		"lastPublishTime": "2023-01-19T12:58:47Z"

--- a/workspace/pipeline/pln_casework_main.json
+++ b/workspace/pipeline/pln_casework_main.json
@@ -4,6 +4,7 @@
 		"activities": [
 			{
 				"name": "Ingest Standardised",
+				"description": "Ingests raw data into standardised. Can create tables if they don't already exist.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -46,6 +47,7 @@
 			},
 			{
 				"name": "Prepare Views",
+				"description": "Creates views from each standardised table with the data from the latest ingestion.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -79,6 +81,7 @@
 			},
 			{
 				"name": "Ingest Harmonised",
+				"description": "Sequentially runs the notebooks that are responsible for ingesting data in each of the tables in the harmonised layer. Each notebook may utilise the views created in the previous step.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -112,6 +115,7 @@
 			},
 			{
 				"name": "Ingest Raw",
+				"description": "Copies case, appeal, NSIP, Green Appeal data sourced from Horizon, PICASO and Back Office into ODW's raw layer.",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],

--- a/workspace/pipeline/pln_high_court_main.json
+++ b/workspace/pipeline/pln_high_court_main.json
@@ -4,6 +4,7 @@
 		"activities": [
 			{
 				"name": "Ingest Harmonised",
+				"description": "Ingests data into harmonised",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -37,6 +38,7 @@
 			},
 			{
 				"name": "Ingest Curated",
+				"description": "Ingests data into curated",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -70,6 +72,7 @@
 			},
 			{
 				"name": "Ingest Raw",
+				"description": "Copies High Court data from source to raw",
 				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
@@ -90,6 +93,7 @@
 			},
 			{
 				"name": "Ingest Raw Horizon_BIS_Event",
+				"description": "Copies BIS Event data from source to raw layer",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],
@@ -103,6 +107,7 @@
 			},
 			{
 				"name": "Ingest Standardised",
+				"description": "Ingests data from raw layer into standardised",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{

--- a/workspace/pipeline/pln_high_court_main.json
+++ b/workspace/pipeline/pln_high_court_main.json
@@ -154,7 +154,7 @@
 			}
 		],
 		"folder": {
-			"name": "high_court"
+			"name": "high court"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/pln_hr_main.json
+++ b/workspace/pipeline/pln_hr_main.json
@@ -4,6 +4,7 @@
 		"activities": [
 			{
 				"name": "Ingest Raw",
+				"description": "Copies HR data from SAP into ODW's raw layer.",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],
@@ -17,6 +18,7 @@
 			},
 			{
 				"name": "Ingest Standardised",
+				"description": "Ingests raw data into standardised. Can create tables if they don't already exist considering that their schema is present in odw-config.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -59,6 +61,7 @@
 			},
 			{
 				"name": "Prepare Views",
+				"description": "Creates views from each standardised table with the data from the latest ingestion.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -101,6 +104,7 @@
 			},
 			{
 				"name": "Ingest Harmonised",
+				"description": "Sequentially runs the notebooks that are responsible for ingesting data in each of the tables in the harmonised layer. Each notebook may utilise the views created in the previous step.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -134,6 +138,7 @@
 			},
 			{
 				"name": "Employee Curated",
+				"description": "Joins the employee data from the harmonised layer and ingests it in the curated layer. i.e odw_curated_db.employee",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -167,6 +172,7 @@
 			},
 			{
 				"name": "Employee Publish",
+				"description": "Publishes the data from curated layer to the Service Bus",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -200,6 +206,7 @@
 			},
 			{
 				"name": "HR Measures Curated",
+				"description": "Creates a monthly report of HR measures utilising the data from the absences, leaves, and sap-hr. ",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{

--- a/workspace/pipeline/pln_hr_main.json
+++ b/workspace/pipeline/pln_hr_main.json
@@ -18,7 +18,7 @@
 			},
 			{
 				"name": "Ingest Standardised",
-				"description": "Ingests raw data into standardised. Can create tables if they don't already exist considering that their schema is present in odw-config.",
+				"description": "Ingests raw data into standardised. Can create tables if they don't already exist.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{

--- a/workspace/pipeline/pln_ims_main.json
+++ b/workspace/pipeline/pln_ims_main.json
@@ -4,10 +4,11 @@
 		"activities": [
 			{
 				"name": "ForEach IMS Source",
+				"description": "For each IMS source defined in the parameters of this pipeline, this activity fetches the data from API and saves it in JSON format.",
 				"type": "ForEach",
 				"dependsOn": [
 					{
-						"activity": "py_utils_get_storage_account",
+						"activity": "Get Storage Account",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -48,7 +49,8 @@
 				}
 			},
 			{
-				"name": "py_utils_get_storage_account",
+				"name": "Get Storage Account",
+				"description": "Gets storage account name",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -75,10 +77,11 @@
 			},
 			{
 				"name": "Ingest Standardised",
+				"description": "Ingests the csv data from raw into the standardised layer.",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
-						"activity": "py_convert_json_to_csv_ims",
+						"activity": "JSON to CSV",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -117,7 +120,8 @@
 				}
 			},
 			{
-				"name": "py_convert_json_to_csv_ims",
+				"name": "JSON to CSV",
+				"description": "Converts the json data in raw to csv and removes the json files",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{

--- a/workspace/pipeline/pln_initial_high_court.json
+++ b/workspace/pipeline/pln_initial_high_court.json
@@ -232,7 +232,7 @@
 			}
 		],
 		"folder": {
-			"name": "high_court/utils"
+			"name": "high court/utils"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/pln_listed_buildings_main.json
+++ b/workspace/pipeline/pln_listed_buildings_main.json
@@ -105,7 +105,7 @@
 			}
 		],
 		"folder": {
-			"name": "listed_buildings"
+			"name": "listed buildings"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -101,12 +101,18 @@
 						"referenceName": "py_reload_hr_leavers",
 						"type": "NotebookReference"
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			}
 		],
 		"folder": {
-			"name": "post_deployment"
+			"name": "post deployment"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/pln_zendesk_main.json
+++ b/workspace/pipeline/pln_zendesk_main.json
@@ -3,7 +3,8 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "0_Zendesk_API_to_RAW",
+				"name": "Ingest Raw",
+				"description": "Fetches data (\"zendesk created\" and \"zendesk updated\") from API and ingests in raw. ",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],

--- a/workspace/pipeline/pln_zendesk_main.json
+++ b/workspace/pipeline/pln_zendesk_main.json
@@ -1,0 +1,24 @@
+{
+	"name": "pln_zendesk_main",
+	"properties": {
+		"activities": [
+			{
+				"name": "0_Zendesk_API_to_RAW",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "0_Zendesk_API_to_RAW",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			}
+		],
+		"folder": {
+			"name": "zendesk"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_zendesk_main.json
+++ b/workspace/pipeline/pln_zendesk_main.json
@@ -3,8 +3,8 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "Ingest Raw",
-				"description": "Fetches data (\"zendesk created\" and \"zendesk updated\") from API and ingests in raw. ",
+				"name": "Ingest Raw and Standardised",
+				"description": "Fetches data (\"zendesk created\" and \"zendesk updated\") from API and ingests in raw and standardised.",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],

--- a/workspace/trigger/tr_backup_daily.json
+++ b/workspace/trigger/tr_backup_daily.json
@@ -33,12 +33,6 @@
 					"referenceName": "pln_backup_odw_config",
 					"type": "PipelineReference"
 				}
-			},
-			{
-				"pipelineReference": {
-					"referenceName": "0_Zendesk_API_to_RAW",
-					"type": "PipelineReference"
-				}
 			}
 		],
 		"type": "ScheduleTrigger",

--- a/workspace/trigger/tr_daily.json
+++ b/workspace/trigger/tr_daily.json
@@ -16,6 +16,12 @@
 					"referenceName": "pln_fact_sickness",
 					"type": "PipelineReference"
 				}
+			},
+			{
+				"pipelineReference": {
+					"referenceName": "pln_zendesk_main",
+					"type": "PipelineReference"
+				}
 			}
 		],
 		"type": "ScheduleTrigger",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
