### PR TITLE
Feat/service user deployment

### DIFF
--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/service_user_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/service_user_dim.json
@@ -14,6 +14,18 @@
     },
     {
       "metadata": {},
+      "name": "CaseReference",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "SUAreaID",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "metadata": {},
       "name": "Salutation",
       "type": "string",
       "nullable": true
@@ -80,6 +92,12 @@
     },
     {
       "metadata": {},
+      "name": "ServiceUserType",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
       "name": "Role",
       "type": "string",
       "nullable": true
@@ -105,18 +123,6 @@
     {
       "metadata": {},
       "name": "EmailAddress",
-      "type": "string",
-      "nullable": true
-    },
-    {
-      "metadata": {},
-      "name": "WebAddress",
-      "type": "string",
-      "nullable": true
-    },
-    {
-      "metadata": {},
-      "name": "ServiceUserType",
       "type": "string",
       "nullable": true
     },

--- a/workspace/pipeline/0_Horizon_Service_User.json
+++ b/workspace/pipeline/0_Horizon_Service_User.json
@@ -439,7 +439,7 @@
 			}
 		],
 		"folder": {
-			"name": "casework/layers/0-raw"
+			"name": "service user/layers/0-raw"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,111 +3,36 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "Delete Leavers",
-				"type": "SynapseNotebook",
+				"name": "pln_service_user_clean_slate",
+				"type": "ExecutePipeline",
 				"dependsOn": [],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
 				"userProperties": [],
 				"typeProperties": {
-					"notebook": {
-						"referenceName": "py_delete_table",
-						"type": "NotebookReference"
+					"pipeline": {
+						"referenceName": "pln_service_user_clean_slate",
+						"type": "PipelineReference"
 					},
-					"parameters": {
-						"db_name": {
-							"value": "odw_harmonised_db",
-							"type": "string"
-						},
-						"table_name": {
-							"value": "hr_employee_leavers_dim",
-							"type": "string"
-						}
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "Create Leavers Harmonised",
-				"type": "SynapseNotebook",
+				"name": "0_Horizon_Service_User",
+				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
-						"activity": "Delete Leavers",
+						"activity": "pln_service_user_clean_slate",
 						"dependencyConditions": [
 							"Succeeded"
 						]
 					}
 				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
 				"userProperties": [],
 				"typeProperties": {
-					"notebook": {
-						"referenceName": "py_odw_harmonised_table_creation",
-						"type": "NotebookReference"
+					"pipeline": {
+						"referenceName": "0_Horizon_Service_User",
+						"type": "PipelineReference"
 					},
-					"parameters": {
-						"specific_table": {
-							"value": "hr_employee_leavers_dim",
-							"type": "string"
-						}
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
-				}
-			},
-			{
-				"name": "py_reload_hr_leavers",
-				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "Create Leavers Harmonised",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"notebook": {
-						"referenceName": "py_reload_hr_leavers",
-						"type": "NotebookReference"
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
+					"waitOnCompletion": true
 				}
 			}
 		],

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -16,7 +16,7 @@
 				}
 			},
 			{
-				"name": "0_Horizon_Service_User",
+				"name": "pln_service_user_main",
 				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
@@ -29,7 +29,7 @@
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "0_Horizon_Service_User",
+						"referenceName": "pln_service_user_main",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true

--- a/workspace/pipeline/pln_service_user_clean_slate.json
+++ b/workspace/pipeline/pln_service_user_clean_slate.json
@@ -111,7 +111,7 @@
 				}
 			},
 			{
-				"name": "Delete Standardised Table Legacy",
+				"name": "Delete Legacy Standardised Table",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -183,92 +183,6 @@
 						"spark.dynamicAllocation.maxExecutors": null
 					},
 					"numExecutors": null
-				}
-			},
-			{
-				"name": "Ingest Legacy Standardised",
-				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "Creation of the Harmonised Servicew User Table",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Delete Standardised Table Legacy",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Delete Standardised Table",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"notebook": {
-						"referenceName": "py_raw_to_std",
-						"type": "NotebookReference"
-					},
-					"parameters": {
-						"date_folder": {
-							"value": "2023-05-19",
-							"type": "string"
-						},
-						"source_folder": {
-							"value": "Horizon",
-							"type": "string"
-						},
-						"specific_file": {
-							"value": "CaseInvolvement",
-							"type": "string"
-						}
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
-				}
-			},
-			{
-				"name": "Ingest Legacy Harmonise",
-				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "Ingest Legacy Standardised",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"notebook": {
-						"referenceName": "legacy_service_user_dim",
-						"type": "NotebookReference"
-					},
-					"snapshot": true
 				}
 			}
 		],

--- a/workspace/pipeline/pln_service_user_main.json
+++ b/workspace/pipeline/pln_service_user_main.json
@@ -44,6 +44,12 @@
 						"dependencyConditions": [
 							"Succeeded"
 						]
+					},
+					{
+						"activity": "Ingest Legacy Harmonised",
+						"dependencyConditions": [
+							"Succeeded"
+						]
 					}
 				],
 				"policy": {
@@ -117,53 +123,6 @@
 				}
 			},
 			{
-				"name": "Publish to Sevice Bus",
-				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "Ingest Curated",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"notebook": {
-						"referenceName": "service-user-publish",
-						"type": "NotebookReference"
-					},
-					"parameters": {
-						"secret_name": {
-							"value": "servicebus-connectionstring",
-							"type": "string"
-						},
-						"topic_name": {
-							"value": "service-user",
-							"type": "string"
-						},
-						"table_name": {
-							"value": "odw_curated_db.service_user",
-							"type": "string"
-						}
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
-				}
-			},
-			{
 				"name": "Service Bus to Raw",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
@@ -197,6 +156,97 @@
 							"value": "ServiceUser",
 							"type": "string"
 						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Horizon to Raw",
+				"description": "Copies migration data from Horizon to odw-raw",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "0_Horizon_Service_User",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "Ingest Std Legacy",
+				"description": "Ingests the raw migration data from Horizon to the standardised table i.e horizon_service_user",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Horizon to Raw",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_raw_to_std",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"source_folder": {
+							"value": "Horizon",
+							"type": "string"
+						},
+						"specific_file": {
+							"value": "CaseInvolvement",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Ingest Legacy Harmonised",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Ingest Std Legacy",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "legacy_service_user_dim",
+						"type": "NotebookReference"
 					},
 					"snapshot": true,
 					"conf": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
