### PR TITLE
Pg/feat/aie harm

### DIFF
--- a/workspace/notebook/aie_document_data.json
+++ b/workspace/notebook/aie_document_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "13140289-74dc-45b8-89ba-3d8e9f98f05c"
+				"spark.autotune.trackingId": "240817e9-0ffd-4777-93a5-03a69ffe83c2"
 			}
 		},
 		"metadata": {
@@ -174,7 +174,7 @@
 					"    ON \"DocumentTree\" = T2.Description AND \r\n",
 					"        T2.IsActive = 'Y'\r\n",
 					"FULL JOIN odw_harmonised_db.aie_document_data T3 \r\n",
-					"    ON T1.documentid = T3.DataID AND \r\n",
+					"    ON T1.documentid = T3.DocumentID AND \r\n",
 					"        T3.IsActive = 'Y'\r\n",
 					"WHERE\r\n",
 					"    -- flags new data        \r\n",
@@ -215,7 +215,7 @@
 					"                \r\n",
 					"            )) <> T3.RowID  -- same record, changed data\r\n",
 					"        THEN 'Y'\r\n",
-					"        WHEN T3.DataID IS NULL -- new record\r\n",
+					"        WHEN T3.DocumentID IS NULL -- new record\r\n",
 					"        THEN 'Y'\r\n",
 					"    ELSE 'N'\r\n",
 					"    END  = 'Y' )\r\n",
@@ -223,7 +223,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.aie_document_data)\r\n",
 					";"
 				],
-				"execution_count": 1
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -354,7 +354,7 @@
 					"FROM odw_harmonised_db.aie_document_data\r\n",
 					"WHERE DocumentID IN (SELECT DocumentID FROM aie_document_data_new WHERE AIEDocumentDataID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": 2
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -435,7 +435,7 @@
 					"FROM aie_document_data_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 3
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -490,7 +490,7 @@
 					"MERGE INTO odw_harmonised_db.aie_document_data AS Target\r\n",
 					"USING aie_document_data_changed_rows_final AS Source\r\n",
 					"\r\n",
-					"ON Source.DataID = Target.DataID\r\n",
+					"ON Source.DocumentID = Target.DocumentID\r\n",
 					"\r\n",
 					"-- For Updates existing rows\r\n",
 					"\r\n",
@@ -581,7 +581,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 4
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -663,7 +663,7 @@
 					"FROM odw_harmonised_db.aie_document_data;\r\n",
 					""
 				],
-				"execution_count": 5
+				"execution_count": 10
 			}
 		]
 	}

--- a/workspace/notebook/aie_document_data.json
+++ b/workspace/notebook/aie_document_data.json
@@ -1,0 +1,670 @@
+{
+	"name": "aie_document_data",
+	"properties": {
+		"folder": {
+			"name": "odw-harmonised/DocumentTree"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodwpr",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"runAsWorkspaceSystemIdentity": false,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "13140289-74dc-45b8-89ba-3d8e9f98f05c"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
+				"name": "pinssynspodwpr",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodwpr",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.2",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Check for new, updated or deleted data\n",
+					"- This script checks for new, updated or deleted data by checking the source data (horizon tables) against the target (odw_harmonised_db.casework tables)\n",
+					"- **New Data:** where an main Reference in the source does not exist in the target, then NewData flag is set to 'Y'\n",
+					"- **Updated data:** Comparison occurs on Reference Fields in source and in target where the row hash is different i.e. there is a change in one of the columns. NewData flag is set to 'Y'\n",
+					"- **Deleted data:** where an Reference info in the target exists but the same identifyers don't exist in the source. DeletedData flag is set to 'Y'\n",
+					"\n",
+					"## View aie_document_data is created"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Build aie_document_data table\r\n",
+					"-- Gets modified or deleted from source rows\r\n",
+					"\r\n",
+					"CREATE OR REPLACE TEMPORARY VIEW aie_document_data_new\r\n",
+					"\r\n",
+					"     AS\r\n",
+					"\r\n",
+					"-- gets data that matches of SourceID and flags that it is modified based on a row (md5) hash. Flags as \"NewData\"\r\n",
+					"-- gets data that is in the target but not in source. Flags as \"DeletedData\"\r\n",
+					"\r\n",
+					"SELECT DISTINCT\r\n",
+					"    CASE\r\n",
+					"        WHEN T1.documentid IS NULL\r\n",
+					"        THEN T3.CaseReference\r\n",
+					"        ELSE NULL\r\n",
+					"    END                             AS AIEDocumentDataID,\r\n",
+					"    T1.documentid\tAS\tDocumentID\t,\r\n",
+					"    T1.caseref\tAS\tCaseReference\t,\r\n",
+					"    T1.documentreference\tAS\tDocumentReference\t,\r\n",
+					"    T1.version\tAS\tVersion\t,\r\n",
+					"    T1.examinationrefno\tAS\tExaminationRefNo\t,\r\n",
+					"    T1.filename\tAS\tFileName\t,\r\n",
+					"    T1.originalfilename\tAS\tOriginalFileName\t,\r\n",
+					"    T1.size\tAS\tSize\t,\r\n",
+					"    T1.mime\tAS\tMime\t,\r\n",
+					"    T1.documenturi\tAS\tDocumentURI\t,\r\n",
+					"    T1.path\tAS\tPath\t,\r\n",
+					"    T1.viruscheckstatus\tAS\tVirusCheckStatus\t,\r\n",
+					"    T1.filemd5\tAS\tFileMD5\t,\r\n",
+					"    T1.datecreated\tAS\tDateCreated\t,\r\n",
+					"    T1.lastmodified\tAS\tLastModified\t,\r\n",
+					"    T1.casetype\tAS\tCaseType\t,\r\n",
+					"    T1.documentstatus\tAS\tDocumentStatus\t,\r\n",
+					"    T1.redactedstatus\tAS\tRedactedStatus\t,\r\n",
+					"    T1.publishedstatus\tAS\tPublishedStatus\t,\r\n",
+					"    T1.datepublished\tAS\tDatePublished\t,\r\n",
+					"    T1.documenttype\tAS\tDocumentType\t,\r\n",
+					"    T1.securityclassification\tAS\tSecurityClassification\t,\r\n",
+					"    T1.sourcesystem\tAS\tSourceSystem\t,\r\n",
+					"    T1.origin\tAS\tOrigin\t,\r\n",
+					"    T1.owner\tAS\tOwner\t,\r\n",
+					"    T1.author\tAS\tAuthor\t,\r\n",
+					"    T1.representative\tAS\tRepresentative\t,\r\n",
+					"    T1.description\tAS\tDescription\t,\r\n",
+					"    T1.stage\tAS\tStage\t,\r\n",
+					"    T1.filter1\tAS\tFilter1\t,\r\n",
+					"    T1.filter2\tAS\tFilter2\t,\r\n",
+					"\r\n",
+					"    T2.SourceSystemID               AS SourceSystemID,\r\n",
+					"    to_timestamp(T1.expected_from)  AS IngestionDate,\r\n",
+					"    NULL                            AS ValidTo,\r\n",
+					"    md5(\r\n",
+					"        concat(\r\n",
+					"            IFNULL(T1.documentid\t,'.'),\r\n",
+					"            IFNULL(T1.caseref\t,'.'),\r\n",
+					"            IFNULL(T1.documentreference\t,'.'),\r\n",
+					"            IFNULL(T1.version\t,'.'),\r\n",
+					"            IFNULL(T1.examinationrefno\t,'.'),\r\n",
+					"            IFNULL(T1.filename\t,'.'),\r\n",
+					"            IFNULL(T1.originalfilename\t,'.'),\r\n",
+					"            IFNULL(T1.size\t,'.'),\r\n",
+					"            IFNULL(T1.mime\t,'.'),\r\n",
+					"            IFNULL(T1.documenturi\t,'.'),\r\n",
+					"            IFNULL(T1.path\t,'.'),\r\n",
+					"            IFNULL(T1.viruscheckstatus\t,'.'),\r\n",
+					"            IFNULL(T1.filemd5\t,'.'),\r\n",
+					"            IFNULL(T1.datecreated\t,'.'),\r\n",
+					"            IFNULL(T1.lastmodified\t,'.'),\r\n",
+					"            IFNULL(T1.casetype\t,'.'),\r\n",
+					"            IFNULL(T1.documentstatus\t,'.'),\r\n",
+					"            IFNULL(T1.redactedstatus\t,'.'),\r\n",
+					"            IFNULL(T1.publishedstatus\t,'.'),\r\n",
+					"            IFNULL(T1.datepublished\t,'.'),\r\n",
+					"            IFNULL(T1.documenttype\t,'.'),\r\n",
+					"            IFNULL(T1.securityclassification\t,'.'),\r\n",
+					"            IFNULL(T1.sourcesystem\t,'.'),\r\n",
+					"            IFNULL(T1.origin\t,'.'),\r\n",
+					"            IFNULL(T1.owner\t,'.'),\r\n",
+					"            IFNULL(T1.author\t,'.'),\r\n",
+					"            IFNULL(T1.representative\t,'.'),\r\n",
+					"            IFNULL(T1.description\t,'.'),\r\n",
+					"            IFNULL(T1.stage\t,'.'),\r\n",
+					"            IFNULL(T1.filter1\t,'.'),\r\n",
+					"            IFNULL(T1.filter2\t,'.')\r\n",
+					"        ))                          AS RowID, -- this hash should contain all the defining fields\r\n",
+					"    'Y'                             AS IsActive,\r\n",
+					"    T3.IsActive                     AS HistoricIsActive\r\n",
+					"\r\n",
+					"FROM odw_standardised_db.aie_document_data T1\r\n",
+					"LEFT JOIN odw_harmonised_db.main_sourcesystem_fact T2 \r\n",
+					"    ON \"DocumentTree\" = T2.Description AND \r\n",
+					"        T2.IsActive = 'Y'\r\n",
+					"FULL JOIN odw_harmonised_db.aie_document_data T3 \r\n",
+					"    ON T1.documentid = T3.DataID AND \r\n",
+					"        T3.IsActive = 'Y'\r\n",
+					"WHERE\r\n",
+					"    -- flags new data        \r\n",
+					"    (CASE\r\n",
+					"        WHEN T1.caseref = T3.CaseReference AND md5(\r\n",
+					"            concat(\r\n",
+					"                IFNULL(T1.documentid\t,'.'),\r\n",
+					"                IFNULL(T1.caseref\t,'.'),\r\n",
+					"                IFNULL(T1.documentreference\t,'.'),\r\n",
+					"                IFNULL(T1.version\t,'.'),\r\n",
+					"                IFNULL(T1.examinationrefno\t,'.'),\r\n",
+					"                IFNULL(T1.filename\t,'.'),\r\n",
+					"                IFNULL(T1.originalfilename\t,'.'),\r\n",
+					"                IFNULL(T1.size\t,'.'),\r\n",
+					"                IFNULL(T1.mime\t,'.'),\r\n",
+					"                IFNULL(T1.documenturi\t,'.'),\r\n",
+					"                IFNULL(T1.path\t,'.'),\r\n",
+					"                IFNULL(T1.viruscheckstatus\t,'.'),\r\n",
+					"                IFNULL(T1.filemd5\t,'.'),\r\n",
+					"                IFNULL(T1.datecreated\t,'.'),\r\n",
+					"                IFNULL(T1.lastmodified\t,'.'),\r\n",
+					"                IFNULL(T1.casetype\t,'.'),\r\n",
+					"                IFNULL(T1.documentstatus\t,'.'),\r\n",
+					"                IFNULL(T1.redactedstatus\t,'.'),\r\n",
+					"                IFNULL(T1.publishedstatus\t,'.'),\r\n",
+					"                IFNULL(T1.datepublished\t,'.'),\r\n",
+					"                IFNULL(T1.documenttype\t,'.'),\r\n",
+					"                IFNULL(T1.securityclassification\t,'.'),\r\n",
+					"                IFNULL(T1.sourcesystem\t,'.'),\r\n",
+					"                IFNULL(T1.origin\t,'.'),\r\n",
+					"                IFNULL(T1.owner\t,'.'),\r\n",
+					"                IFNULL(T1.author\t,'.'),\r\n",
+					"                IFNULL(T1.representative\t,'.'),\r\n",
+					"                IFNULL(T1.description\t,'.'),\r\n",
+					"                IFNULL(T1.stage\t,'.'),\r\n",
+					"                IFNULL(T1.filter1\t,'.'),\r\n",
+					"                IFNULL(T1.filter2\t,'.')\r\n",
+					"                \r\n",
+					"            )) <> T3.RowID  -- same record, changed data\r\n",
+					"        THEN 'Y'\r\n",
+					"        WHEN T3.DataID IS NULL -- new record\r\n",
+					"        THEN 'Y'\r\n",
+					"    ELSE 'N'\r\n",
+					"    END  = 'Y' )\r\n",
+					"    AND T1.documentid IS NOT NULL\r\n",
+					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.aie_document_data)\r\n",
+					";"
+				],
+				"execution_count": 1
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Dataset is created that contains changed data and corresponding target data\n",
+					"- This script combines data that has been updated, Deleted or is new, with corresponding target data\n",
+					"- View **casework_all_appeals_new** is unioned to the target data filter to only those rows where changes have been detected\n",
+					"## View aie_document_data_changed_rows is created"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Create new and updated dataset\r\n",
+					"\r\n",
+					"CREATE OR REPLACE TEMPORARY VIEW aie_document_data_changed_rows\r\n",
+					"\r\n",
+					"    AS\r\n",
+					"\r\n",
+					"-- gets updated, deleted and new rows \r\n",
+					"SELECT \r\n",
+					"    AIEDocumentDataID\t,\r\n",
+					"    DocumentID\t,\r\n",
+					"    CaseReference\t,\r\n",
+					"    DocumentReference\t,\r\n",
+					"    Version\t,\r\n",
+					"    ExaminationRefNo\t,\r\n",
+					"    FileName\t,\r\n",
+					"    OriginalFileName\t,\r\n",
+					"    Size\t,\r\n",
+					"    Mime\t,\r\n",
+					"    DocumentURI\t,\r\n",
+					"    Path\t,\r\n",
+					"    VirusCheckStatus\t,\r\n",
+					"    FileMD5\t,\r\n",
+					"    DateCreated\t,\r\n",
+					"    LastModified\t,\r\n",
+					"    CaseType\t,\r\n",
+					"    DocumentStatus\t,\r\n",
+					"    RedactedStatus\t,\r\n",
+					"    PublishedStatus\t,\r\n",
+					"    DatePublished\t,\r\n",
+					"    DocumentType\t,\r\n",
+					"    SecurityClassification\t,\r\n",
+					"    SourceSystem\t,\r\n",
+					"    Origin\t,\r\n",
+					"    Owner\t,\r\n",
+					"    Author\t,\r\n",
+					"    Representative\t,\r\n",
+					"    Description\t,\r\n",
+					"    Stage\t,\r\n",
+					"    Filter1\t,\r\n",
+					"    Filter2\t,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"    \r\n",
+					"\r\n",
+					"From aie_document_data_new WHERE HistoricIsActive = 'Y' or HistoricIsActive IS NULL\r\n",
+					"\r\n",
+					"    UNION ALL\r\n",
+					"\r\n",
+					"-- gets original versions of updated rows so we can update EndDate and set IsActive flag to 'N'\r\n",
+					"SELECT\r\n",
+					"    AIEDocumentDataID\t,\r\n",
+					"    DocumentID\t,\r\n",
+					"    CaseReference\t,\r\n",
+					"    DocumentReference\t,\r\n",
+					"    Version\t,\r\n",
+					"    ExaminationRefNo\t,\r\n",
+					"    FileName\t,\r\n",
+					"    OriginalFileName\t,\r\n",
+					"    Size\t,\r\n",
+					"    Mime\t,\r\n",
+					"    DocumentURI\t,\r\n",
+					"    Path\t,\r\n",
+					"    VirusCheckStatus\t,\r\n",
+					"    FileMD5\t,\r\n",
+					"    DateCreated\t,\r\n",
+					"    LastModified\t,\r\n",
+					"    CaseType\t,\r\n",
+					"    DocumentStatus\t,\r\n",
+					"    RedactedStatus\t,\r\n",
+					"    PublishedStatus\t,\r\n",
+					"    DatePublished\t,\r\n",
+					"    DocumentType\t,\r\n",
+					"    SecurityClassification\t,\r\n",
+					"    SourceSystem\t,\r\n",
+					"    Origin\t,\r\n",
+					"    Owner\t,\r\n",
+					"    Author\t,\r\n",
+					"    Representative\t,\r\n",
+					"    Description\t,\r\n",
+					"    Stage\t,\r\n",
+					"    Filter1\t,\r\n",
+					"    Filter2\t,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"    \r\n",
+					"FROM odw_harmonised_db.aie_document_data\r\n",
+					"WHERE DocumentID IN (SELECT DocumentID FROM aie_document_data_new WHERE AIEDocumentDataID IS NULL) AND IsActive = 'Y'; "
+				],
+				"execution_count": 2
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"CREATE OR REPLACE TEMPORARY VIEW Loading_month\n",
+					"\n",
+					"    AS\n",
+					"\n",
+					"SELECT DISTINCT\n",
+					"    IngestionDate AS IngestionDate,\n",
+					"    to_timestamp(date_sub(IngestionDate,1)) AS ClosingDate,\n",
+					"    'Y' AS IsActive\n",
+					"\n",
+					"FROM aie_document_data_new;\n",
+					"\n",
+					"CREATE OR REPLACE TEMPORARY VIEW aie_document_data_changed_rows_final\n",
+					"\n",
+					"    AS\n",
+					"\n",
+					"SELECT \n",
+					"    \n",
+					"    AIEDocumentDataID\t,\n",
+					"    DocumentID\t,\n",
+					"    CaseReference\t,\n",
+					"    DocumentReference\t,\n",
+					"    Version\t,\n",
+					"    ExaminationRefNo\t,\n",
+					"    FileName\t,\n",
+					"    OriginalFileName\t,\n",
+					"    Size\t,\n",
+					"    Mime\t,\n",
+					"    DocumentURI\t,\n",
+					"    Path\t,\n",
+					"    VirusCheckStatus\t,\n",
+					"    FileMD5\t,\n",
+					"    DateCreated\t,\n",
+					"    LastModified\t,\n",
+					"    CaseType\t,\n",
+					"    DocumentStatus\t,\n",
+					"    RedactedStatus\t,\n",
+					"    PublishedStatus\t,\n",
+					"    DatePublished\t,\n",
+					"    DocumentType\t,\n",
+					"    SecurityClassification\t,\n",
+					"    SourceSystem\t,\n",
+					"    Origin\t,\n",
+					"    Owner\t,\n",
+					"    Author\t,\n",
+					"    Representative\t,\n",
+					"    Description\t,\n",
+					"    Stage\t,\n",
+					"    Filter1\t,\n",
+					"    Filter2\t,\n",
+					"    \n",
+					"    T1.SourceSystemID,\n",
+					"    T1.IngestionDate,\n",
+					"    T1.ValidTo,\n",
+					"    T1.RowID,\n",
+					"    T1.IsActive,\n",
+					"    T2.ClosingDate\n",
+					"FROM aie_document_data_changed_rows T1\n",
+					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
+				],
+				"execution_count": 3
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					""
+				]
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# View aie_document_data_changed_rows is used in a merge (Upsert) statement into the target table\n",
+					"- **WHEN MATCHED** ON the surrogate Key (i.e. AllAppealsID), EndDate is set to today -1 day and the IsActive flag is set to 'N'\n",
+					"- **WHEN NOT MATCHED** ON the surrogate Key, insert rows\n",
+					"## Table odw_harmonised_db.aie_document_data is updated"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- merge into dim table\r\n",
+					"\r\n",
+					"MERGE INTO odw_harmonised_db.aie_document_data AS Target\r\n",
+					"USING aie_document_data_changed_rows_final AS Source\r\n",
+					"\r\n",
+					"ON Source.DataID = Target.DataID\r\n",
+					"\r\n",
+					"-- For Updates existing rows\r\n",
+					"\r\n",
+					"WHEN MATCHED\r\n",
+					"    THEN \r\n",
+					"    UPDATE SET\r\n",
+					"    Target.ValidTo = to_timestamp(ClosingDate),\r\n",
+					"    Target.IsActive = 'N'\r\n",
+					"\r\n",
+					"-- Insert completely new rows\r\n",
+					"\r\n",
+					"WHEN NOT MATCHED \r\n",
+					"    THEN INSERT (\r\n",
+					"        AIEDocumentDataID\t,\r\n",
+					"        DocumentID\t,\r\n",
+					"        CaseReference\t,\r\n",
+					"        DocumentReference\t,\r\n",
+					"        Version\t,\r\n",
+					"        ExaminationRefNo\t,\r\n",
+					"        FileName\t,\r\n",
+					"        OriginalFileName\t,\r\n",
+					"        Size\t,\r\n",
+					"        Mime\t,\r\n",
+					"        DocumentURI\t,\r\n",
+					"        Path\t,\r\n",
+					"        VirusCheckStatus\t,\r\n",
+					"        FileMD5\t,\r\n",
+					"        DateCreated\t,\r\n",
+					"        LastModified\t,\r\n",
+					"        CaseType\t,\r\n",
+					"        DocumentStatus\t,\r\n",
+					"        RedactedStatus\t,\r\n",
+					"        PublishedStatus\t,\r\n",
+					"        DatePublished\t,\r\n",
+					"        DocumentType\t,\r\n",
+					"        SecurityClassification\t,\r\n",
+					"        SourceSystem\t,\r\n",
+					"        Origin\t,\r\n",
+					"        Owner\t,\r\n",
+					"        Author\t,\r\n",
+					"        Representative\t,\r\n",
+					"        Description\t,\r\n",
+					"        Stage\t,\r\n",
+					"        Filter1\t,\r\n",
+					"        Filter2\t,\r\n",
+					"        SourceSystemID,\r\n",
+					"        IngestionDate,\r\n",
+					"        ValidTo,\r\n",
+					"        RowID,\r\n",
+					"        IsActive)\r\n",
+					"    VALUES (\r\n",
+					"        Source.AIEDocumentDataID\t,\r\n",
+					"        Source.DocumentID\t,\r\n",
+					"        Source.CaseReference\t,\r\n",
+					"        Source.DocumentReference\t,\r\n",
+					"        Source.Version\t,\r\n",
+					"        Source.ExaminationRefNo\t,\r\n",
+					"        Source.FileName\t,\r\n",
+					"        Source.OriginalFileName\t,\r\n",
+					"        Source.Size\t,\r\n",
+					"        Source.Mime\t,\r\n",
+					"        Source.DocumentURI\t,\r\n",
+					"        Source.Path\t,\r\n",
+					"        Source.VirusCheckStatus\t,\r\n",
+					"        Source.FileMD5\t,\r\n",
+					"        Source.DateCreated\t,\r\n",
+					"        Source.LastModified\t,\r\n",
+					"        Source.CaseType\t,\r\n",
+					"        Source.DocumentStatus\t,\r\n",
+					"        Source.RedactedStatus\t,\r\n",
+					"        Source.PublishedStatus\t,\r\n",
+					"        Source.DatePublished\t,\r\n",
+					"        Source.DocumentType\t,\r\n",
+					"        Source.SecurityClassification\t,\r\n",
+					"        Source.SourceSystem\t,\r\n",
+					"        Source.Origin\t,\r\n",
+					"        Source.Owner\t,\r\n",
+					"        Source.Author\t,\r\n",
+					"        Source.Representative\t,\r\n",
+					"        Source.Description\t,\r\n",
+					"        Source.Stage\t,\r\n",
+					"        Source.Filter1\t,\r\n",
+					"        Source.Filter2\t,\r\n",
+					"        Source.SourceSystemID,\r\n",
+					"        Source.IngestionDate,\r\n",
+					"        Source.ValidTo,\r\n",
+					"        Source.RowID,\r\n",
+					"        Source.IsActive)\r\n",
+					"     ;   "
+				],
+				"execution_count": 4
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Fix the IDs\n",
+					"- No auto-increment feature is available in delta tables, therefore we need to create new IDs for the inserted rows\n",
+					"- This is done by select the target data and using INSERT OVERWRITE to re-insert the data is a new Row Number\n",
+					"## Table odw_harmonised_db.aie_document_data is updated"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Insert new aie_document_data\r\n",
+					"\r\n",
+					"INSERT OVERWRITE odw_harmonised_db.aie_document_data\r\n",
+					"\r\n",
+					"SELECT \r\n",
+					"    ROW_NUMBER() OVER (ORDER BY CaseReference NULLS LAST) AS AIEDocumentDataID,\r\n",
+					"    DocumentID\t,\r\n",
+					"    CaseReference\t,\r\n",
+					"    DocumentReference\t,\r\n",
+					"    Version\t,\r\n",
+					"    ExaminationRefNo\t,\r\n",
+					"    FileName\t,\r\n",
+					"    OriginalFileName\t,\r\n",
+					"    Size\t,\r\n",
+					"    Mime\t,\r\n",
+					"    DocumentURI\t,\r\n",
+					"    Path\t,\r\n",
+					"    VirusCheckStatus\t,\r\n",
+					"    FileMD5\t,\r\n",
+					"    DateCreated\t,\r\n",
+					"    LastModified\t,\r\n",
+					"    CaseType\t,\r\n",
+					"    DocumentStatus\t,\r\n",
+					"    RedactedStatus\t,\r\n",
+					"    PublishedStatus\t,\r\n",
+					"    DatePublished\t,\r\n",
+					"    DocumentType\t,\r\n",
+					"    SecurityClassification\t,\r\n",
+					"    SourceSystem\t,\r\n",
+					"    Origin\t,\r\n",
+					"    Owner\t,\r\n",
+					"    Author\t,\r\n",
+					"    Representative\t,\r\n",
+					"    Description\t,\r\n",
+					"    Stage\t,\r\n",
+					"    Filter1\t,\r\n",
+					"    Filter2\t,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"FROM odw_harmonised_db.aie_document_data;\r\n",
+					""
+				],
+				"execution_count": 5
+			}
+		]
+	}
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
