### PR TITLE
Updating notebook: py_sb_to_raw

### DIFF
--- a/workspace/notebook/py_sb_to_raw.json
+++ b/workspace/notebook/py_sb_to_raw.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "deaf16b9-c11b-4307-bae1-849b406bafce"
+				"spark.autotune.trackingId": "23e00cbd-63f8-45ac-a6f8-c79332f0d67b"
 			}
 		},
 		"metadata": {
@@ -83,6 +83,7 @@
 				"source": [
 					"kv_linked_service=\"ls_kv\"\n",
 					"secret_name=''\n",
+					"\n",
 					"\n",
 					"topic_name=''\n",
 					"subscription_name=''\n",

--- a/workspace/pipeline/pln_nsip_project_clean_slate.json
+++ b/workspace/pipeline/pln_nsip_project_clean_slate.json
@@ -5,14 +5,7 @@
 			{
 				"name": "Delete Contact Info Hrm Table",
 				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "Delete Contact Info Std Table",
-						"dependencyConditions": [
-							"Completed"
-						]
-					}
-				],
+				"dependsOn": [],
 				"policy": {
 					"timeout": "0.12:00:00",
 					"retry": 0,
@@ -32,7 +25,7 @@
 							"type": "string"
 						},
 						"table_name": {
-							"value": "casework_nsip_project_info_internal_dim",
+							"value": "casework_contact_information_dim",
 							"type": "string"
 						}
 					},
@@ -82,42 +75,6 @@
 				}
 			},
 			{
-				"name": "Delete Curated Table",
-				"type": "SynapseNotebook",
-				"dependsOn": [],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"notebook": {
-						"referenceName": "py_delete_table",
-						"type": "NotebookReference"
-					},
-					"parameters": {
-						"db_name": {
-							"value": "odw_curated_db",
-							"type": "string"
-						},
-						"table_name": {
-							"value": "service_user",
-							"type": "string"
-						}
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
-				}
-			},
-			{
 				"name": "Create Contact Info Hrm Table",
 				"type": "SynapseNotebook",
 				"dependsOn": [
@@ -143,7 +100,7 @@
 					},
 					"parameters": {
 						"specific_table": {
-							"value": "casework_nsip_project_info_internal_dim",
+							"value": "casework_contact_information_dim",
 							"type": "string"
 						}
 					},
@@ -193,16 +150,9 @@
 				}
 			},
 			{
-				"name": "Delete NSIP Data Hrm Table",
+				"name": "Delete Project Info Hrm Table",
 				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "Delete NSIP Data Std Table",
-						"dependencyConditions": [
-							"Completed"
-						]
-					}
-				],
+				"dependsOn": [],
 				"policy": {
 					"timeout": "0.12:00:00",
 					"retry": 0,
@@ -236,11 +186,11 @@
 				}
 			},
 			{
-				"name": "Create NSIP Data Hrm Table",
+				"name": "Create Project Info Hrm Table",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
-						"activity": "Delete NSIP Data Hrm Table",
+						"activity": "Delete Project Info Hrm Table",
 						"dependencyConditions": [
 							"Succeeded"
 						]

--- a/workspace/pipeline/pln_nsip_project_clean_slate.json
+++ b/workspace/pipeline/pln_nsip_project_clean_slate.json
@@ -1,0 +1,283 @@
+{
+	"name": "pln_nsip_project_clean_slate",
+	"properties": {
+		"activities": [
+			{
+				"name": "Delete Contact Info Hrm Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Delete Contact Info Std Table",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_delete_table",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_harmonised_db",
+							"type": "string"
+						},
+						"table_name": {
+							"value": "casework_nsip_project_info_internal_dim",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Delete NSIP Data Std Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_delete_table",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_standardised_db",
+							"type": "string"
+						},
+						"table_name": {
+							"value": "horizon_nsip_data",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Delete Curated Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_delete_table",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_curated_db",
+							"type": "string"
+						},
+						"table_name": {
+							"value": "service_user",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Create Contact Info Hrm Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Delete Contact Info Hrm Table",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_odw_harmonised_table_creation",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"specific_table": {
+							"value": "casework_nsip_project_info_internal_dim",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Delete Contact Info Std Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_delete_table",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_standardised_db",
+							"type": "string"
+						},
+						"table_name": {
+							"value": "horizon_contact_information",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Delete NSIP Data Hrm Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Delete NSIP Data Std Table",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_delete_table",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_harmonised_db",
+							"type": "string"
+						},
+						"table_name": {
+							"value": "casework_nsip_project_info_internal_dim",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Create NSIP Data Hrm Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Delete NSIP Data Hrm Table",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_odw_harmonised_table_creation",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"specific_table": {
+							"value": "casework_nsip_project_info_internal_dim",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			}
+		],
+		"folder": {
+			"name": "nsip project/utils"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,24 +3,24 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "pln_service_user_clean_slate",
+				"name": "pln_nsip_project_clean_slate",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_service_user_clean_slate",
+						"referenceName": "pln_nsip_project_clean_slate",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_service_user_main",
+				"name": "pln_nsip_project_main",
 				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
-						"activity": "pln_service_user_clean_slate",
+						"activity": "pln_nsip_project_clean_slate",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -29,7 +29,7 @@
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_service_user_main",
+						"referenceName": "pln_nsip_project_main",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
