### PR TITLE
Mvg/fix/nsip exam timetable

### DIFF
--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "71a1c05e-9b08-4c15-88aa-5536359448e0"
+				"spark.autotune.trackingId": "6d4b1495-154a-43d3-ab21-62b93dca5278"
 			}
 		},
 		"metadata": {
@@ -105,8 +105,8 @@
 					"    ET.ODTEventID                                               AS eventID,\r\n",
 					"    ET.TypeOfExamination                                        AS eventType,\r\n",
 					"    ET.Name                                                     AS eventTitle,\r\n",
-					"    ET.DeadlineStartDateTime                                    AS eventDeadlineStartDate,\r\n",
-					"    ET.Date                                                     AS eventDate,\r\n",
+					"    to_date(ET.DeadlineStartDateTime)                           AS eventDeadlineStartDate,\r\n",
+					"    to_date(ET.Date)                                            AS eventDate,\r\n",
 					"    ET.EventLineItems                                           AS eventLineItems,\r\n",
 					"    ET.Description                                              AS eventLineItemDescription \r\n",
 					"    \r\n",

--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6d4b1495-154a-43d3-ab21-62b93dca5278"
+				"spark.autotune.trackingId": "1c4d00a4-7c93-493c-a1c1-6319c3827ab1"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"from notebookutils import mssparkutils\n",
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 4
+				"execution_count": 11
 			},
 			{
 				"cell_type": "markdown",
@@ -105,17 +105,17 @@
 					"    ET.ODTEventID                                               AS eventID,\r\n",
 					"    ET.TypeOfExamination                                        AS eventType,\r\n",
 					"    ET.Name                                                     AS eventTitle,\r\n",
-					"    to_date(ET.DeadlineStartDateTime)                           AS eventDeadlineStartDate,\r\n",
-					"    to_date(ET.Date)                                            AS eventDate,\r\n",
+					"    CAST(ET.DeadlineStartDateTime AS date)                      AS eventDeadlineStartDate,\r\n",
+					"    CAST(ET.Date AS date)                                       AS eventDate,\r\n",
 					"    ET.EventLineItems                                           AS eventLineItems,\r\n",
 					"    ET.Description                                              AS eventLineItemDescription \r\n",
 					"    \r\n",
 					"FROM odw_harmonised_db.casework_nsip_examination_timetable_dim  AS ET\r\n",
 					"WHERE ET.IsActive = 'Y'\r\n",
-					"-- ORDER BY IngestionDate DESC\r\n",
+					"ORDER BY caseReference,eventTitle DESC\r\n",
 					""
 				],
-				"execution_count": 5
+				"execution_count": 13
 			},
 			{
 				"cell_type": "markdown",
@@ -163,7 +163,7 @@
 					"    eventLineItemDescription   \r\n",
 					"FROM odw_curated_db.vw_examination_timetable"
 				],
-				"execution_count": 6
+				"execution_count": null
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
