### PR TITLE
Updating notebook: service_user

### DIFF
--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "079e2420-b4c9-429c-ac4b-e54359c1178e"
+				"spark.autotune.trackingId": "44bcbf6a-86e8-4253-95f7-d79dba2a7eb7"
 			}
 		},
 		"metadata": {
@@ -55,6 +55,28 @@
 			{
 				"cell_type": "code",
 				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"from notebookutils import mssparkutils\n",
+					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
+					"\n",
+					"is_dev_or_test_env = 'dev' in storage_account or 'test' in storage_account\n",
+					"spark.sql(f\"SET IS_DEV_OR_TEST = '{is_dev_or_test_env}'\")"
+				],
+				"execution_count": 18
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
 					"microsoft": {
 						"language": "sparksql"
 					},
@@ -70,8 +92,43 @@
 					"SELECT DISTINCT\r\n",
 					"\r\n",
 					"    SU.Salutation                                               AS salutation,\r\n",
-					"    SU.FirstName                                                AS firstName,\r\n",
-					"    SU.LastName                                                 AS lastName,\r\n",
+					"    \r\n",
+					"    CASE ${IS_DEV_OR_TEST}\r\n",
+					"        WHEN TRUE\r\n",
+					"        THEN '[Anonymized]'     \r\n",
+					"        ELSE SU.FirstName \r\n",
+					"    END                                                         AS firstName,\r\n",
+					"\r\n",
+					"    CASE ${IS_DEV_OR_TEST}\r\n",
+					"        WHEN TRUE\r\n",
+					"        THEN '[Anonymized]'     \r\n",
+					"        ELSE SU.LastName \r\n",
+					"    END                                                         AS lastName,\r\n",
+					"\r\n",
+					"    CASE ${IS_DEV_OR_TEST}\r\n",
+					"        WHEN TRUE\r\n",
+					"        THEN '[Anonymized]'     \r\n",
+					"        ELSE SU.EmailAddress \r\n",
+					"    END                                                         AS emailAddress,\r\n",
+					"\r\n",
+					"    CASE ${IS_DEV_OR_TEST}\r\n",
+					"        WHEN TRUE\r\n",
+					"        THEN '[Anonymized]'     \r\n",
+					"        ELSE SU.TelephoneNumber \r\n",
+					"    END                                                         AS telephoneNumber,\r\n",
+					"\r\n",
+					"    CASE ${IS_DEV_OR_TEST}\r\n",
+					"        WHEN TRUE\r\n",
+					"        THEN '[Anonymized]'     \r\n",
+					"        ELSE SU.OtherPhoneNumber \r\n",
+					"    END                                                         AS otherPhoneNumber,\r\n",
+					"\r\n",
+					"    CASE ${IS_DEV_OR_TEST}\r\n",
+					"        WHEN TRUE\r\n",
+					"        THEN '[Anonymized]'     \r\n",
+					"        ELSE SU.FaxNumber \r\n",
+					"    END                                                         AS faxNumber,\r\n",
+					"\r\n",
 					"    SU.AddressLine1                                             AS addressLine1,\r\n",
 					"    SU.AddressLine2                                             AS addressLine2,\r\n",
 					"    SU.AddressTown                                              AS addressTown,\r\n",
@@ -79,9 +136,6 @@
 					"    SU.Postcode                                                 AS postcode,\r\n",
 					"    SU.Organisation                                             AS organisation,\r\n",
 					"    SU.OrganisationType                                         AS organisationType,\r\n",
-					"    SU.TelephoneNumber                                          AS telephoneNumber,\r\n",
-					"    SU.OtherPhoneNumber                                         AS otherPhoneNumber,\r\n",
-					"    SU.FaxNumber                                                AS faxNumber,\r\n",
 					"    SU.Role                                                     AS serviceUserType,\r\n",
 					"    SU.CaseReference                                            AS caseReference\r\n",
 					"    \r\n",
@@ -89,7 +143,7 @@
 					"WHERE SU.IsActive = 'Y'\r\n",
 					""
 				],
-				"execution_count": 9
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
