### PR TITLE
Updating pipeline: 0_Horizon_Document_Folder - Source has had a column renamed

### DIFF
--- a/workspace/pipeline/0_Horizon_Document_Folder.json
+++ b/workspace/pipeline/0_Horizon_Document_Folder.json
@@ -1773,12 +1773,12 @@
 							},
 							{
 								"source": {
-									"name": "ValStr",
+									"name": "author",
 									"type": "String",
 									"physicalType": "nvarchar"
 								},
 								"sink": {
-									"name": "ValStr",
+									"name": "author",
 									"type": "String",
 									"physicalType": "String"
 								}


### PR DESCRIPTION
Not much to this PR....

The document meta data source has changed at source, the column ValStr has been renamed to Author. Which means I need to update the mapping in this data copy task