### PR TITLE
Fix/exam timetable

### DIFF
--- a/workspace/pipeline/0_Horizon_Data_Transfer_Raw.json
+++ b/workspace/pipeline/0_Horizon_Data_Transfer_Raw.json
@@ -3502,234 +3502,11 @@
 				}
 			},
 			{
-				"name": "Examination_Timetable",
-				"description": "NSIP Examination Timetable",
-				"type": "Copy",
-				"dependsOn": [
-					{
-						"activity": "HZN_Right_of_Way",
-						"dependencyConditions": [
-							"Completed"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"source": {
-						"type": "AzureSqlSource",
-						"sqlReaderQuery": "SELECT\r\nET.ID,\r\nCR.CaseReference,\r\nTOE.[Name] AS TypeOfExamination,\r\nET.[Name],\r\nREPLACE(CONVERT(VARCHAR(MAX), ET.[Description]), '\"', '') AS Description,\r\nET.[DeadlineStartDateTime],\r\nET.[Date],\r\nET.[Location]\r\nFROM horizon_ExamTimetable ET\r\nJOIN horizon_CaseReference CR on CR.CaseNodeID = ET.CaseId\r\nJOIN horizon_TypeOfExamination TOE on TOE.ID = ET.ExaminationTypeID\r\n;",
-						"queryTimeout": "02:00:00",
-						"isolationLevel": "ReadCommitted",
-						"partitionOption": "None"
-					},
-					"sink": {
-						"type": "DelimitedTextSink",
-						"storeSettings": {
-							"type": "AzureBlobFSWriteSettings"
-						},
-						"formatSettings": {
-							"type": "DelimitedTextWriteSettings",
-							"quoteAllText": true,
-							"fileExtension": ".txt"
-						}
-					},
-					"enableStaging": false,
-					"translator": {
-						"type": "TabularTranslator",
-						"mappings": [
-							{
-								"source": {
-									"name": "ID",
-									"type": "Int32",
-									"physicalType": "int"
-								},
-								"sink": {
-									"name": "ID",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "CaseReference",
-									"type": "String",
-									"physicalType": "varchar"
-								},
-								"sink": {
-									"name": "CaseReference",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "TypeOfExamination",
-									"type": "String",
-									"physicalType": "nvarchar"
-								},
-								"sink": {
-									"name": "TypeOfExamination",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Name",
-									"type": "String",
-									"physicalType": "varchar"
-								},
-								"sink": {
-									"name": "Name",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Description",
-									"type": "String",
-									"physicalType": "varchar"
-								},
-								"sink": {
-									"name": "Description",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "DeadlineStartDateTime",
-									"type": "DateTime",
-									"physicalType": "datetime"
-								},
-								"sink": {
-									"name": "DeadlineStartDateTime",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Date",
-									"type": "DateTime",
-									"physicalType": "datetime"
-								},
-								"sink": {
-									"name": "Date",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Location",
-									"type": "String",
-									"physicalType": "nvarchar"
-								},
-								"sink": {
-									"name": "Location",
-									"type": "String",
-									"physicalType": "String"
-								}
-							}
-						],
-						"typeConversion": true,
-						"typeConversionSettings": {
-							"allowDataTruncation": true,
-							"treatBooleanAsNumber": false
-						}
-					}
-				},
-				"inputs": [
-					{
-						"referenceName": "HZN_NSIP_Query",
-						"type": "DatasetReference"
-					}
-				],
-				"outputs": [
-					{
-						"referenceName": "ExaminationTimeTable",
-						"type": "DatasetReference",
-						"parameters": {
-							"FileName": "ExaminationTimetable.csv"
-						}
-					}
-				]
-			},
-			{
-				"name": "ExaminationTimetable_Data_Copy_Failure1",
-				"description": "ExaminationTimetable data loading into the RAW ODW Layer as csv has failed",
-				"type": "Fail",
-				"dependsOn": [
-					{
-						"activity": "Examination_Timetable",
-						"dependencyConditions": [
-							"Failed"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"message": "The Horizon ExaminationTimetable load to RAW has failed",
-					"errorCode": "HZN_Data_Copy_ExaminationTimetable"
-				}
-			},
-			{
-				"name": "Logging Failed Activities-12",
-				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "ExaminationTimetable_Data_Copy_Failure1",
-						"dependencyConditions": [
-							"Completed"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"notebook": {
-						"referenceName": "py_fail_activity_logging",
-						"type": "NotebookReference"
-					},
-					"parameters": {
-						"output": {
-							"value": {
-								"value": "@activity('ExaminationTimetable_Data_Copy_Failure1').output.message",
-								"type": "Expression"
-							},
-							"type": "string"
-						}
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
-				}
-			},
-			{
 				"name": "NSIP_Relevant_Representation",
 				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
-						"activity": "Examination_Timetable",
+						"activity": "NSIP_Exam_Timetable",
 						"dependencyConditions": [
 							"Completed"
 						]
@@ -3759,6 +3536,26 @@
 				"typeProperties": {
 					"pipeline": {
 						"referenceName": "0_Raw_Horizon_NSIP_Data",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "NSIP_Exam_Timetable",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "HZN_Right_of_Way",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "0_Raw_Horizon_NSIP_Exam_Timetable",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true

--- a/workspace/pipeline/0_Raw_Horizon_NSIP_Exam_Timetable.json
+++ b/workspace/pipeline/0_Raw_Horizon_NSIP_Exam_Timetable.json
@@ -1,0 +1,227 @@
+{
+	"name": "0_Raw_Horizon_NSIP_Exam_Timetable",
+	"properties": {
+		"activities": [
+			{
+				"name": "Examination_Timetable",
+				"description": "NSIP Examination Timetable",
+				"type": "Copy",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"source": {
+						"type": "AzureSqlSource",
+						"sqlReaderQuery": "SELECT\r\nET.ID,\r\nCR.CaseReference,\r\nTOE.[Name] AS TypeOfExamination,\r\nET.[Name],\r\nREPLACE(CONVERT(VARCHAR(MAX), ET.[Description]), '\"', '') AS Description,\r\nET.[DeadlineStartDateTime],\r\nET.[Date],\r\nET.[Location]\r\nFROM horizon_ExamTimetable ET\r\nJOIN horizon_CaseReference CR on CR.CaseNodeID = ET.CaseId\r\nJOIN horizon_TypeOfExamination TOE on TOE.ID = ET.ExaminationTypeID\r\n;",
+						"queryTimeout": "02:00:00",
+						"isolationLevel": "ReadCommitted",
+						"partitionOption": "None"
+					},
+					"sink": {
+						"type": "DelimitedTextSink",
+						"storeSettings": {
+							"type": "AzureBlobFSWriteSettings"
+						},
+						"formatSettings": {
+							"type": "DelimitedTextWriteSettings",
+							"quoteAllText": true,
+							"fileExtension": ".txt"
+						}
+					},
+					"enableStaging": false,
+					"translator": {
+						"type": "TabularTranslator",
+						"mappings": [
+							{
+								"source": {
+									"name": "ID",
+									"type": "Int32",
+									"physicalType": "int"
+								},
+								"sink": {
+									"name": "ID",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "CaseReference",
+									"type": "String",
+									"physicalType": "varchar"
+								},
+								"sink": {
+									"name": "CaseReference",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "TypeOfExamination",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "TypeOfExamination",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Name",
+									"type": "String",
+									"physicalType": "varchar"
+								},
+								"sink": {
+									"name": "Name",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Description",
+									"type": "String",
+									"physicalType": "varchar"
+								},
+								"sink": {
+									"name": "Description",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "DeadlineStartDateTime",
+									"type": "DateTime",
+									"physicalType": "datetime"
+								},
+								"sink": {
+									"name": "DeadlineStartDateTime",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Date",
+									"type": "DateTime",
+									"physicalType": "datetime"
+								},
+								"sink": {
+									"name": "Date",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Location",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Location",
+									"type": "String",
+									"physicalType": "String"
+								}
+							}
+						],
+						"typeConversion": true,
+						"typeConversionSettings": {
+							"allowDataTruncation": true,
+							"treatBooleanAsNumber": false
+						}
+					}
+				},
+				"inputs": [
+					{
+						"referenceName": "HZN_NSIP_Query",
+						"type": "DatasetReference"
+					}
+				],
+				"outputs": [
+					{
+						"referenceName": "ExaminationTimeTable",
+						"type": "DatasetReference",
+						"parameters": {
+							"FileName": "ExaminationTimetable.csv"
+						}
+					}
+				]
+			},
+			{
+				"name": "ExaminationTimetable_Data_Copy_Failure1",
+				"description": "ExaminationTimetable data loading into the RAW ODW Layer as csv has failed",
+				"type": "Fail",
+				"dependsOn": [
+					{
+						"activity": "Examination_Timetable",
+						"dependencyConditions": [
+							"Failed"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"message": "The Horizon ExaminationTimetable load to RAW has failed",
+					"errorCode": "HZN_Data_Copy_ExaminationTimetable"
+				}
+			},
+			{
+				"name": "Logging Failed Activities-12",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "ExaminationTimetable_Data_Copy_Failure1",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_fail_activity_logging",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"output": {
+							"value": {
+								"value": "@activity('ExaminationTimetable_Data_Copy_Failure1').output.message",
+								"type": "Expression"
+							},
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			}
+		],
+		"folder": {
+			"name": "casework/layers/0-raw"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_horizon_nsip_exam_timetable.json
+++ b/workspace/pipeline/pln_horizon_nsip_exam_timetable.json
@@ -81,147 +81,16 @@
 			},
 			{
 				"name": "Src to Raw",
-				"description": "Copies data from Horizon to odw-raw",
-				"type": "Copy",
+				"type": "ExecutePipeline",
 				"dependsOn": [],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
 				"userProperties": [],
 				"typeProperties": {
-					"source": {
-						"type": "AzureSqlSource",
-						"sqlReaderQuery": "SELECT\r\nCR.CaseReference,\r\nTOE.[Name] AS TypeOfExamination,\r\nET.[Name],\r\nREPLACE(CONVERT(VARCHAR(MAX), ET.[Description]), '\"', '') AS Description,\r\nET.[DeadlineStartDateTime],\r\nET.[Date],\r\nET.[Location]\r\nFROM horizon_ExamTimetable ET\r\nJOIN horizon_CaseReference CR on CR.CaseNodeID = ET.CaseId\r\nJOIN horizon_TypeOfExamination TOE on TOE.ID = ET.ExaminationTypeID\r\n;",
-						"queryTimeout": "02:00:00",
-						"isolationLevel": "ReadCommitted",
-						"partitionOption": "None"
+					"pipeline": {
+						"referenceName": "0_Raw_Horizon_NSIP_Exam_Timetable",
+						"type": "PipelineReference"
 					},
-					"sink": {
-						"type": "DelimitedTextSink",
-						"storeSettings": {
-							"type": "AzureBlobFSWriteSettings"
-						},
-						"formatSettings": {
-							"type": "DelimitedTextWriteSettings",
-							"quoteAllText": true,
-							"fileExtension": ".txt"
-						}
-					},
-					"enableStaging": false,
-					"translator": {
-						"type": "TabularTranslator",
-						"mappings": [
-							{
-								"source": {
-									"name": "CaseReference",
-									"type": "String",
-									"physicalType": "varchar"
-								},
-								"sink": {
-									"name": "CaseReference",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "TypeOfExamination",
-									"type": "String",
-									"physicalType": "nvarchar"
-								},
-								"sink": {
-									"name": "TypeOfExamination",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Name",
-									"type": "String",
-									"physicalType": "varchar"
-								},
-								"sink": {
-									"name": "Name",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Description",
-									"type": "String",
-									"physicalType": "ntext"
-								},
-								"sink": {
-									"name": "Description",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "DeadlineStartDateTime",
-									"type": "DateTime",
-									"physicalType": "datetime"
-								},
-								"sink": {
-									"name": "DeadlineStartDateTime",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Date",
-									"type": "DateTime",
-									"physicalType": "datetime"
-								},
-								"sink": {
-									"name": "Date",
-									"type": "String",
-									"physicalType": "String"
-								}
-							},
-							{
-								"source": {
-									"name": "Location",
-									"type": "String",
-									"physicalType": "nvarchar"
-								},
-								"sink": {
-									"name": "Location",
-									"type": "String",
-									"physicalType": "String"
-								}
-							}
-						],
-						"typeConversion": true,
-						"typeConversionSettings": {
-							"allowDataTruncation": true,
-							"treatBooleanAsNumber": false
-						}
-					}
-				},
-				"inputs": [
-					{
-						"referenceName": "HZN_NSIP_Query",
-						"type": "DatasetReference"
-					}
-				],
-				"outputs": [
-					{
-						"referenceName": "ExaminationTimeTable",
-						"type": "DatasetReference",
-						"parameters": {
-							"FileName": "ExaminationTimetable.csv"
-						}
-					}
-				]
+					"waitOnCompletion": true
+				}
 			}
 		],
 		"folder": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
