### PR TITLE
enable prod function app and service bus

### DIFF
--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -68,7 +68,7 @@ key_vault_role_assignments = {
 
 network_watcher_enabled = false
 
-odt_back_office_service_bus_enabled                      = false
+odt_back_office_service_bus_enabled                      = true
 odt_back_office_service_bus_failover_enabled             = false
 odt_back_office_service_bus_name                         = "pins-sb-back-office-prod-ukw-001"
 odt_back_office_service_bus_name_failover                = "pins-sb-back-office-prod-uks-001"
@@ -80,7 +80,7 @@ odt_backoffice_sb_topic_subscriptions = [
     topic_name        = "service-user"
     role_assignments = {
       "Azure Service Bus Data Receiver" = {
-        service_principals = ["pins-synw-odw-prod-uks"]
+        service_principals = ["pins-synw-odw-prod-uks", "pins-fnapp01-odw-prod-uks"]
       }
     }
   },
@@ -89,7 +89,7 @@ odt_backoffice_sb_topic_subscriptions = [
     topic_name        = "nsip-project"
     role_assignments = {
       "Azure Service Bus Data Receiver" = {
-        service_principals = ["pins-synw-odw-prod-uks"]
+        service_principals = ["pins-synw-odw-prod-uks", "pins-fnapp01-odw-prod-uks"]
       }
     }
   },

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -80,7 +80,7 @@ odt_backoffice_sb_topic_subscriptions = [
     topic_name        = "service-user"
     role_assignments = {
       "Azure Service Bus Data Receiver" = {
-        service_principals = ["pins-synw-odw-test-uks"]
+        service_principals = ["pins-synw-odw-test-uks", "pins-fnapp01-odw-test-uks"]
       }
     }
   },
@@ -89,7 +89,7 @@ odt_backoffice_sb_topic_subscriptions = [
     topic_name        = "nsip-project"
     role_assignments = {
       "Azure Service Bus Data Receiver" = {
-        service_principals = ["pins-synw-odw-test-uks"]
+        service_principals = ["pins-synw-odw-test-uks", "pins-fnapp01-odw-test-uks"]
       }
     }
   },


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [x] No

 2. Have any new tables been created in Standardised?

  	- [x] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [x] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [x] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [x] No - No scripts have run 
	
 
