### PR TITLE
Updated function app with vnet routing

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -79,7 +79,7 @@ odt_backoffice_sb_topic_subscriptions = [
     topic_name        = "service-user"
     role_assignments = {
       "Azure Service Bus Data Receiver" = {
-        service_principals = ["pins-synw-odw-dev-uks"]
+        service_principals = ["pins-synw-odw-dev-uks", "pins-fnapp01-odw-dev-uks"]
       }
     }
   },
@@ -88,7 +88,7 @@ odt_backoffice_sb_topic_subscriptions = [
     topic_name        = "nsip-project"
     role_assignments = {
       "Azure Service Bus Data Receiver" = {
-        service_principals = ["pins-synw-odw-dev-uks"]
+        service_principals = ["pins-synw-odw-dev-uks", "pins-fnapp01-odw-dev-uks"]
       }
     }
   },

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -15,9 +15,10 @@ locals {
   app_settings = merge(
     var.app_settings,
     {
-      "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING" = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key};EndpointSuffix=core.windows.net"
-      "WEBSITE_CONTENTSHARE"                     = var.file_share_name
-      "WEBSITE_CONTENTOVERVNET"                  = 1
+      ServiceBusConnection__fullyQualifiedNamespace = "${var.servicebus_namespace}.servicebus.windows.net"
+      "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"    = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key};EndpointSuffix=core.windows.net"
+      "WEBSITE_CONTENTSHARE"                        = var.file_share_name
+      "WEBSITE_CONTENTOVERVNET"                     = 1
     }
   )
 

--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_linux_function_app" "function" {
   storage_account_access_key    = var.storage_account_access_key
   https_only                    = true
   tags                          = local.tags
-  public_network_access_enabled = false
+  public_network_access_enabled = true
   functions_extension_version   = var.functions_extension_version
   virtual_network_subnet_id     = var.synapse_vnet_subnet_names[var.synapse_function_app_subnet_name]
   app_settings                  = local.app_settings

--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -11,9 +11,6 @@ resource "azurerm_linux_function_app" "function" {
   functions_extension_version   = var.functions_extension_version
   virtual_network_subnet_id     = var.synapse_vnet_subnet_names[var.synapse_function_app_subnet_name]
   app_settings                  = local.app_settings
-  auth_settings {
-    enabled = var.auth_settings["enabled"]
-  }
   site_config {
     always_on = local.site_config["always_on"]
     cors {

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -72,14 +72,6 @@ variable "functions_extension_version" {
   default     = "~4"
 }
 
-variable "auth_settings" {
-  type        = map(string)
-  description = "Function app auth settings"
-  default = {
-    enabled = true
-  }
-}
-
 variable "app_settings" {
   type        = map(string)
   description = "Function app settings"

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -148,7 +148,7 @@ variable "site_config_defaults" {
     scm_use_main_ip_restriction = true
     use_32_bit_worker           = false
     websockets_enabled          = true
-    vnet_route_all_enabled      = true
+    vnet_route_all_enabled      = false
     application_stack = {
       dotnet_version          = ""
       use_dotnet_isolated     = false

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -86,6 +86,12 @@ variable "app_settings" {
   default     = {}
 }
 
+variable "servicebus_namespace" {
+  type        = string
+  description = "The name of the service bus namespace to use for the function app"
+  default     = null
+}
+
 variable "site_config_defaults" {
   type = object({
     always_on = bool
@@ -147,7 +153,7 @@ variable "site_config_defaults" {
     pre_warmed_instance_count   = null
     scm_use_main_ip_restriction = true
     use_32_bit_worker           = false
-    websockets_enabled          = true
+    websockets_enabled          = false
     vnet_route_all_enabled      = false
     application_stack = {
       dotnet_version          = ""

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -98,6 +98,7 @@ module "function_app" {
   app_settings               = var.function_app_settings
   site_config                = var.function_app_site_config
   file_share_name            = "pins-${var.function_app_name}-${local.resource_suffix}"
+  servicebus_namespace       = var.odt_back_office_service_bus_name
 }
 
 module "function_app_failover" {
@@ -118,4 +119,5 @@ module "function_app_failover" {
   app_settings               = var.function_app_settings
   site_config                = var.function_app_site_config
   file_share_name            = "pins-${var.function_app_name}-${local.resource_suffix_failover}"
+  servicebus_namespace       = var.odt_back_office_service_bus_name_failover
 }


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [x] No

 2. Have any new tables been created in Standardised?

  	- [x] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [x] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [x] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [x] No - No scripts have run 
	
 
