### PR TITLE
Mvg/fix/horizon nsip

### DIFF
--- a/workspace/notebook/nsip_data.json
+++ b/workspace/notebook/nsip_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "46d69a96-f829-4b32-8d43-0474fd87517c"
+				"spark.autotune.trackingId": "7e7b711d-43cb-47c1-977d-3afc72459f93"
 			}
 		},
 		"metadata": {
@@ -88,7 +88,7 @@
 					"\n",
 					"# spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 3
+				"execution_count": 1
 			},
 			{
 				"cell_type": "markdown",
@@ -232,7 +232,7 @@
 					"\n",
 					"-- LIMIT ${MAX_LIMIT}"
 				],
-				"execution_count": 4
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -344,7 +344,7 @@
 					"\n",
 					"WHERE caseId IS NOT NULL;"
 				],
-				"execution_count": 5
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -376,7 +376,7 @@
 					"# %%pyspark\n",
 					"# pip install Faker"
 				],
-				"execution_count": 6
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -429,7 +429,7 @@
 					"#         table_loc = \"abfss://odw-curated@\"+storage_account+'nsip_data'\n",
 					"#         df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 7
+				"execution_count": 5
 			}
 		]
 	}

--- a/workspace/notebook/nsip_data.json
+++ b/workspace/notebook/nsip_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7b5e5af7-3716-4a58-acff-1b4492856f83"
+				"spark.autotune.trackingId": "46d69a96-f829-4b32-8d43-0474fd87517c"
 			}
 		},
 		"metadata": {
@@ -147,7 +147,12 @@
 					"\tT1.CaseNodeID\t\t\t\t\t\t\t\t\t\t\tAS caseNodeId,\n",
 					"\tT1.ProjectLocation \t\t\t\t\t\t\t\t\t\tAS projectLocation,\n",
 					"\tT1.ProjectEmailAddress \t\t\t\t\t\t\t\t\tAS projectEmailAddress,\n",
-					"\tLOWER(REPLACE(T1.Region,' ', '_'))\t\t\t\t\t\tAS region,\n",
+					"\tLOWER(\n",
+					"\t\tREPLACE(\n",
+					"\t\t\tREPLACE(\n",
+					"\t\t\t\tREPLACE(T1.Region,' ', '_'),\n",
+					"\t\t\t'[', ''),\n",
+					"\t\t']', '')) \t\t\t\t\t\t\t\t\t\t\tAS region,\n",
 					"\tCAST(T1.Easting AS INT)\t\t\t\t\t\t\t\t\tAS easting,\n",
 					"\tCAST(T1.Northing AS INT)\t\t\t\t\t\t\t\tAS northing,\n",
 					"\tT1.Transboundary \t\t\t\t\t\t\t\t\t\tAS transboundary,\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
