### PR TITLE
fix: nsip project schema

### DIFF
--- a/infrastructure/configuration/data-lake/standardised_table_definitions/NSIP/NSIPProject.json
+++ b/infrastructure/configuration/data-lake/standardised_table_definitions/NSIP/NSIPProject.json
@@ -1,1 +1,335 @@
-{"fields": [{"metadata": {}, "name": "ingested_datetime", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_from", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "expected_to", "type": "timestamp", "nullable": false}, {"metadata": {}, "name": "anticipateddateofsubmission", "type": "string", "nullable": true}, {"metadata": {}, "name": "anticipatedsubmissiondatenonspecific", "type": "string", "nullable": true}, {"metadata": {}, "name": "applicantid", "type": "string", "nullable": true}, {"metadata": {}, "name": "caseid", "type": "string", "nullable": true}, {"metadata": {}, "name": "casereference", "type": "string", "nullable": true}, {"metadata": {}, "name": "confirmeddateofdecision", "type": "string", "nullable": true}, {"metadata": {}, "name": "confirmedstartofexamination", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateiapidue", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateofdcoacceptance", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateofdcosubmission", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateofnonacceptance", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateofrecommendations", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateofrelevantrepresentationclose", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateofrepresentationperiodopen", "type": "string", "nullable": true}, {"metadata": {}, "name": "datepinsfirstnotifiedofproject", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateprojectappearsonwebsite", "type": "string", "nullable": true}, {"metadata": {}, "name": "dateprojectwithdrawn", "type": "string", "nullable": true}, {"metadata": {}, "name": "daterrepappearonwebsite", "type": "string", "nullable": true}, {"metadata": {}, "name": "datesection58noticereceived", "type": "string", "nullable": true}, {"metadata": {}, "name": "datetimeexaminationends", "type": "string", "nullable": true}, {"metadata": {}, "name": "deadlineforacceptancedecision", "type": "string", "nullable": true}, {"metadata": {}, "name": "deadlineforcloseofexamination", "type": "string", "nullable": true}, {"metadata": {}, "name": "deadlinefordecision", "type": "string", "nullable": true}, {"metadata": {}, "name": "deadlineforsubmissionofrecommendation", "type": "string", "nullable": true}, {"metadata": {}, "name": "easting", "type": "string", "nullable": true}, {"metadata": {}, "name": "extensiontodaterelevantrepresentationsclose", "type": "string", "nullable": true}, {"metadata": {}, "name": "inspectorids", "type": "string", "nullable": true}, {"metadata": {}, "name": "jrperiodenddate", "type": "string", "nullable": true}, {"metadata": {}, "name": "mapzoomlevel", "type": "string", "nullable": true}, {"metadata": {}, "name": "northing", "type": "string", "nullable": true}, {"metadata": {}, "name": "notificationdateforeventsdeveloper", "type": "string", "nullable": true}, {"metadata": {}, "name": "notificationdateforpmandeventsdirectlyfollowingpm", "type": "string", "nullable": true}, {"metadata": {}, "name": "nsipadministrationofficerids", "type": "string", "nullable": true}, {"metadata": {}, "name": "nsipofficerids", "type": "string", "nullable": true}, {"metadata": {}, "name": "preliminarymeetingstartdate", "type": "string", "nullable": true}, {"metadata": {}, "name": "projectdescription", "type": "string", "nullable": true}, {"metadata": {}, "name": "projectemailaddress", "type": "string", "nullable": true}, {"metadata": {}, "name": "projectlocation", "type": "string", "nullable": true}, {"metadata": {}, "name": "projectname", "type": "string", "nullable": true}, {"metadata": {}, "name": "projecttype", "type": "string", "nullable": true}, {"metadata": {}, "name": "publishstatus", "type": "string", "nullable": true}, {"metadata": {}, "name": "regions", "type": "string", "nullable": true}, {"metadata": {}, "name": "rule6letterpublishdate", "type": "string", "nullable": true}, {"metadata": {}, "name": "rule8letterpublishdate", "type": "string", "nullable": true}, {"metadata": {}, "name": "scopingopinionissued", "type": "string", "nullable": true}, {"metadata": {}, "name": "scopingopinionsought", "type": "string", "nullable": true}, {"metadata": {}, "name": "screeningopinionissued", "type": "string", "nullable": true}, {"metadata": {}, "name": "screeningopinionsought", "type": "string", "nullable": true}, {"metadata": {}, "name": "section46notification", "type": "string", "nullable": true}, {"metadata": {}, "name": "sector", "type": "string", "nullable": true}, {"metadata": {}, "name": "sourcesystem", "type": "string", "nullable": true}, {"metadata": {}, "name": "stage", "type": "string", "nullable": true}, {"metadata": {}, "name": "stage4extensiontoexamclosedate", "type": "string", "nullable": true}, {"metadata": {}, "name": "stage5extensiontodecisiondeadline", "type": "string", "nullable": true}, {"metadata": {}, "name": "stage5extensiontorecommendationdeadline", "type": "string", "nullable": true}, {"metadata": {}, "name": "welshlanguage", "type": "string", "nullable": true}]}
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "ingested_datetime",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_from",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "expected_to",
+      "type": "timestamp",
+      "nullable": false
+    },
+    {
+      "metadata": {},
+      "name": "anticipateddateofsubmission",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "anticipatedsubmissiondatenonspecific",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "applicantid",
+      "type": "string",
+      "nullable": true
+    },
+    { "metadata": {}, "name": "caseid", "type": "string", "nullable": true },
+    {
+      "metadata": {},
+      "name": "casereference",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "confirmeddateofdecision",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "confirmedstartofexamination",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateiapidue",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateofdcoacceptance",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateofdcosubmission",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateofnonacceptance",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateofrecommendations",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateofrelevantrepresentationclose",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateofrepresentationperiodopen",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datepinsfirstnotifiedofproject",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateprojectappearsonwebsite",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "dateprojectwithdrawn",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "daterrepappearonwebsite",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datesection58noticereceived",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "datetimeexaminationends",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "deadlineforacceptancedecision",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "deadlineforcloseofexamination",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "deadlinefordecision",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "deadlineforsubmissionofrecommendation",
+      "type": "string",
+      "nullable": true
+    },
+    { "metadata": {}, "name": "easting", "type": "string", "nullable": true },
+    {
+      "metadata": {},
+      "name": "extensiontodaterelevantrepresentationsclose",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "inspectorids",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "jrperiodenddate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "mapzoomlevel",
+      "type": "string",
+      "nullable": true
+    },
+    { "metadata": {}, "name": "northing", "type": "string", "nullable": true },
+    {
+      "metadata": {},
+      "name": "notificationdateforeventsdeveloper",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "notificationdateforpmandeventsdirectlyfollowingpm",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "nsipadministrationofficerids",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "nsipofficerids",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "preliminarymeetingstartdate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "projectdescription",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "projectemailaddress",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "projectlocation",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "projectname",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "projecttype",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "publishstatus",
+      "type": "string",
+      "nullable": true
+    },
+    { "metadata": {}, "name": "regions", "type": "string", "nullable": true },
+    {
+      "metadata": {},
+      "name": "rule6letterpublishdate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "rule8letterpublishdate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "scopingopinionissued",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "scopingopinionsought",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "screeningopinionissued",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "screeningopinionsought",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "section46notification",
+      "type": "string",
+      "nullable": true
+    },
+    { "metadata": {}, "name": "sector", "type": "string", "nullable": true },
+    {
+      "metadata": {},
+      "name": "sourcesystem",
+      "type": "string",
+      "nullable": true
+    },
+    { "metadata": {}, "name": "stage", "type": "string", "nullable": true },
+    {
+      "metadata": {},
+      "name": "stage4extensiontoexamclosedate",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "stage5extensiontodecisiondeadline",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "stage5extensiontorecommendationdeadline",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
+      "name": "welshlanguage",
+      "type": "string",
+      "nullable": true
+    },
+    { "metadata": {}, "name": "decision", "type": "string", "nullable": true },
+    {
+      "metadata": {},
+      "name": "casecreateddate",
+      "type": "string",
+      "nullable": true
+    }
+  ]
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
