### PR TITLE
Updating notebook: examination_timetable

### DIFF
--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "28dc7342-0d18-4f9d-b770-b0b01969fe8c"
+				"spark.autotune.trackingId": "71a1c05e-9b08-4c15-88aa-5536359448e0"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"from notebookutils import mssparkutils\n",
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 8
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -104,7 +104,7 @@
 					"    ET.CaseReference                                            AS caseReference,\r\n",
 					"    ET.ODTEventID                                               AS eventID,\r\n",
 					"    ET.TypeOfExamination                                        AS eventType,\r\n",
-					"    ET.Name                                                     AS eventName,\r\n",
+					"    ET.Name                                                     AS eventTitle,\r\n",
 					"    ET.DeadlineStartDateTime                                    AS eventDeadlineStartDate,\r\n",
 					"    ET.Date                                                     AS eventDate,\r\n",
 					"    ET.EventLineItems                                           AS eventLineItems,\r\n",
@@ -115,7 +115,7 @@
 					"-- ORDER BY IngestionDate DESC\r\n",
 					""
 				],
-				"execution_count": 9
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -156,14 +156,14 @@
 					"    caseReference,\r\n",
 					"    eventID,\r\n",
 					"    eventType,\r\n",
-					"    eventName,\r\n",
+					"    eventTitle,\r\n",
 					"    eventDeadlineStartDate,\r\n",
 					"    eventDate,\r\n",
 					"    eventLineItems,\r\n",
 					"    eventLineItemDescription   \r\n",
 					"FROM odw_curated_db.vw_examination_timetable"
 				],
-				"execution_count": 10
+				"execution_count": 6
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
