### PR TITLE
Fix/service user inbound msg

### DIFF
--- a/workspace/notebook/employee-publish.json
+++ b/workspace/notebook/employee-publish.json
@@ -2,7 +2,7 @@
 	"name": "employee-publish",
 	"properties": {
 		"folder": {
-			"name": "odw-esb"
+			"name": "odw-sb"
 		},
 		"nbformat": 4,
 		"nbformat_minor": 2,
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e0184991-316a-430f-8b0f-87e76c8493e4"
+				"spark.autotune.trackingId": "4eac6bf4-d474-489b-a48c-549fad455928"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/establish-sb-connection.json
+++ b/workspace/notebook/establish-sb-connection.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c749d9b8-9c35-4fd9-8308-e00cbbcfbbba"
+				"spark.autotune.trackingId": "0b6eb926-3ca0-4fe4-97bc-4daa67f9471f"
 			}
 		},
 		"metadata": {
@@ -66,15 +66,14 @@
 			},
 			{
 				"cell_type": "code",
+				"metadata": {
+					"tags": [
+						"parameters"
+					]
+				},
 				"source": [
-					"kv_linked_service=\"ls_kv\"\n",
-					"secret_name='servicebus-connectionstring'\n",
-					"# secret_name='odt-servicebus-connectionstring'\n",
-					"\n",
-					"topic_name='service-user'\n",
-					"subscription_name = 'service-user'\n",
-					"\n",
-					"table_name='service-user'"
+					"kv_linked_service=''\n",
+					"secret_name=''"
 				],
 				"execution_count": 1
 			},

--- a/workspace/notebook/establish-sb-connection.json
+++ b/workspace/notebook/establish-sb-connection.json
@@ -1,0 +1,151 @@
+{
+	"name": "establish-sb-connection",
+	"properties": {
+		"folder": {
+			"name": "odw-esb/utils"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "c749d9b8-9c35-4fd9-8308-e00cbbcfbbba"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"## Sets the notebook variables"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"kv_linked_service=\"ls_kv\"\n",
+					"secret_name='servicebus-connectionstring'\n",
+					"# secret_name='odt-servicebus-connectionstring'\n",
+					"\n",
+					"topic_name='service-user'\n",
+					"subscription_name = 'service-user'\n",
+					"\n",
+					"table_name='service-user'"
+				],
+				"execution_count": 1
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"## Gets Servicebus connectionstring from Key Vault"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"from pyspark.sql import SparkSession\n",
+					"spark = SparkSession.builder.getOrCreate()\n",
+					"akv_name=spark.sparkContext.environment.get('keyVaultName', 'get')\n",
+					"from notebookutils import mssparkutils\n",
+					"conn_str = mssparkutils.credentials.getSecret(akv_name, secret_name, kv_linked_service)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"## Creates and returns the Service Bus Client"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
+					"servicebus_client = ServiceBusClient.from_connection_string(conn_str=conn_str, logging_enable=True)\n",
+					"mssparkutils.notebook.exit(servicebus_client)"
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/establish-sb-connection.json
+++ b/workspace/notebook/establish-sb-connection.json
@@ -2,7 +2,7 @@
 	"name": "establish-sb-connection",
 	"properties": {
 		"folder": {
-			"name": "odw-esb/utils"
+			"name": "odw-sb/utils"
 		},
 		"nbformat": 4,
 		"nbformat_minor": 2,
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "aef2bdc1-8ebd-4cdb-89d0-8b72041844cc"
+				"spark.autotune.trackingId": "d9b9549a-7705-4c61-bf5b-2f308c0251fa"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/establish-sb-connection.json
+++ b/workspace/notebook/establish-sb-connection.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0b6eb926-3ca0-4fe4-97bc-4daa67f9471f"
+				"spark.autotune.trackingId": "aef2bdc1-8ebd-4cdb-89d0-8b72041844cc"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/service-user-inbound.json
+++ b/workspace/notebook/service-user-inbound.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fc4e7db2-d3e5-4e3f-a5e8-354553b2ef31"
+				"spark.autotune.trackingId": "1ff44f7e-6fea-4748-a5c8-59ecd25803ac"
 			}
 		},
 		"metadata": {
@@ -82,10 +82,10 @@
 					"akv_name=spark.sparkContext.environment.get('keyVaultName', 'get')\n",
 					"from notebookutils import mssparkutils\n",
 					"\n",
-					"servicebus_client = mssparkutils.notebook.run('/odw-sb/utils/establish-sb-connection')\n",
+					"servicebus_client = mssparkutils.notebook.run('/odw-sb/employee-publish')\n",
 					"# , arguments={'kv_linked_service'=kv_linked_service, 'secret_name': secret_name})"
 				],
-				"execution_count": 4
+				"execution_count": 7
 			}
 		]
 	}

--- a/workspace/notebook/service-user-inbound.json
+++ b/workspace/notebook/service-user-inbound.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3559249d-9852-4935-9ad0-dfbb769bb6ff"
+				"spark.autotune.trackingId": "931b38b8-aa36-4671-8936-06513daa6e6c"
 			}
 		},
 		"metadata": {
@@ -28,7 +28,7 @@
 			"enableDebugMode": false,
 			"kernelspec": {
 				"name": "synapse_pyspark",
-				"display_name": "python"
+				"display_name": "Synapse PySpark"
 			},
 			"language_info": {
 				"name": "python"
@@ -72,7 +72,7 @@
 					"topic_name='service-user'\n",
 					"subscription_name = 'service-user'"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -82,9 +82,9 @@
 					"akv_name=spark.sparkContext.environment.get('keyVaultName', 'get')\n",
 					"from notebookutils import mssparkutils\n",
 					"\n",
-					"mssparkutils.notebook.run('/odw-sb/utils/establish-sb-connection', timeout_in_seconds, arguments={\\\"expected_from\\\": date})\\n\","
+					"servicebus_client = mssparkutils.notebook.run('/odw-sb/utils/establish-sb-connection', arguments={'secret_name': secret_name})"
 				],
-				"execution_count": null
+				"execution_count": 3
 			}
 		]
 	}

--- a/workspace/notebook/service-user-inbound.json
+++ b/workspace/notebook/service-user-inbound.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "931b38b8-aa36-4671-8936-06513daa6e6c"
+				"spark.autotune.trackingId": "fc4e7db2-d3e5-4e3f-a5e8-354553b2ef31"
 			}
 		},
 		"metadata": {
@@ -82,9 +82,10 @@
 					"akv_name=spark.sparkContext.environment.get('keyVaultName', 'get')\n",
 					"from notebookutils import mssparkutils\n",
 					"\n",
-					"servicebus_client = mssparkutils.notebook.run('/odw-sb/utils/establish-sb-connection', arguments={'secret_name': secret_name})"
+					"servicebus_client = mssparkutils.notebook.run('/odw-sb/utils/establish-sb-connection')\n",
+					"# , arguments={'kv_linked_service'=kv_linked_service, 'secret_name': secret_name})"
 				],
-				"execution_count": 3
+				"execution_count": 4
 			}
 		]
 	}

--- a/workspace/notebook/service-user-inbound.json
+++ b/workspace/notebook/service-user-inbound.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1ff44f7e-6fea-4748-a5c8-59ecd25803ac"
+				"spark.autotune.trackingId": "9f61d179-0603-4f62-bfcc-433a1961de5b"
 			}
 		},
 		"metadata": {
@@ -72,7 +72,7 @@
 					"topic_name='service-user'\n",
 					"subscription_name = 'service-user'"
 				],
-				"execution_count": 2
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -85,7 +85,75 @@
 					"servicebus_client = mssparkutils.notebook.run('/odw-sb/employee-publish')\n",
 					"# , arguments={'kv_linked_service'=kv_linked_service, 'secret_name': secret_name})"
 				],
-				"execution_count": 7
+				"execution_count": 2
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"import json\n",
+					"\n",
+					"new_messages = []\n",
+					"\n",
+					"\n",
+					"with servicebus_client:\n",
+					"    receiver = servicebus_client.get_subscription_receiver(topic_name=topic_name, subscription_name=subscription_name, max_wait_time=5)\n",
+					"    with receiver:\n",
+					"        received_msgs = receiver.peek_messages(max_wait_time=5, max_message_count=20)\n",
+					"        for msg in received_msgs:\n",
+					"            msg = json.loads(str(msg))\n",
+					"            if isinstance(msg, list):\n",
+					"                new_messages.extend(msg)\n",
+					"            elif isinstance(msg, dict):\n",
+					"                new_messages.append(msg)\n",
+					"\n",
+					"new_messages = json.dumps(new_messages)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"from datetime import date\n",
+					"\n",
+					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
+					"todaysdate = date.today().strftime(\"%Y-%m-%d\")\n",
+					"\n",
+					"df = spark.read.json(spark.sparkContext.parallelize([new_messages]))\n",
+					"\n",
+					"output_folder_path = f\"abfss://odw-raw@{storage_account}Service-Bus/Service-User1/{todaysdate}/data.csv\"\n",
+					"df.repartition(1).write.mode('overwrite').option(\"header\",True).csv(output_folder_path)\n",
+					"\n",
+					"output_files = mssparkutils.fs.ls(output_folder_path)\n",
+					"output_files = [f for f in output_files if f.name.endswith('.csv')]\n",
+					"\n",
+					"if len(output_files) > 0:\n",
+					"    output_file = output_files[0]\n",
+					"    mssparkutils.fs.mv(output_file.path, output_folder_path.replace('data', 'ServiceUser'), True)\n",
+					"    mssparkutils.fs.rm(output_folder_path, True)"
+				],
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/service-user-inbound.json
+++ b/workspace/notebook/service-user-inbound.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "9f61d179-0603-4f62-bfcc-433a1961de5b"
+				"spark.autotune.trackingId": "dfcaf870-61ea-4c89-864a-70d09143f439"
 			}
 		},
 		"metadata": {
@@ -85,7 +85,7 @@
 					"servicebus_client = mssparkutils.notebook.run('/odw-sb/employee-publish')\n",
 					"# , arguments={'kv_linked_service'=kv_linked_service, 'secret_name': secret_name})"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/service-user-inbound.json
+++ b/workspace/notebook/service-user-inbound.json
@@ -1,0 +1,91 @@
+{
+	"name": "service-user-inbound",
+	"properties": {
+		"folder": {
+			"name": "odw-sb"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "3559249d-9852-4935-9ad0-dfbb769bb6ff"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "python"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"kv_linked_service=\"ls_kv\"\n",
+					"secret_name='servicebus-connectionstring'\n",
+					"# secret_name='odt-servicebus-connectionstring'\n",
+					"\n",
+					"topic_name='service-user'\n",
+					"subscription_name = 'service-user'"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"from pyspark.sql import SparkSession\n",
+					"spark = SparkSession.builder.getOrCreate()\n",
+					"akv_name=spark.sparkContext.environment.get('keyVaultName', 'get')\n",
+					"from notebookutils import mssparkutils\n",
+					"\n",
+					"mssparkutils.notebook.run('/odw-sb/utils/establish-sb-connection', timeout_in_seconds, arguments={\\\"expected_from\\\": date})\\n\","
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/service-user-publish-legacy-code.json
+++ b/workspace/notebook/service-user-publish-legacy-code.json
@@ -2,7 +2,7 @@
 	"name": "service-user-publish-legacy-code",
 	"properties": {
 		"folder": {
-			"name": "odw-esb/utils"
+			"name": "odw-sb/utils"
 		},
 		"nbformat": 4,
 		"nbformat_minor": 2,
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ac6407a1-e4b8-4959-9b0a-96793175ff99"
+				"spark.autotune.trackingId": "111c6a53-ef93-49cf-8621-62e64c4493f8"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/service-user-publish.json
+++ b/workspace/notebook/service-user-publish.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "76873026-cade-4217-81db-cce16f487259"
+				"spark.autotune.trackingId": "e612b4e5-f0e3-4aac-bd37-f983958a065a"
 			}
 		},
 		"metadata": {
@@ -100,7 +100,7 @@
 					"kv_linked_service=\"ls_kv\"\n",
 					"secret_name=''\n",
 					"topic_name=''\n",
-					"table_name = ''"
+					"table_name=''"
 				],
 				"execution_count": 27
 			},

--- a/workspace/notebook/service-user-publish.json
+++ b/workspace/notebook/service-user-publish.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "91670c80-9f1d-48d6-a103-55ce46e3ab99"
+				"spark.autotune.trackingId": "76873026-cade-4217-81db-cce16f487259"
 			}
 		},
 		"metadata": {
@@ -100,7 +100,7 @@
 					"kv_linked_service=\"ls_kv\"\n",
 					"secret_name=''\n",
 					"topic_name=''\n",
-					"subscription_name = ''"
+					"table_name = ''"
 				],
 				"execution_count": 27
 			},

--- a/workspace/notebook/service-user-publish.json
+++ b/workspace/notebook/service-user-publish.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0a040d47-88d4-4285-acd7-c6f88dd2b5fe"
+				"spark.autotune.trackingId": "91670c80-9f1d-48d6-a103-55ce46e3ab99"
 			}
 		},
 		"metadata": {
@@ -98,13 +98,9 @@
 				},
 				"source": [
 					"kv_linked_service=\"ls_kv\"\n",
-					"secret_name='servicebus-connectionstring'\n",
-					"# secret_name='odt-servicebus-connectionstring'\n",
-					"\n",
-					"topic_name='service-user'\n",
-					"subscription_name = 'service-user'\n",
-					"\n",
-					"table_name='service-user'"
+					"secret_name=''\n",
+					"topic_name=''\n",
+					"subscription_name = ''"
 				],
 				"execution_count": 27
 			},
@@ -174,9 +170,9 @@
 					"import pandas as pd\n",
 					"\n",
 					"def publish_full_message(msg):\n",
+					"    from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
+					"    servicebus_client = ServiceBusClient.from_connection_string(conn_str=conn_str, logging_enable=True)\n",
 					"    try:\n",
-					"        from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
-					"        servicebus_client = ServiceBusClient.from_connection_string(conn_str=conn_str, logging_enable=True)\n",
 					"        with servicebus_client:\n",
 					"            sender = servicebus_client.get_topic_sender(topic_name=topic_name)\n",
 					"            with sender:\n",

--- a/workspace/notebook/service-user-publish.json
+++ b/workspace/notebook/service-user-publish.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1fe4ad1c-e352-457b-a6f8-ed7044170ced"
+				"spark.autotune.trackingId": "0a040d47-88d4-4285-acd7-c6f88dd2b5fe"
 			}
 		},
 		"metadata": {
@@ -106,7 +106,7 @@
 					"\n",
 					"table_name='service-user'"
 				],
-				"execution_count": 17
+				"execution_count": 27
 			},
 			{
 				"cell_type": "markdown",
@@ -141,66 +141,7 @@
 					"from notebookutils import mssparkutils\n",
 					"conn_str = mssparkutils.credentials.getSecret(akv_name, secret_name, kv_linked_service)"
 				],
-				"execution_count": 18
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"## Creates the Service Bus Client"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
-					"servicebus_client = ServiceBusClient.from_connection_string(conn_str=conn_str, logging_enable=True)\n",
-					"    "
-				],
-				"execution_count": 19
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"with servicebus_client:\n",
-					"    # get the Subscription Receiver object for the subscription\n",
-					"    receiver = servicebus_client.get_subscription_receiver(topic_name=topic_name, subscription_name=subscription_name, max_wait_time=5)\n",
-					"    with receiver:\n",
-					"        received_msgs = receiver.receive_messages(max_wait_time=5, max_message_count=20)\n",
-					"        for msg in received_msgs:\n",
-					"            print(\"Received: \" + str(msg))\n",
-					"            # complete the message so that the message is removed from the subscription\n",
-					"            receiver.complete_message(msg)"
-				],
-				"execution_count": 26
+				"execution_count": 28
 			},
 			{
 				"cell_type": "markdown",
@@ -234,14 +175,15 @@
 					"\n",
 					"def publish_full_message(msg):\n",
 					"    try:\n",
+					"        from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
+					"        servicebus_client = ServiceBusClient.from_connection_string(conn_str=conn_str, logging_enable=True)\n",
 					"        with servicebus_client:\n",
 					"            sender = servicebus_client.get_topic_sender(topic_name=topic_name)\n",
 					"            with sender:\n",
 					"                message = ServiceBusMessage(msg)\n",
 					"                sender.send_messages(message)\n",
 					"    except Exception as e:  \n",
-					"            print(f\"{e}\") \n",
-					""
+					"            print(f\"{e}\") "
 				],
 				"execution_count": 87
 			},
@@ -272,12 +214,11 @@
 					}
 				},
 				"source": [
-					"# import json\n",
+					"import json\n",
 					"\n",
-					"# df = spark.sql(f\"SELECT * FROM {table_name}\")\n",
-					"# json_data = df.toPandas().to_json(orient='records')\n",
-					"# publish_full_message(json_data)\n",
-					""
+					"df = spark.sql(f\"SELECT * FROM {table_name}\")\n",
+					"json_data = df.toPandas().to_json(orient='records')\n",
+					"publish_full_message(json_data)"
 				],
 				"execution_count": 88
 			}

--- a/workspace/notebook/service-user-publish.json
+++ b/workspace/notebook/service-user-publish.json
@@ -2,7 +2,7 @@
 	"name": "service-user-publish",
 	"properties": {
 		"folder": {
-			"name": "odw-esb"
+			"name": "odw-sb"
 		},
 		"nbformat": 4,
 		"nbformat_minor": 2,
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b9e646df-c9db-43a0-b4f2-7a87fa9dd1ed"
+				"spark.autotune.trackingId": "1fe4ad1c-e352-457b-a6f8-ed7044170ced"
 			}
 		},
 		"metadata": {
@@ -98,11 +98,15 @@
 				},
 				"source": [
 					"kv_linked_service=\"ls_kv\"\n",
-					"secret_name=''\n",
-					"topic_name=''\n",
-					"table_name=''"
+					"secret_name='servicebus-connectionstring'\n",
+					"# secret_name='odt-servicebus-connectionstring'\n",
+					"\n",
+					"topic_name='service-user'\n",
+					"subscription_name = 'service-user'\n",
+					"\n",
+					"table_name='service-user'"
 				],
-				"execution_count": 85
+				"execution_count": 17
 			},
 			{
 				"cell_type": "markdown",
@@ -137,7 +141,66 @@
 					"from notebookutils import mssparkutils\n",
 					"conn_str = mssparkutils.credentials.getSecret(akv_name, secret_name, kv_linked_service)"
 				],
-				"execution_count": 86
+				"execution_count": 18
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"## Creates the Service Bus Client"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
+					"servicebus_client = ServiceBusClient.from_connection_string(conn_str=conn_str, logging_enable=True)\n",
+					"    "
+				],
+				"execution_count": 19
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"with servicebus_client:\n",
+					"    # get the Subscription Receiver object for the subscription\n",
+					"    receiver = servicebus_client.get_subscription_receiver(topic_name=topic_name, subscription_name=subscription_name, max_wait_time=5)\n",
+					"    with receiver:\n",
+					"        received_msgs = receiver.receive_messages(max_wait_time=5, max_message_count=20)\n",
+					"        for msg in received_msgs:\n",
+					"            print(\"Received: \" + str(msg))\n",
+					"            # complete the message so that the message is removed from the subscription\n",
+					"            receiver.complete_message(msg)"
+				],
+				"execution_count": 26
 			},
 			{
 				"cell_type": "markdown",
@@ -170,8 +233,6 @@
 					"import pandas as pd\n",
 					"\n",
 					"def publish_full_message(msg):\n",
-					"    from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
-					"    servicebus_client = ServiceBusClient.from_connection_string(conn_str=conn_str, logging_enable=True)\n",
 					"    try:\n",
 					"        with servicebus_client:\n",
 					"            sender = servicebus_client.get_topic_sender(topic_name=topic_name)\n",
@@ -211,11 +272,11 @@
 					}
 				},
 				"source": [
-					"import json\n",
+					"# import json\n",
 					"\n",
-					"df = spark.sql(f\"SELECT * FROM {table_name}\")\n",
-					"json_data = df.toPandas().to_json(orient='records')\n",
-					"publish_full_message(json_data)\n",
+					"# df = spark.sql(f\"SELECT * FROM {table_name}\")\n",
+					"# json_data = df.toPandas().to_json(orient='records')\n",
+					"# publish_full_message(json_data)\n",
 					""
 				],
 				"execution_count": 88


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
