### PR TITLE
Fix/hr record fact

### DIFF
--- a/workspace/notebook/py_reload_hr_record_fact.json
+++ b/workspace/notebook/py_reload_hr_record_fact.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "978b3053-9c30-451e-a1d8-3146481d03e2"
+				"spark.autotune.trackingId": "25da753e-e518-4bae-a7d5-9b004e33aa04"
 			}
 		},
 		"metadata": {
@@ -28,7 +28,7 @@
 			"enableDebugMode": false,
 			"kernelspec": {
 				"name": "synapse_pyspark",
-				"display_name": "python"
+				"display_name": "Synapse PySpark"
 			},
 			"language_info": {
 				"name": "python"
@@ -76,7 +76,7 @@
 					"\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 1
 			}
 		]
 	}

--- a/workspace/notebook/py_reload_hr_record_fact.json
+++ b/workspace/notebook/py_reload_hr_record_fact.json
@@ -1,0 +1,83 @@
+{
+	"name": "py_reload_hr_record_fact",
+	"properties": {
+		"folder": {
+			"name": "post-deployment"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "978b3053-9c30-451e-a1d8-3146481d03e2"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "python"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"source": [
+					"from pyspark.sql import SparkSession\n",
+					"from notebookutils import mssparkutils\n",
+					"from datetime import datetime, date\n",
+					"from tqdm import tqdm\n",
+					"import pandas as pd\n",
+					"\n",
+					"spark = SparkSession.builder.getOrCreate()\n",
+					"\n",
+					"dates = [\"2020-11-01T00:00:00.000000\",\"2020-12-01T00:00:00.000000\"]\n",
+					"\n",
+					"timeout_in_seconds = 60 * 60\n",
+					"mssparkutils.notebook.run('/utils/py_delete_table_contents', timeout_in_seconds, arguments={\"db_name\": \"odw_harmonised_db\", \"table_name\": \"hr_record_fact\"})\n",
+					"\n",
+					"for date in tqdm(dates):\n",
+					"    print(f\"Processing: {date}\")\n",
+					"    mssparkutils.notebook.run('/odw-harmonised/SAP-HR/sap-hr-views-saphr', timeout_in_seconds, arguments={\"expected_from\": date})\n",
+					"    mssparkutils.notebook.run('/odw-harmonised/SAP-HR/hr_record_fact', timeout_in_seconds)\n",
+					"\n",
+					"mssparkutils.notebook.run('/odw-harmonised/SAP-HR/sap-hr-views-saphr', timeout_in_seconds, arguments={\"expected_from\": \"2021-01-01T00:00:00.000000\"})\n",
+					"\n",
+					""
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/sap-hr-views-saphr.json
+++ b/workspace/notebook/sap-hr-views-saphr.json
@@ -1,0 +1,243 @@
+{
+	"name": "sap-hr-views-saphr",
+	"properties": {
+		"folder": {
+			"name": "odw-harmonised/SAP-HR"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "62e5dc47-8d6e-4d17-9868-cdffa2cc4641"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"tags": [
+						"parameters"
+					]
+				},
+				"source": [
+					"expected_from=''"
+				],
+				"execution_count": 42
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"**The expected_from parameter above is the month which we want to ingest. For example, if we want data from January 2023, we can query this data from standardised by setting the expected_from as the start of next month (February)**"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if expected_from != '':\n",
+					"    spark.sql(f\"SET DATE_VAR = '{expected_from}'\")\n",
+					"else:\n",
+					"    spark.sql(f\"SET DATE_VAR = (SELECT MAX(expected_from) FROM odw_standardised_db.hr_saphr)\")"
+				],
+				"execution_count": 43
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"## Creates a view odw_standardised_db.vw_leavers_temp \n",
+					"#### Creates the view with a column RN (Row Number) to be able to select non-duplicates. This is a temporary view and will be deleted after being utilised in the harmonised layer"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql   \n",
+					"\n",
+					"CREATE OR REPLACE VIEW odw_standardised_db.vw_saphr\n",
+					"\n",
+					"AS\n",
+					"\n",
+					"SELECT \n",
+					"    CASE \n",
+					"        WHEN LENGTH(Pers_No) = 6 AND SUBSTR(Pers_No,1,1) = 5\n",
+					"        THEN CONCAT('00',Pers_No)\n",
+					"        WHEN LENGTH(Pers_No) = 6 AND SUBSTR(Pers_No,1,1) = 4\n",
+					"        THEN CONCAT('50',Pers_No)        \n",
+					"        ELSE Pers_No\n",
+					"    END as Pers_No,\n",
+					"    First_name,\n",
+					"    Last_name,\n",
+					"    Employee_No,\n",
+					"    CoCd,\n",
+					"    Company_Code,\n",
+					"    PA,\n",
+					"    Personnel_Area,\n",
+					"    PSubarea,\n",
+					"    Personnel_Subarea,\n",
+					"    Org_Unit,\n",
+					"    Organizational_Unit,\n",
+					"    Organizational_key1,\n",
+					"    Organizational_key2,\n",
+					"    WorkC,\n",
+					"    Work_Contract,\n",
+					"    CT,\n",
+					"    Contract_Type,\n",
+					"    PS_Group,\n",
+					"    Pay_Band_Description,\n",
+					"    FTE,\n",
+					"    Wk_hrs,\n",
+					"    Indicator_Part_Time_Employee,\n",
+					"    S,\n",
+					"    Employment_Status,\n",
+					"    Gender_Key,\n",
+					"    to_timestamp(TRA_Start_Date) AS TRA_Start_Date,\n",
+					"    to_timestamp(TRA_End_Date) AS TRA_End_Date,\n",
+					"    TRA_Status,\n",
+					"    TRA_Grade,\n",
+					"    Prev_PersNo,\n",
+					"    ActR,\n",
+					"    Reason_for_Action,\n",
+					"    Position,\n",
+					"    Position_1,\n",
+					"    Cost_Ctr,\n",
+					"    Cost_Centre,\n",
+					"    to_timestamp(Civil_Service_Start) AS Civil_Service_Start,\n",
+					"    to_timestamp(Date_to_Current_Job) AS Date_to_Current_Job,\n",
+					"    to_timestamp(Seniority_Date) AS Seniority_Date,\n",
+					"    to_timestamp(Date_to_Subst_Grade) AS Date_to_Subst_Grade,\n",
+					"    Pers_No_1,\n",
+					"    Name_of_Manager_OM,\n",
+					"    Manager_Position,\n",
+					"    Manager_Position_Text,\n",
+					"    Counter_Sign_Manager,\n",
+					"    Loc,\n",
+					"    Location,\n",
+					"    to_timestamp(Org_Start_Date) AS Org_Start_Date,\n",
+					"    to_timestamp(Fix_Term_End_Date) AS Fix_Term_End_Date,\n",
+					"    to_timestamp(Loan_Start_Date) AS Loan_Start_Date,\n",
+					"    to_timestamp(Loan_End_Date) AS Loan_End_Date,\n",
+					"    EEGrp,\n",
+					"    Employee_Group,\n",
+					"    Annual_salary,\n",
+					"    Curr,\n",
+					"    NI_number,\n",
+					"    Birth_date,\n",
+					"    Age_of_employee,\n",
+					"    EO,\n",
+					"    Ethnic_origin,\n",
+					"    NID,\n",
+					"    Rel,\n",
+					"    Religious_Denomination_Key,\n",
+					"    SxO,\n",
+					"    Wage_Type,\n",
+					"    Employee_Subgroup,\n",
+					"    LOA_Abs_Type,\n",
+					"    LOA_Absence_Type_Text,\n",
+					"    Scheme_reference,\n",
+					"    Pension_Scheme_Name,\n",
+					"    Disability_Code,\n",
+					"    Disability_Text,\n",
+					"    Disability_Code_Description,\n",
+					"    PArea,\n",
+					"    Payroll_Area,\n",
+					"    Assignment_Number,\n",
+					"    FTE_2,\n",
+					"    ingested_datetime,\n",
+					"    expected_from,\n",
+					"    expected_to\n",
+					"\n",
+					"FROM odw_standardised_db.hr_saphr\n",
+					"WHERE expected_from = ${DATE_VAR}"
+				],
+				"execution_count": null
+			}
+		]
+	}
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
