### PR TITLE
Fix/s51 advice advice details

### DIFF
--- a/infrastructure/configuration/data-lake/harmonised_table_definitions/casework_nsip_advice_dim.json
+++ b/infrastructure/configuration/data-lake/harmonised_table_definitions/casework_nsip_advice_dim.json
@@ -44,13 +44,7 @@
         },
         {
             "metadata": {},
-            "name": "EnquirerFirstName",
-            "type": "string",
-            "nullable": true
-        },
-        {
-            "metadata": {},
-            "name": "EnquirerLastName",
+            "name": "Enquirer",
             "type": "string",
             "nullable": true
         },
@@ -142,6 +136,18 @@
             "name": "CaseWorkType",
             "type": "string",
             "nullable": true
+        },
+        {
+          "metadata": {},
+          "name": "Migrated",
+          "type": "string",
+          "nullable": false
+        },
+        {
+          "metadata": {},
+          "name": "ODTSourceSystem",
+          "type": "string",
+          "nullable": true
         },
         {
             "metadata": {},

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "18b7c070-28f2-443e-9636-697b759a7d90"
+				"spark.autotune.trackingId": "ad090444-d5e3-41f7-96d1-118195656337"
 			}
 		},
 		"metadata": {
@@ -88,7 +88,7 @@
 					"\n",
 					"# spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 23
+				"execution_count": 27
 			},
 			{
 				"cell_type": "markdown",
@@ -136,16 +136,16 @@
 					"    AD.AdviceReference\t\t\t\t\t\t\t\t\t    AS adviceReference,\n",
 					"    AD.CaseReference\t\t\t\t\t\t\t\t\t    AS caseReference,\n",
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
-					"    trim(\n",
-					"        concat(\n",
-					"            AD.EnquirerFirstName,' ',AD.EnquirerLastName))  AS from,\n",
+					"    trim(AD.Enquirer)                                       AS from,\n",
 					"    AD.EnquirerOrganisation                                 AS agent,\n",
 					"    AD.EnquiryMethod                                        AS method,\n",
 					"    AD.EnquiryDate                                          AS enquiryDate,\n",
 					"    AD.Enquiry                                              AS enquiryDetails,\n",
 					"    AD.AdviceFrom                                           AS adviceGivenBy,\n",
 					"    AD.AdviceStatus                                         AS adviceDate,\n",
-					"    AD.Advice                                               AS adviceDetails,\n",
+					"    SUBSTRING(AD.Advice, 1, 7999)                           AS adviceDetails1,\n",
+					"    SUBSTRING(AD.Advice, 8000, 15999)                       AS adviceDetails2,\n",
+					"    SUBSTRING(AD.Advice, 16000, 23999)                      AS adviceDetails3,\n",
 					"    AD.AdviceStatus                                         AS status,\n",
 					"    \"unredacted\"                                            AS redactionStatus,\n",
 					"    AD.AttachmentID                                         AS attachmentIds\n",
@@ -154,7 +154,7 @@
 					"\t\n",
 					"-- LIMIT ${MAX_LIMIT}"
 				],
-				"execution_count": null
+				"execution_count": 28
 			},
 			{
 				"cell_type": "markdown",
@@ -203,7 +203,7 @@
 					"    \n",
 					"FROM odw_curated_db.vw_nsip_s51_advice"
 				],
-				"execution_count": null
+				"execution_count": 29
 			},
 			{
 				"cell_type": "markdown",
@@ -235,7 +235,7 @@
 					"# %%pyspark\n",
 					"# pip install Faker"
 				],
-				"execution_count": null
+				"execution_count": 30
 			},
 			{
 				"cell_type": "markdown",
@@ -288,7 +288,7 @@
 					"#         table_loc = \"abfss://odw-curated@\"+storage_account+'nsip_data'\n",
 					"#         df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": null
+				"execution_count": 31
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ad090444-d5e3-41f7-96d1-118195656337"
+				"spark.autotune.trackingId": "0345a1d0-14d5-4fa4-acbc-6eccb93e96f2"
 			}
 		},
 		"metadata": {
@@ -136,16 +136,14 @@
 					"    AD.AdviceReference\t\t\t\t\t\t\t\t\t    AS adviceReference,\n",
 					"    AD.CaseReference\t\t\t\t\t\t\t\t\t    AS caseReference,\n",
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
-					"    trim(AD.Enquirer)                                       AS from,\n",
+					"    AD.Enquirer                                             AS from,\n",
 					"    AD.EnquirerOrganisation                                 AS agent,\n",
 					"    AD.EnquiryMethod                                        AS method,\n",
 					"    AD.EnquiryDate                                          AS enquiryDate,\n",
 					"    AD.Enquiry                                              AS enquiryDetails,\n",
 					"    AD.AdviceFrom                                           AS adviceGivenBy,\n",
 					"    AD.AdviceStatus                                         AS adviceDate,\n",
-					"    SUBSTRING(AD.Advice, 1, 7999)                           AS adviceDetails1,\n",
-					"    SUBSTRING(AD.Advice, 8000, 15999)                       AS adviceDetails2,\n",
-					"    SUBSTRING(AD.Advice, 16000, 23999)                      AS adviceDetails3,\n",
+					"    AD.Advice                                               AS adviceDetails,\n",
 					"    AD.AdviceStatus                                         AS status,\n",
 					"    \"unredacted\"                                            AS redactionStatus,\n",
 					"    AD.AttachmentID                                         AS attachmentIds\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
