### PR TITLE
POC Service Bus Trigger

### DIFF
--- a/infrastructure/modules/odt-backoffice-sb/outputs.tf
+++ b/infrastructure/modules/odt-backoffice-sb/outputs.tf
@@ -17,3 +17,11 @@ output "resource_group_name" {
   description = "value of the resource group name."
   value       = azurerm_private_endpoint.odt_backoffice_servicebus_private_endpoint[*].resource_group_name
 }
+
+output "subscription_ids" {
+  value = { 
+    for key, subscription in azurerm_servicebus_subscription.odt_backoffice_subscriptions : 
+      subscription.name => subscription.id 
+  }
+  description = "A map map of Subscription Name to Subscription Keys (used for consumer RBAC assignments)"
+}

--- a/infrastructure/modules/odt-backoffice-sb/outputs.tf
+++ b/infrastructure/modules/odt-backoffice-sb/outputs.tf
@@ -19,9 +19,9 @@ output "resource_group_name" {
 }
 
 output "subscription_ids" {
-  value = { 
-    for key, subscription in azurerm_servicebus_subscription.odt_backoffice_subscriptions : 
-      subscription.name => subscription.id 
+  value = {
+    for key, subscription in azurerm_servicebus_subscription.odt_backoffice_subscriptions :
+    subscription.name => subscription.id
   }
   description = "A map map of Subscription Name to Subscription Keys (used for consumer RBAC assignments)"
 }

--- a/infrastructure/workload-odt-ingestion.tf
+++ b/infrastructure/workload-odt-ingestion.tf
@@ -4,7 +4,7 @@ locals {
     }
 }
 
-module "function_app" {
+module "odt_ingestion_function_app" {
   count = var.odt_back_office_service_bus_enabled ? 1 : 0
 
   source = "./modules/function-app"
@@ -26,9 +26,7 @@ module "function_app" {
 }
 
 resource "azurerm_role_assignment" "servicebus_data_receiver" {
-  count = var.odt_back_office_service_bus_enabled ? 1 : 0
-
-  for_each = one(module.odt_backoffice_sb).servicebus_subscription_ids
+  for_each = var.odt_back_office_service_bus_enabled ? one(module.odt_backoffice_sb).servicebus_subscription_ids : []
 
   scope                = each.value
   role_definition_name = "Azure Service Bus Data Receiver"

--- a/infrastructure/workload-odt-ingestion.tf
+++ b/infrastructure/workload-odt-ingestion.tf
@@ -19,7 +19,6 @@ module "odt_ingestion_function_app" {
   location                   = module.azure_region.location_cli
   tags                       = local.tags
   synapse_vnet_subnet_names  = module.synapse_network.vnet_subnets # TODO: This is likely not needed
-  app_settings               = local.odt_ingestion_fn_app.settings
   site_config                = var.function_app_site_config
   file_share_name            = "pins-${local.odt_ingestion_fn_app.name}-${local.resource_suffix}"
   servicebus_namespace       = var.odt_back_office_service_bus_name

--- a/infrastructure/workload-odt-ingestion.tf
+++ b/infrastructure/workload-odt-ingestion.tf
@@ -1,0 +1,38 @@
+locals {
+    odt_ingestion_fn_app = {
+        name = "odt-ingestion-fa"
+    }
+}
+
+module "function_app" {
+  count = var.odt_back_office_service_bus_enabled ? 1 : 0
+
+  source = "./modules/function-app"
+
+  resource_group_name        = azurerm_resource_group.function_app[0].name
+  function_app_name          = local.odt_ingestion_fn_app.name
+  service_name               = local.service_name
+  service_plan_id            = module.service_plan[0].id
+  storage_account_name       = module.storage_account[0].storage_name
+  storage_account_access_key = module.storage_account[0].primary_access_key
+  environment                = var.environment
+  location                   = module.azure_region.location_cli
+  tags                       = local.tags
+  synapse_vnet_subnet_names  = module.synapse_network.vnet_subnets # TODO: This is likely not needed
+  app_settings               = local.odt_ingestion_fn_app.settings
+  site_config                = var.function_app_site_config
+  file_share_name            = "pins-${local.odt_ingestion_fn_app.name}-${local.resource_suffix}"
+  servicebus_namespace       = var.odt_back_office_service_bus_name
+}
+
+resource "azurerm_role_assignment" "servicebus_data_receiver" {
+  count = var.odt_back_office_service_bus_enabled ? 1 : 0
+
+  for_each = one(module.odt_backoffice_sb).servicebus_subscription_ids
+
+  scope                = each.value
+  role_definition_name = "Azure Service Bus Data Receiver"
+  # TODO: Why is the output a list?
+  principal_id         = one(module.function_app).identity[0].principal_id
+}
+

--- a/infrastructure/workload-odt-ingestion.tf
+++ b/infrastructure/workload-odt-ingestion.tf
@@ -1,7 +1,7 @@
 locals {
-    odt_ingestion_fn_app = {
-        name = "odt-ingestion-fa"
-    }
+  odt_ingestion_fn_app = {
+    name = "odt-ingestion-fa"
+  }
 }
 
 module "odt_ingestion_function_app" {
@@ -31,6 +31,6 @@ resource "azurerm_role_assignment" "servicebus_data_receiver" {
   scope                = each.value
   role_definition_name = "Azure Service Bus Data Receiver"
   # TODO: Why is the output a list?
-  principal_id         = one(module.function_app).identity[0].principal_id
+  principal_id = one(module.function_app).identity[0].principal_id
 }
 


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
