### PR TITLE
Fix/preprod errors service users and nsip

### DIFF
--- a/infrastructure/configuration/data-lake/orchestration/orchestration.json
+++ b/infrastructure/configuration/data-lake/orchestration/orchestration.json
@@ -1490,10 +1490,10 @@
     {
       "Source_ID": 107,
       "Source_Folder": "ServiceBus",
-      "Source_Frequency_Folder": "ServiceUser",
+      "Source_Frequency_Folder": "service-user",
       "Source_Folder_Date_Format": "YYYY-MM-DD",
-      "Source_Filename_Format": "ServiceUser.csv",
-      "Source_Filename_Start": "ServiceUser",
+      "Source_Filename_Format": "service-user.csv",
+      "Source_Filename_Start": "service-user",
       "Source_Filename_Date_Format": "None",
       "Completion_Frequency_CRON": "Adhoc",
       "Expected_Within_Weekdays": 1,

--- a/infrastructure/configuration/data-lake/standardised_table_definitions/NSIP/NSIPProject.json
+++ b/infrastructure/configuration/data-lake/standardised_table_definitions/NSIP/NSIPProject.json
@@ -39,6 +39,12 @@
     { "metadata": {}, "name": "caseid", "type": "string", "nullable": true },
     {
       "metadata": {},
+      "name": "casenodeid",
+      "type": "string",
+      "nullable": true
+    },
+    {
+      "metadata": {},
       "name": "casereference",
       "type": "string",
       "nullable": true

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "18dc16dd-7622-48d9-b03d-aef722688f6a"
+				"spark.autotune.trackingId": "ef60f735-e7c1-4170-ae03-e4384fdc8c43"
 			}
 		},
 		"metadata": {
@@ -402,7 +402,6 @@
 					"    sparkDF = sparkDF.withColumn(\"expected_from\",lit(expected_from))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_to\",lit(expected_to))\n",
 					"\n",
-					"                    \n",
 					"    schema = StructType.fromJson(json.loads(standardised_table_def_json))\n",
 					"    \n",
 					"    ### remove characters that Delta can't allow in headers and add numbers to repeated column headers\n",
@@ -417,6 +416,11 @@
 					"    for colix in range(len(cols_orig)):\n",
 					"        sparkDF = sparkDF.toDF(*newlist) \n",
 					"\n",
+					"    ### Cast any column in sparkDF with type mismatch into String\n",
+					"    for field in sparkDF.schema:\n",
+					"        table_field = next((f for f in schema if f.name == field.name), None)\n",
+					"        if table_field is not None and field.dataType != table_field.dataType:\n",
+					"            sparkDF = sparkDF.withColumn(field.name, col(field.name).cast(StringType()))\n",
 					"\n",
 					"    ### writing the dataframe to the existing standardised table\n",
 					"    sparkDF.write.option(\"mergeSchema\", \"true\").format(\"delta\").mode(\"append\").saveAsTable(f\"odw_standardised_db.{standardised_table_name}\")\n",

--- a/workspace/pipeline/pln_nsip_project_main.json
+++ b/workspace/pipeline/pln_nsip_project_main.json
@@ -1060,15 +1060,9 @@
 				}
 			},
 			{
-				"name": "Hrmonised to Curated",
+				"name": "Hzn - Hrm to Cur",
 				"type": "SynapseNotebook",
 				"dependsOn": [
-					{
-						"activity": "SB - Std to Hrm",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
 					{
 						"activity": "Hzn - Std to Hrm",
 						"dependencyConditions": [
@@ -1089,7 +1083,46 @@
 						"referenceName": "nsip_data",
 						"type": "NotebookReference"
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "SB - Hrm to Cur",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "SB - Std to Hrm",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "nsip_data",
+						"type": "NotebookReference"
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			}
 		],

--- a/workspace/pipeline/pln_service_user_main.json
+++ b/workspace/pipeline/pln_service_user_main.json
@@ -3,15 +3,9 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "Harmonised to Curated",
+				"name": "SB - Hrm to Cur",
 				"type": "SynapseNotebook",
 				"dependsOn": [
-					{
-						"activity": "Hzn - Std to Hrm",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
 					{
 						"activity": "SB - Std to Hrm",
 						"dependencyConditions": [
@@ -276,6 +270,39 @@
 							},
 							"type": "string"
 						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Hzn - Hrm to Cur",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Hzn - Std to Hrm",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "service_user",
+						"type": "NotebookReference"
 					},
 					"snapshot": true,
 					"conf": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
