### PR TITLE
Updating notebook: nsip_data

### DIFF
--- a/workspace/notebook/nsip_data.json
+++ b/workspace/notebook/nsip_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5d0ccea8-f5ef-4c31-a522-10de0c32f492"
+				"spark.autotune.trackingId": "7b5e5af7-3716-4a58-acff-1b4492856f83"
 			}
 		},
 		"metadata": {
@@ -88,7 +88,7 @@
 					"\n",
 					"# spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 1
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -131,7 +131,10 @@
 					"\n",
 					"\tT1.ProjectName \t\t\t\t\t\t\t\t\t\t\tAS projectName,\n",
 					"\tLOWER(T1.Decision)  \t\t\t\t\t\t\t\t\tAS decision,\n",
-					"\tLOWER(T1.ProjectStatus)  \t\t\t\t\t\t\t\tAS publishStatus,\n",
+					"\tCASE WHEN LOWER(T1.ProjectStatus) = 'published' \n",
+					"\t\t THEN 'published'\n",
+					"\t\t ELSE 'unpublished'\n",
+					"\tEND\t\t\t\t\t\t\t\t\t\t\t\t\t\tAS publishStatus,\n",
 					"\tT1.ExamTimetablePublishStatus \t\t\t\t\t\t\tAS examTimetablePublishStatus,\n",
 					"\tT1.Sector \t\t\t\t\t\t\t\t\t\t\t\tAS sector,\n",
 					"\tT1.ProjectType \t\t\t\t\t\t\t\t\t\t\tAS projectType,\n",
@@ -148,7 +151,10 @@
 					"\tCAST(T1.Easting AS INT)\t\t\t\t\t\t\t\t\tAS easting,\n",
 					"\tCAST(T1.Northing AS INT)\t\t\t\t\t\t\t\tAS northing,\n",
 					"\tT1.Transboundary \t\t\t\t\t\t\t\t\t\tAS transboundary,\n",
-					"\tT1.WelshLanguage \t\t\t\t\t\t\t\t\t\tAS welshLanguage,\n",
+					"\tCASE WHEN T1.WelshLanguage = 'YES' \n",
+					"\t\t THEN TRUE\n",
+					"\t\t ELSE FALSE\n",
+					"\tEND\t\t\t\t\t\t\t\t\t\t\t\t\t\tAS welshLanguage,\n",
 					"\tLOWER(T1.MapZoomLevel) \t\t\t\t\t\t\t\t\tAS mapZoomLevel,\n",
 					"\tT1.ProjectDescription \t\t\t\t\t\t\t\t\tAS projectDescription,\n",
 					"\tT1.SoS \t\t\t\t\t\t\t\t\t\t\t\t\tAS secretaryOfState,\n",
@@ -221,7 +227,7 @@
 					"\n",
 					"-- LIMIT ${MAX_LIMIT}"
 				],
-				"execution_count": 2
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -333,7 +339,7 @@
 					"\n",
 					"WHERE caseId IS NOT NULL;"
 				],
-				"execution_count": 3
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -365,7 +371,7 @@
 					"# %%pyspark\n",
 					"# pip install Faker"
 				],
-				"execution_count": 4
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -418,7 +424,7 @@
 					"#         table_loc = \"abfss://odw-curated@\"+storage_account+'nsip_data'\n",
 					"#         df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 5
+				"execution_count": 7
 			}
 		]
 	}

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5941a3c8-2d2e-4cac-8701-e7b413ca4ae3"
+				"spark.autotune.trackingId": "1ec7bc2f-9080-4411-8300-7e116e4282f6"
 			}
 		},
 		"metadata": {
@@ -120,7 +120,7 @@
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"\r\n",
-					"    SU.ContactID                            AS id,\r\n",
+					"    REPLACE(SU.ContactID, 'P_', '')         AS id,\r\n",
 					"    SU.Salutation                           AS salutation,\r\n",
 					"    SU.FirstName                            AS firstName,\r\n",
 					"    SU.LastName                             AS lastName,\r\n",
@@ -146,12 +146,12 @@
 					"    SU.SUAreaID                             AS sourceSuid\r\n",
 					"    \r\n",
 					"FROM odw_harmonised_db.service_user_dim     AS SU\r\n",
+					"\r\n",
 					"WHERE SU.IsActive = 'Y'\r\n",
+					"\r\n",
 					"ORDER BY ingestionDate DESC\r\n",
 					"\r\n",
-					"\r\n",
-					"LIMIT ${MAX_LIMIT}\r\n",
-					""
+					"LIMIT ${MAX_LIMIT}"
 				],
 				"execution_count": 15
 			},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
