### PR TITLE
Fix/anonymization service user curated

### DIFF
--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "02cb238c-1f31-4186-a821-c0ac49ceda29"
+				"spark.autotune.trackingId": "12f5c11c-94f3-4bed-be24-175cb4c4846e"
 			}
 		},
 		"metadata": {
@@ -94,6 +94,7 @@
 					"SELECT DISTINCT\r\n",
 					"\r\n",
 					"    SU.SUAreaID                                                 AS ID,\r\n",
+					"    SU.SourceSystemID                                           AS SourceSystemID,\r\n",
 					"    SU.Salutation                                               AS salutation,\r\n",
 					"    SU.FirstName                                                AS firstName,\r\n",
 					"    SU.LastName                                                 AS lastName,\r\n",
@@ -204,6 +205,29 @@
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
 				"execution_count": 69
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"select * from odw_curated_db.service_user"
+				],
+				"execution_count": 71
 			}
 		]
 	}

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "12f5c11c-94f3-4bed-be24-175cb4c4846e"
+				"spark.autotune.trackingId": "179f7a40-4e15-45c3-aa1c-5690c3b3d9a8"
 			}
 		},
 		"metadata": {
@@ -74,7 +74,7 @@
 					"\n",
 					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 64
+				"execution_count": 72
 			},
 			{
 				"cell_type": "code",
@@ -118,7 +118,7 @@
 					"LIMIT ${MAX_LIMIT}\r\n",
 					""
 				],
-				"execution_count": 65
+				"execution_count": 73
 			},
 			{
 				"cell_type": "code",
@@ -144,7 +144,7 @@
 					"as\r\n",
 					"SELECT * FROM odw_curated_db.vw_service_user"
 				],
-				"execution_count": 66
+				"execution_count": 74
 			},
 			{
 				"cell_type": "code",
@@ -166,7 +166,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": 67
+				"execution_count": 75
 			},
 			{
 				"cell_type": "code",
@@ -204,30 +204,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 69
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"select * from odw_curated_db.service_user"
-				],
-				"execution_count": 71
+				"execution_count": 76
 			}
 		]
 	}

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c2e6b1cd-31ab-4c68-86d7-e884090f9423"
+				"spark.autotune.trackingId": "b7053301-ca29-4013-87ba-3250460ddb18"
 			}
 		},
 		"metadata": {
@@ -70,9 +70,10 @@
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"\n",
 					"is_dev_or_test_env = 'dev' in storage_account or 'test' in storage_account\n",
-					"spark.sql(f\"SET IS_DEV_OR_TEST = '{is_dev_or_test_env}'\")"
+					"spark.sql(f\"SET IS_DEV_OR_TEST = '{is_dev_or_test_env}'\")\n",
+					"spark.sql(f\"SET MAX_LIMIT = 100000000\")"
 				],
-				"execution_count": null
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -91,44 +92,14 @@
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"\r\n",
+					"    0                                                           AS ID,\r\n",
 					"    SU.Salutation                                               AS salutation,\r\n",
-					"    \r\n",
-					"    CASE ${IS_DEV_OR_TEST}\r\n",
-					"        WHEN TRUE\r\n",
-					"        THEN '[Anonymized]'     \r\n",
-					"        ELSE SU.FirstName \r\n",
-					"    END                                                         AS firstName,\r\n",
-					"\r\n",
-					"    CASE ${IS_DEV_OR_TEST}\r\n",
-					"        WHEN TRUE\r\n",
-					"        THEN '[Anonymized]'     \r\n",
-					"        ELSE SU.LastName \r\n",
-					"    END                                                         AS lastName,\r\n",
-					"\r\n",
-					"    CASE ${IS_DEV_OR_TEST}\r\n",
-					"        WHEN TRUE\r\n",
-					"        THEN '[Anonymized]'     \r\n",
-					"        ELSE SU.EmailAddress \r\n",
-					"    END                                                         AS emailAddress,\r\n",
-					"\r\n",
-					"    CASE ${IS_DEV_OR_TEST}\r\n",
-					"        WHEN TRUE\r\n",
-					"        THEN '[Anonymized]'     \r\n",
-					"        ELSE SU.TelephoneNumber \r\n",
-					"    END                                                         AS telephoneNumber,\r\n",
-					"\r\n",
-					"    CASE ${IS_DEV_OR_TEST}\r\n",
-					"        WHEN TRUE\r\n",
-					"        THEN '[Anonymized]'     \r\n",
-					"        ELSE SU.OtherPhoneNumber \r\n",
-					"    END                                                         AS otherPhoneNumber,\r\n",
-					"\r\n",
-					"    CASE ${IS_DEV_OR_TEST}\r\n",
-					"        WHEN TRUE\r\n",
-					"        THEN '[Anonymized]'     \r\n",
-					"        ELSE SU.FaxNumber \r\n",
-					"    END                                                         AS faxNumber,\r\n",
-					"\r\n",
+					"    SU.FirstName                                                AS firstName,\r\n",
+					"    SU.LastName                                                 AS lastName,\r\n",
+					"    SU.EmailAddress                                             AS emailAddress,\r\n",
+					"    SU.TelephoneNumber                                          AS telephoneNumber,\r\n",
+					"    SU.OtherPhoneNumber                                         AS otherPhoneNumber,\r\n",
+					"    SU.FaxNumber                                                AS faxNumber,\r\n",
 					"    SU.AddressLine1                                             AS addressLine1,\r\n",
 					"    SU.AddressLine2                                             AS addressLine2,\r\n",
 					"    SU.AddressTown                                              AS addressTown,\r\n",
@@ -142,8 +113,35 @@
 					"FROM odw_harmonised_db.service_user_dim                        AS SU\r\n",
 					"WHERE SU.IsActive = 'Y'\r\n",
 					"\r\n",
-					"LIMIT 1\r\n",
+					"LIMIT   CASE\r\n",
+					"            WHEN ${IS_DEV_OR_TEST} = True\r\n",
+					"            THEN 20 -- only need limited data for dev/test environment\r\n",
+					"            ELSE ${MAX_LIMIT}\r\n",
+					"        END;\r\n",
 					""
+				],
+				"execution_count": 30
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"select count(*) from odw_curated_db.vw_service_user  "
 				],
 				"execution_count": null
 			},
@@ -163,7 +161,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.service_user;\")"
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -189,7 +187,51 @@
 					"as\r\n",
 					"SELECT * FROM odw_curated_db.vw_service_user"
 				],
-				"execution_count": 11
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "python"
+					}
+				},
+				"source": [
+					"%%pyspark\n",
+					"pip install Faker"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					}
+				},
+				"source": [
+					"%%sql\n",
+					"select * from odw_curated_db.service_user"
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -205,29 +247,49 @@
 					}
 				},
 				"source": [
+					"if is_dev_or_test_env:\n",
 					"\n",
-					"absences_table = 'odw_standardised_db.hr_absences'\n",
-					"absences_table_loc = \"abfss://odw-standardised@\" + storage_account+'HR/hr_absences'\n",
+					"    import pandas as pd\n",
+					"    from faker import Faker\n",
+					"    \n",
+					"    df = spark.sql(\"select * from odw_curated_db.service_user\").toPandas()\n",
 					"\n",
-					"# getting the closest expected_from date in the table based on the expected_from parameter\n",
-					"if expected_from != '':\n",
-					"    absences_expected_from = spark.sql(f\"SELECT expected_from FROM {absences_table} as table_alias WHERE table_alias.expected_from <= '{expected_from}' ORDER BY table_alias.expected_from DESC LIMIT 1;\")\n",
-					"else:\n",
-					"    absences_expected_from = spark.sql(f\"SELECT MAX(expected_from) FROM {absences_table}\")\n",
-					"try:\n",
-					"    absences_expected_from = absences_expected_from.first()[0]\n",
-					"except:\n",
-					"    absences_expected_from = ''\n",
+					"    if(len(df) > 0):\n",
+					"        fake = Faker()\n",
+					"        \n",
+					"        df['firstName'] = [fake.first_name() for _ in range(len(df))]\n",
+					"        df['lastName'] = [fake.last_name() for _ in range(len(df))]\n",
+					"        df['emailAddress'] = [fake.email() for _ in range(len(df))]\n",
+					"        df['telephoneNumber'] = [fake.phone_number() for _ in range(len(df))]\n",
+					"        df['otherPhoneNumber'] = [fake.phone_number() for _ in range(len(df))]\n",
+					"        df['faxNumber'] = [fake.phone_number() for _ in range(len(df))]\n",
+					"        \n",
+					"        df = spark.createDataFrame(df)\n",
 					"\n",
-					"work_schedule = spark.read.format('delta').load(\"abfss://odw-standardised@\" + storage_account+'HR/hr_work_schedule_rule').toPandas()\n",
-					"absences = spark.sql(f\"select * from {absences_table} where cast(expected_from as Date) = '{absences_expected_from}'\").toPandas()\n",
-					"\n",
-					"if(len(absences) > 0):\n",
-					"    for i, row in absences.iterrows():\n",
-					"        absences.at[i, 'hrs'] = get_absence_hrs(float(row['days']), float(row['hrs']), row['start_date'], row['end_date'], row['work_schedule_rule'])\n",
-					"\n",
-					"    absencesDF = spark.createDataFrame(absences)\n",
-					"    absencesDF.write.format(\"delta\").mode(\"overwrite\").option(\"replaceWhere\", f\"cast(expected_from as Date) = '{absences_expected_from}'\").save(absences_table_loc)"
+					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
+					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					}
+				},
+				"source": [
+					"%%sql\n",
+					"select * from odw_curated_db.service_user"
 				],
 				"execution_count": null
 			}

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b7053301-ca29-4013-87ba-3250460ddb18"
+				"spark.autotune.trackingId": "deafea6c-d8fb-47da-ab14-80e819afb3b6"
 			}
 		},
 		"metadata": {
@@ -70,10 +70,11 @@
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"\n",
 					"is_dev_or_test_env = 'dev' in storage_account or 'test' in storage_account\n",
-					"spark.sql(f\"SET IS_DEV_OR_TEST = '{is_dev_or_test_env}'\")\n",
-					"spark.sql(f\"SET MAX_LIMIT = 100000000\")"
+					"max_limit = 20 if is_dev_or_test_env else 100000000\n",
+					"\n",
+					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 29
+				"execution_count": 58
 			},
 			{
 				"cell_type": "code",
@@ -112,56 +113,11 @@
 					"    \r\n",
 					"FROM odw_harmonised_db.service_user_dim                        AS SU\r\n",
 					"WHERE SU.IsActive = 'Y'\r\n",
-					"\r\n",
-					"LIMIT   CASE\r\n",
-					"            WHEN ${IS_DEV_OR_TEST} = True\r\n",
-					"            THEN 20 -- only need limited data for dev/test environment\r\n",
-					"            ELSE ${MAX_LIMIT}\r\n",
-					"        END;\r\n",
+					"    \r\n",
+					"LIMIT ${MAX_LIMIT}\r\n",
 					""
 				],
-				"execution_count": 30
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"select count(*) from odw_curated_db.vw_service_user  "
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"spark.sql(f\"drop table if exists odw_curated_db.service_user;\")"
-				],
-				"execution_count": null
+				"execution_count": 59
 			},
 			{
 				"cell_type": "code",
@@ -187,7 +143,7 @@
 					"as\r\n",
 					"SELECT * FROM odw_curated_db.vw_service_user"
 				],
-				"execution_count": null
+				"execution_count": 60
 			},
 			{
 				"cell_type": "code",
@@ -209,7 +165,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": null
+				"execution_count": 61
 			},
 			{
 				"cell_type": "code",
@@ -225,13 +181,14 @@
 					},
 					"microsoft": {
 						"language": "sparksql"
-					}
+					},
+					"collapsed": false
 				},
 				"source": [
 					"%%sql\n",
-					"select * from odw_curated_db.service_user"
+					"select * from odw_curated_db.service_user limit 100"
 				],
-				"execution_count": null
+				"execution_count": 62
 			},
 			{
 				"cell_type": "code",
@@ -269,7 +226,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": null
+				"execution_count": 63
 			},
 			{
 				"cell_type": "code",
@@ -285,11 +242,12 @@
 					},
 					"microsoft": {
 						"language": "sparksql"
-					}
+					},
+					"collapsed": false
 				},
 				"source": [
 					"%%sql\n",
-					"select * from odw_curated_db.service_user"
+					"select * from odw_curated_db.service_user limit 100"
 				],
 				"execution_count": null
 			}

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "44bcbf6a-86e8-4253-95f7-d79dba2a7eb7"
+				"spark.autotune.trackingId": "c2e6b1cd-31ab-4c68-86d7-e884090f9423"
 			}
 		},
 		"metadata": {
@@ -72,7 +72,7 @@
 					"is_dev_or_test_env = 'dev' in storage_account or 'test' in storage_account\n",
 					"spark.sql(f\"SET IS_DEV_OR_TEST = '{is_dev_or_test_env}'\")"
 				],
-				"execution_count": 18
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -141,9 +141,11 @@
 					"    \r\n",
 					"FROM odw_harmonised_db.service_user_dim                        AS SU\r\n",
 					"WHERE SU.IsActive = 'Y'\r\n",
+					"\r\n",
+					"LIMIT 1\r\n",
 					""
 				],
-				"execution_count": 19
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -188,6 +190,46 @@
 					"SELECT * FROM odw_curated_db.vw_service_user"
 				],
 				"execution_count": 11
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"\n",
+					"absences_table = 'odw_standardised_db.hr_absences'\n",
+					"absences_table_loc = \"abfss://odw-standardised@\" + storage_account+'HR/hr_absences'\n",
+					"\n",
+					"# getting the closest expected_from date in the table based on the expected_from parameter\n",
+					"if expected_from != '':\n",
+					"    absences_expected_from = spark.sql(f\"SELECT expected_from FROM {absences_table} as table_alias WHERE table_alias.expected_from <= '{expected_from}' ORDER BY table_alias.expected_from DESC LIMIT 1;\")\n",
+					"else:\n",
+					"    absences_expected_from = spark.sql(f\"SELECT MAX(expected_from) FROM {absences_table}\")\n",
+					"try:\n",
+					"    absences_expected_from = absences_expected_from.first()[0]\n",
+					"except:\n",
+					"    absences_expected_from = ''\n",
+					"\n",
+					"work_schedule = spark.read.format('delta').load(\"abfss://odw-standardised@\" + storage_account+'HR/hr_work_schedule_rule').toPandas()\n",
+					"absences = spark.sql(f\"select * from {absences_table} where cast(expected_from as Date) = '{absences_expected_from}'\").toPandas()\n",
+					"\n",
+					"if(len(absences) > 0):\n",
+					"    for i, row in absences.iterrows():\n",
+					"        absences.at[i, 'hrs'] = get_absence_hrs(float(row['days']), float(row['hrs']), row['start_date'], row['end_date'], row['work_schedule_rule'])\n",
+					"\n",
+					"    absencesDF = spark.createDataFrame(absences)\n",
+					"    absencesDF.write.format(\"delta\").mode(\"overwrite\").option(\"replaceWhere\", f\"cast(expected_from as Date) = '{absences_expected_from}'\").save(absences_table_loc)"
+				],
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "deafea6c-d8fb-47da-ab14-80e819afb3b6"
+				"spark.autotune.trackingId": "dac48404-5097-4d94-a6cc-a08f38c013f2"
 			}
 		},
 		"metadata": {
@@ -93,7 +93,7 @@
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"\r\n",
-					"    0                                                           AS ID,\r\n",
+					"    SU.SUAreaID                                                 AS ID,\r\n",
 					"    SU.Salutation                                               AS salutation,\r\n",
 					"    SU.FirstName                                                AS firstName,\r\n",
 					"    SU.LastName                                                 AS lastName,\r\n",
@@ -113,7 +113,7 @@
 					"    \r\n",
 					"FROM odw_harmonised_db.service_user_dim                        AS SU\r\n",
 					"WHERE SU.IsActive = 'Y'\r\n",
-					"    \r\n",
+					"\r\n",
 					"LIMIT ${MAX_LIMIT}\r\n",
 					""
 				],

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "dac48404-5097-4d94-a6cc-a08f38c013f2"
+				"spark.autotune.trackingId": "02cb238c-1f31-4186-a821-c0ac49ceda29"
 			}
 		},
 		"metadata": {
@@ -74,7 +74,7 @@
 					"\n",
 					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 58
+				"execution_count": 64
 			},
 			{
 				"cell_type": "code",
@@ -117,7 +117,7 @@
 					"LIMIT ${MAX_LIMIT}\r\n",
 					""
 				],
-				"execution_count": 59
+				"execution_count": 65
 			},
 			{
 				"cell_type": "code",
@@ -143,7 +143,7 @@
 					"as\r\n",
 					"SELECT * FROM odw_curated_db.vw_service_user"
 				],
-				"execution_count": 60
+				"execution_count": 66
 			},
 			{
 				"cell_type": "code",
@@ -165,30 +165,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": 61
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"select * from odw_curated_db.service_user limit 100"
-				],
-				"execution_count": 62
+				"execution_count": 67
 			},
 			{
 				"cell_type": "code",
@@ -226,30 +203,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 63
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"select * from odw_curated_db.service_user limit 100"
-				],
-				"execution_count": null
+				"execution_count": 69
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
