### PR TITLE
Fix/service user limit in test

### DIFF
--- a/workspace/notebook/nsip_data.json
+++ b/workspace/notebook/nsip_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7e7b711d-43cb-47c1-977d-3afc72459f93"
+				"spark.autotune.trackingId": "27d26fe4-008a-4e62-aae9-62d818d35ff8"
 			}
 		},
 		"metadata": {
@@ -84,7 +84,9 @@
 					"# storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"\n",
 					"# is_dev_or_test_env = 'dev' in storage_account or 'test' in storage_account\n",
-					"# max_limit = 20 if is_dev_or_test_env else 100000000\n",
+					"\n",
+					"# # limiting the number of output to 20 rows for dev environment\n",
+					"# max_limit = 20 if 'dev' in storage_account else 100000000\n",
 					"\n",
 					"# spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1ec7bc2f-9080-4411-8300-7e116e4282f6"
+				"spark.autotune.trackingId": "34d0bc82-e3b9-47c7-9fcb-40acbe988852"
 			}
 		},
 		"metadata": {
@@ -84,7 +84,9 @@
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"\n",
 					"is_dev_or_test_env = 'dev' in storage_account or 'test' in storage_account\n",
-					"max_limit = 20 if is_dev_or_test_env else 100000000\n",
+					"\n",
+					"# limiting the number of output to 20 rows for dev environment\n",
+					"max_limit = 20 if 'dev' in storage_account else 100000000\n",
 					"\n",
 					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
@@ -263,7 +265,7 @@
 					}
 				},
 				"source": [
-					"## Anonymisation of sensitive fields"
+					"## Anonymisation of sensitive fields in dev and test"
 				]
 			},
 			{


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
