### PR TITLE
Add Function App

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -346,5 +346,6 @@ The below tables outline the steps in each stage of the `Terraform CD` pipeline:
 | <a name="output_synapse_dev_endpoint"></a> [synapse\_dev\_endpoint](#output\_synapse\_dev\_endpoint) | The development connectivity endpoint for the Synapse Workspace |
 | <a name="output_synapse_dsql_endpoint"></a> [synapse\_dsql\_endpoint](#output\_synapse\_dsql\_endpoint) | The dedicated SQL pool connectivity endpoint for the Synapse Workspace |
 | <a name="output_synapse_ssql_endpoint"></a> [synapse\_ssql\_endpoint](#output\_synapse\_ssql\_endpoint) | The serverless SQL pool connectivity endpoint for the Synapse Workspace |
+| <a name="output_synapse_workspace_id"></a> [synapse\_workspace\_id](#output\_synapse\_workspace\_id) | The ARM ID of the Synapse Workspace |
 | <a name="output_synapse_workspace_name"></a> [synapse\_workspace\_name](#output\_synapse\_workspace\_name) | The name of the Synapse Workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -45,7 +45,7 @@ devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-dev-ukw"
 
 environment = "dev"
 
-function_app_enabled = true
+function_app_enabled = false
 function_app_name    = "fnapp01"
 function_app_site_config = {
   application_stack = {

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -45,7 +45,7 @@ devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-dev-ukw"
 
 environment = "dev"
 
-function_app_enabled = false
+function_app_enabled = true
 function_app_name    = "fnapp01"
 function_app_site_config = {
   application_stack = {

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -12,6 +12,15 @@ locals {
     }
   )
 
+  app_settings = merge(
+    var.app_settings,
+    {
+      "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING" = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key};EndpointSuffix=core.windows.net"
+      "WEBSITE_CONTENTSHARE"                     = var.file_share_name
+      "WEBSITE_CONTENTOVERVNET"                  = 1
+    }
+  )
+
   site_config = merge(
     var.site_config_defaults,
     var.site_config

--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_linux_function_app" "function" {
   public_network_access_enabled = false
   functions_extension_version   = var.functions_extension_version
   virtual_network_subnet_id     = var.synapse_vnet_subnet_names[var.synapse_function_app_subnet_name]
-  app_settings                  = var.app_settings
+  app_settings                  = local.app_settings
   auth_settings {
     enabled = var.auth_settings["enabled"]
   }

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -9,7 +9,7 @@ variable "environment" {
 variable "location" {
   type        = string
   description = "The region resources will be deployed to"
-  default     = "northeurope"
+  default     = "uksouth"
 }
 
 variable "tags" {

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -24,6 +24,11 @@ variable "resource_group_name" {
   default     = ""
 }
 
+variable "file_share_name" {
+  type        = string
+  description = "The name of the file share to create"
+}
+
 variable "function_app_name" {
   type        = string
   description = "Name of the function app"
@@ -143,7 +148,7 @@ variable "site_config_defaults" {
     scm_use_main_ip_restriction = true
     use_32_bit_worker           = false
     websockets_enabled          = true
-    vnet_route_all_enabled      = false
+    vnet_route_all_enabled      = true
     application_stack = {
       dotnet_version          = ""
       use_dotnet_isolated     = false

--- a/infrastructure/modules/storage-account/locals.tf
+++ b/infrastructure/modules/storage-account/locals.tf
@@ -9,8 +9,6 @@ locals {
     }
   )
 
-  cicd_subnet_ids = []
-
   soft_delete_retention_policy = var.soft_delete_retention_policy == true || substr(var.environment, 0, 2) == "production" ? true : var.soft_delete_retention_policy
 
 }

--- a/infrastructure/modules/storage-account/main.tf
+++ b/infrastructure/modules/storage-account/main.tf
@@ -56,10 +56,12 @@ resource "azurerm_storage_account" "storage" {
 }
 
 resource "azurerm_storage_account_network_rules" "storage_network_rule" {
+  #checkov:skip=CKV_AZURE_59: Firewall is enabled using azurerm_storage_account_network_rules
+  count                      = var.network_rules_enabled ? 1 : 0
   storage_account_id         = azurerm_storage_account.storage.id
   default_action             = var.network_default_action
   ip_rules                   = var.network_rule_ips
-  virtual_network_subnet_ids = var.network_rule_virtual_network_subnet_ids_include_cicd_agents ? concat(local.cicd_subnet_ids, var.network_rule_virtual_network_subnet_ids) : var.network_rule_virtual_network_subnet_ids
+  virtual_network_subnet_ids = var.network_rule_virtual_network_subnet_ids
   bypass                     = var.network_rule_bypass
 }
 

--- a/infrastructure/modules/storage-account/output.tf
+++ b/infrastructure/modules/storage-account/output.tf
@@ -54,3 +54,10 @@ output "share_id" {
     for share in azurerm_storage_share.share : share.id
   ])
 }
+
+output "share_name" {
+  description = "List of file share names"
+  value = tolist([
+    for share in azurerm_storage_share.share : share.name
+  ])
+}

--- a/infrastructure/modules/storage-account/variables.tf
+++ b/infrastructure/modules/storage-account/variables.tf
@@ -6,7 +6,7 @@ variable "environment" {
 variable "location" {
   type        = string
   description = "The region resources will be deployed to"
-  default     = "ukwest"
+  default     = "uksouth"
 }
 
 variable "tags" {
@@ -100,7 +100,7 @@ variable "network_rule_virtual_network_subnet_ids" {
 variable "network_rule_bypass" {
   type        = list(string)
   description = "Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of Logging, Metrics, AzureServices, or None"
-  default     = ["AzureServices"]
+  default     = ["AzureServices", "Logging", "Metrics"]
 }
 
 variable "container_name" {

--- a/infrastructure/modules/storage-account/variables.tf
+++ b/infrastructure/modules/storage-account/variables.tf
@@ -79,6 +79,12 @@ variable "network_default_action" {
   default     = "Deny"
 }
 
+variable "network_rules_enabled" {
+  type        = bool
+  description = "Is network rules enabled for this storage account?"
+  default     = true
+}
+
 variable "network_rule_ips" {
   type        = list(string)
   description = "List of public IPs that are allowed to access the storage account. Private IPs in RFC1918 are not allowed here"
@@ -89,12 +95,6 @@ variable "network_rule_virtual_network_subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs which are allowed to access the storage account"
   default     = []
-}
-
-variable "network_rule_virtual_network_subnet_ids_include_cicd_agents" {
-  type        = bool
-  description = "A boolean switch to allow for scenarios where the default set of cicd subnets (containing for example ADO agents) should not be added to the storage accounts network rules. An example would be a storage accounts used as a cloud witness for a windows failover cluster that exists outside of the paired regions of the cluster nodes"
-  default     = true
 }
 
 variable "network_rule_bypass" {

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -50,7 +50,7 @@ module "storage_account" {
   environment                             = var.environment
   location                                = module.azure_region.location_cli
   tags                                    = local.tags
-  network_rules_enabled                   = false
+  network_rules_enabled                   = true
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
 }
 
@@ -64,7 +64,7 @@ module "storage_account_failover" {
   environment                             = var.environment
   location                                = module.azure_region.paired_location.location_cli
   tags                                    = local.tags
-  network_rules_enabled                   = false
+  network_rules_enabled                   = true
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network_failover.vnet_subnets[local.functionapp_subnet_name], module.synapse_network_failover.vnet_subnets[local.compute_subnet_name]])
 }
 

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -52,6 +52,12 @@ module "storage_account" {
   tags                                    = local.tags
   network_rules_enabled                   = true
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
+  shares = [
+    {
+      name  = "pins-${var.function_app_name}-${local.resource_suffix}"
+      quota = 5120
+    }
+  ]
 }
 
 module "storage_account_failover" {
@@ -66,6 +72,12 @@ module "storage_account_failover" {
   tags                                    = local.tags
   network_rules_enabled                   = true
   network_rule_virtual_network_subnet_ids = concat([module.synapse_network_failover.vnet_subnets[local.functionapp_subnet_name], module.synapse_network_failover.vnet_subnets[local.compute_subnet_name]])
+  shares = [
+    {
+      name  = "pins-${var.function_app_name}-${local.resource_suffix_failover}"
+      quota = 5120
+    }
+  ]
 }
 
 module "function_app" {
@@ -85,6 +97,7 @@ module "function_app" {
   synapse_vnet_subnet_names  = module.synapse_network.vnet_subnets
   app_settings               = var.function_app_settings
   site_config                = var.function_app_site_config
+  file_share_name            = module.storage_account[0].share_name[var.function_app_name]
 }
 
 module "function_app_failover" {
@@ -104,4 +117,5 @@ module "function_app_failover" {
   synapse_vnet_subnet_names  = module.synapse_network_failover.vnet_subnets
   app_settings               = var.function_app_settings
   site_config                = var.function_app_site_config
+  file_share_name            = module.storage_account_failover[0].share_name[var.function_app_name]
 }

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -97,7 +97,7 @@ module "function_app" {
   synapse_vnet_subnet_names  = module.synapse_network.vnet_subnets
   app_settings               = var.function_app_settings
   site_config                = var.function_app_site_config
-  file_share_name            = module.storage_account[0].share_name[var.function_app_name]
+  file_share_name            = "pins-${var.function_app_name}-${local.resource_suffix}"
 }
 
 module "function_app_failover" {
@@ -117,5 +117,5 @@ module "function_app_failover" {
   synapse_vnet_subnet_names  = module.synapse_network_failover.vnet_subnets
   app_settings               = var.function_app_settings
   site_config                = var.function_app_site_config
-  file_share_name            = module.storage_account_failover[0].share_name[var.function_app_name]
+  file_share_name            = "pins-${var.function_app_name}-${local.resource_suffix_failover}"
 }

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -50,7 +50,8 @@ module "storage_account" {
   environment                             = var.environment
   location                                = module.azure_region.location_cli
   tags                                    = local.tags
-  network_rule_virtual_network_subnet_ids = [module.synapse_network.vnet_subnets[local.functionapp_subnet_name]]
+  network_rules_enabled                   = false
+  network_rule_virtual_network_subnet_ids = concat([module.synapse_network.vnet_subnets[local.functionapp_subnet_name], module.synapse_network.vnet_subnets[local.compute_subnet_name]])
 }
 
 module "storage_account_failover" {
@@ -63,7 +64,8 @@ module "storage_account_failover" {
   environment                             = var.environment
   location                                = module.azure_region.paired_location.location_cli
   tags                                    = local.tags
-  network_rule_virtual_network_subnet_ids = [module.synapse_network_failover.vnet_subnets[local.functionapp_subnet_name]]
+  network_rules_enabled                   = false
+  network_rule_virtual_network_subnet_ids = concat([module.synapse_network_failover.vnet_subnets[local.functionapp_subnet_name], module.synapse_network_failover.vnet_subnets[local.compute_subnet_name]])
 }
 
 module "function_app" {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [x] No

 2. Have any new tables been created in Standardised?

  	- [x] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [x] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [x] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [x] No - No scripts have run 
	
 
