### PR TITLE
new orchestration file items +2 scheams

### DIFF
--- a/infrastructure/configuration/data-lake/orchestration/orchestration.json
+++ b/infrastructure/configuration/data-lake/orchestration/orchestration.json
@@ -1245,6 +1245,28 @@
       "Standardised_Path": "NSIP",
       "Standardised_Table_Name": "nsip_s51_advice",
       "Standardised_Table_Definition": "standardised_table_definitions/NSIP/nsip_s51_advice.json"
+    },
+    {
+      "Source_ID": 114,
+      "Source_Folder": "Horizon",
+      "Source_Frequency_Folder": "",
+      "Source_Filename_Format": "DocumentMetaData.csv",
+      "Source_Filename_Start": "DocumentMetaData",
+      "Expected_Within_Weekdays": 1,
+      "Standardised_Path": "Horizon",
+      "Standardised_Table_Name": "document_meta_data",
+      "Standardised_Table_Definition": "standardised_table_definitions/Horizon/DocumentMetaData.json"
+    },
+    {
+      "Source_ID": 115,
+      "Source_Folder": "Horizon",
+      "Source_Frequency_Folder": "",
+      "Source_Filename_Format": "HorizonFolder.csv",
+      "Source_Filename_Start": "HorizonFolder",
+      "Expected_Within_Weekdays": 1,
+      "Standardised_Path": "Horizon",
+      "Standardised_Table_Name": "horizon_folder",
+      "Standardised_Table_Definition": "standardised_table_definitions/Horizon/HorizonFolder.json"
     }
   ]
 }

--- a/infrastructure/configuration/data-lake/standardised_table_definitions/Horizon/DocumentMetaData.json
+++ b/infrastructure/configuration/data-lake/standardised_table_definitions/Horizon/DocumentMetaData.json
@@ -1,0 +1,154 @@
+{
+    "fields": [
+        {
+            "metadata": {},
+            "name": "ingested_datetime",
+            "type": "timestamp",
+            "nullable": false
+        },
+        {
+            "metadata": {},
+            "name": "expected_from",
+            "type": "timestamp",
+            "nullable": false
+        },
+        {
+            "metadata": {},
+            "name": "expected_to",
+            "type": "timestamp",
+            "nullable": false
+        },
+        {
+            "metadata": {},
+            "name": "DataId",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "CaseNodeId",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "caseReference",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "documentReference",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "Version",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "Name",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "DataSize",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "virusCheckStatus",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "CreateDate",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "ModifyDate",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "caseworkType",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "publishedStatus",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "datePublished",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "documentType",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "sourceSystem",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "ValStr",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "representative",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "documentDescription",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "documentCaseStage",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "filter1",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "filter2",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "ParentID",
+            "type": "string",
+            "nullable": true
+        }
+    ]
+}

--- a/infrastructure/configuration/data-lake/standardised_table_definitions/Horizon/HorizonFolder.json
+++ b/infrastructure/configuration/data-lake/standardised_table_definitions/Horizon/HorizonFolder.json
@@ -1,0 +1,59 @@
+{
+    "fields": [
+        {
+            "metadata": {},
+            "name": "ingested_datetime",
+            "type": "timestamp",
+            "nullable": false
+        },
+        {
+            "metadata": {},
+            "name": "expected_from",
+            "type": "timestamp",
+            "nullable": false
+        },
+        {
+            "metadata": {},
+            "name": "expected_to",
+            "type": "timestamp",
+            "nullable": false
+        },
+        {
+            "metadata": {},
+            "name": "id",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "caseReference",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "displayNameEnglish",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "displayNameWelsh",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "parentFolderID",
+            "type": "string",
+            "nullable": true
+        },
+        {
+            "metadata": {},
+            "name": "caseNodeId",
+            "type": "string",
+            "nullable": true
+        }
+        
+    ]
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
