### PR TITLE
Fix/remove testing column absece all

### DIFF
--- a/workspace/notebook/mipins_vw_fact_absence_all.json
+++ b/workspace/notebook/mipins_vw_fact_absence_all.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c6bde105-e7ab-4056-b42f-6661208a96ed"
+				"spark.autotune.trackingId": "b1fb8033-f9a7-43ea-8d40-8154fc566c08"
 			}
 		},
 		"metadata": {
@@ -66,8 +66,8 @@
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"    T7.CalendarDate AS AbsenceDate,\r\n",
-					"    T1.AbsenceStartDate,\r\n",
-					"    T1.AbsenceEndDate,\r\n",
+					"    -- T1.AbsenceStartDate,\r\n",
+					"    -- T1.AbsenceEndDate,\r\n",
 					"    T1.Hours AS AbsenceHours,\r\n",
 					"    T1.EmployeeID AS StaffNumber,\r\n",
 					"    T6.WorkScheduleRule,\r\n",
@@ -92,8 +92,8 @@
 					"\t\twhen 6 then T6.WorkDayHours/7.4\r\n",
 					"\t\telse null\r\n",
 					"\tend as LeaveONS,\r\n",
-					"    T6.WorkDayHours,\r\n",
-					"    T5.Description PayBand,\r\n",
+					"    -- T6.WorkDayHours,\r\n",
+					"    -- T5.Description PayBand,\r\n",
 					"    T5.PSGroupCode AS PSGroup,\r\n",
 					"    T3.Description AS PersonnelArea,\r\n",
 					"    T4.Description AS PersonnelSubArea,\r\n",

--- a/workspace/notebook/mipins_vw_fact_absence_all.json
+++ b/workspace/notebook/mipins_vw_fact_absence_all.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b1fb8033-f9a7-43ea-8d40-8154fc566c08"
+				"spark.autotune.trackingId": "cd058ec1-ecab-4549-b9ea-4c0951630172"
 			}
 		},
 		"metadata": {
@@ -115,7 +115,7 @@
 					"WHERE T1.IsActive = 'Y'\r\n",
 					"ORDER BY StaffNumber,AbsenceDate"
 				],
-				"execution_count": 2
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -133,7 +133,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.mipins_fact_absence_all;\")"
 				],
-				"execution_count": 3
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -159,7 +159,7 @@
 					"as\r\n",
 					"SELECT * FROM odw_curated_db.vw_mipins_fact_absence_all"
 				],
-				"execution_count": 4
+				"execution_count": 3
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
