### PR TITLE
Updating notebook: nsip_applicant_service_user

### DIFF
--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "9306542b-5dd5-47c5-a481-a04b2382eaa2"
+				"spark.autotune.trackingId": "4aab072d-d47d-4639-8f22-20666e1aa751"
 			}
 		},
 		"metadata": {
@@ -91,7 +91,7 @@
 					"\n",
 					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 11
+				"execution_count": 52
 			},
 			{
 				"cell_type": "markdown",
@@ -155,8 +155,8 @@
 					"    RR.RelRepOrganisation                               AS organisationType,\r\n",
 					"    RR.JobTitle                                         AS role,\r\n",
 					"    RR.PhoneNumber                                      AS telephoneNumber,\r\n",
-					"    NULL                                                AS otherPhoneNumber,\r\n",
-					"    NULL                                                AS faxNumber,\r\n",
+					"    ''                                                  AS otherPhoneNumber,\r\n",
+					"    ''                                                  AS faxNumber,\r\n",
 					"    RR.EmailAddress                                     AS emailAddress,\r\n",
 					"    NULL                                                AS webAddress,\r\n",
 					"    'RepresentationContact'                             AS serviceUserType,\r\n",
@@ -246,8 +246,8 @@
 					"    RR.RelRepOrganisation                               AS organisationType,\r\n",
 					"    RR.JobTitle                                         AS role,\r\n",
 					"    RR.PhoneNumber                                      AS telephoneNumber,\r\n",
-					"    NULL                                                AS otherPhoneNumber,\r\n",
-					"    NULL                                                AS faxNumber,\r\n",
+					"    ''                                                  AS otherPhoneNumber,\r\n",
+					"    ''                                                  AS faxNumber,\r\n",
 					"    RR.EmailAddress                                     AS emailAddress,\r\n",
 					"    NULL                                                AS webAddress,\r\n",
 					"    'Agent'                                             AS serviceUserType,\r\n",
@@ -266,7 +266,7 @@
 					"ORDER BY ingestionDate DESC\r\n",
 					""
 				],
-				"execution_count": 12
+				"execution_count": 53
 			},
 			{
 				"cell_type": "markdown",
@@ -329,7 +329,7 @@
 					"    \r\n",
 					"FROM odw_curated_db.vw_nsip_service_user"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -364,7 +364,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -415,7 +415,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 15
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,23 +3,36 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "nsip_applicant_service_user",
-				"type": "SynapseNotebook",
+				"name": "pln_service_user_clean_slate",
+				"type": "ExecutePipeline",
 				"dependsOn": [],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
 				"userProperties": [],
 				"typeProperties": {
-					"notebook": {
-						"referenceName": "nsip_applicant_service_user",
-						"type": "NotebookReference"
+					"pipeline": {
+						"referenceName": "pln_service_user_clean_slate",
+						"type": "PipelineReference"
 					},
-					"snapshot": true
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_service_user_main",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "pln_service_user_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_service_user_main",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
 				}
 			}
 		],


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
