### PR TITLE
Fix/sercice user standardised table name

### DIFF
--- a/infrastructure/configuration/data-lake/orchestration/orchestration.json
+++ b/infrastructure/configuration/data-lake/orchestration/orchestration.json
@@ -1177,7 +1177,7 @@
       "Source_Filename_Start": "service-user",
       "Expected_Within_Weekdays": 1,
       "Standardised_Path": "Horizon",
-      "Standardised_Table_Name": "horizon_service_user_new",
+      "Standardised_Table_Name": "service_user",
       "Standardised_Table_Definition": "standardised_table_definitions/Horizon/ServiceUser.json"
     },
     {

--- a/workspace/notebook/service_user_dim.json
+++ b/workspace/notebook/service_user_dim.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d78d9cc9-7bb8-4d5e-a66f-151041c2892f"
+				"spark.autotune.trackingId": "e5451200-442d-44ac-9280-bd9fa0750c24"
 			}
 		},
 		"metadata": {
@@ -119,7 +119,7 @@
 					"FROM odw_harmonised_db.service_user_dim T1\r\n",
 					"LEFT JOIN odw_harmonised_db.main_sourcesystem_fact T2 \r\n",
 					"    ON T1.SourceSystemID = T2.SourceSystemID\r\n",
-					"FULL JOIN odw_standardised_db.horizon_service_user_new T3 \r\n",
+					"FULL JOIN odw_standardised_db.service_user T3 \r\n",
 					"    ON T1.CaseReference = T3.casereference\r\n",
 					"        AND T1.ContactID = T3.id\r\n",
 					"        AND T1.IsActive = 'Y'\r\n",
@@ -146,7 +146,7 @@
 					"        END  = 'Y' )\r\n",
 					"    )\r\n",
 					"    AND T3.casereference IS NOT NULL\r\n",
-					"    AND T3.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_service_user_new)\r\n",
+					"    AND T3.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.service_user)\r\n",
 					";\r\n",
 					""
 				],

--- a/workspace/pipeline/pln_service_bus_service_user.json
+++ b/workspace/pipeline/pln_service_bus_service_user.json
@@ -37,7 +37,7 @@
 			},
 			{
 				"name": "Raw to Std",
-				"description": "Ingests raw data into the new standardised table i.e horizon_service_user_new",
+				"description": "Ingests raw data into the new standardised table i.e service_user",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{

--- a/workspace/pipeline/pln_service_user_clean_slate.json
+++ b/workspace/pipeline/pln_service_user_clean_slate.json
@@ -61,7 +61,7 @@
 							"type": "string"
 						},
 						"table_name": {
-							"value": "horizon_service_user_new",
+							"value": "service_user",
 							"type": "string"
 						}
 					},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
