### PR TITLE
Updating notebook: nsip_s51_advice

### DIFF
--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7c6a8558-6ea2-4cb8-8456-af455a42a431"
+				"spark.autotune.trackingId": "c3114525-cdcc-4e20-95fa-4c3958ce69d5"
 			}
 		},
 		"metadata": {
@@ -88,7 +88,7 @@
 					"\n",
 					"# spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 115
+				"execution_count": 124
 			},
 			{
 				"cell_type": "markdown",
@@ -127,7 +127,7 @@
 					"%%sql\n",
 					"SET MAX_LEN = 7900"
 				],
-				"execution_count": 117
+				"execution_count": 125
 			},
 			{
 				"cell_type": "markdown",
@@ -194,7 +194,7 @@
 					"\t\n",
 					"-- LIMIT ${MAX_LIMIT}"
 				],
-				"execution_count": 118
+				"execution_count": 126
 			},
 			{
 				"cell_type": "markdown",
@@ -241,7 +241,7 @@
 					"    \n",
 					"FROM odw_curated_db.vw_nsip_s51_advice"
 				],
-				"execution_count": 120
+				"execution_count": 127
 			},
 			{
 				"cell_type": "markdown",
@@ -273,7 +273,7 @@
 					"# %%pyspark\n",
 					"# pip install Faker"
 				],
-				"execution_count": 121
+				"execution_count": 128
 			},
 			{
 				"cell_type": "markdown",
@@ -326,7 +326,7 @@
 					"#         table_loc = \"abfss://odw-curated@\"+storage_account+'nsip_data'\n",
 					"#         df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 122
+				"execution_count": 129
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0345a1d0-14d5-4fa4-acbc-6eccb93e96f2"
+				"spark.autotune.trackingId": "7c6a8558-6ea2-4cb8-8456-af455a42a431"
 			}
 		},
 		"metadata": {
@@ -88,7 +88,46 @@
 					"\n",
 					"# spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 27
+				"execution_count": 115
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"#### Setting a Max Column Length since a dedicated SQL pool only supports upto VARCHAR(8000)\n",
+					"#### \n",
+					"https://learn.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-service-capacity-limits#database-objects\n",
+					""
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"SET MAX_LEN = 7900"
+				],
+				"execution_count": 117
 			},
 			{
 				"cell_type": "markdown",
@@ -121,9 +160,8 @@
 					"collapsed": false
 				},
 				"source": [
-					"%%sql\n",
 					"\n",
-					"---TEST TEST TEST----\n",
+					"%%sql\n",
 					"\n",
 					"CREATE OR REPLACE VIEW odw_curated_db.vw_nsip_s51_advice\n",
 					"\n",
@@ -140,10 +178,14 @@
 					"    AD.EnquirerOrganisation                                 AS agent,\n",
 					"    AD.EnquiryMethod                                        AS method,\n",
 					"    AD.EnquiryDate                                          AS enquiryDate,\n",
-					"    AD.Enquiry                                              AS enquiryDetails,\n",
+					"    SUBSTRING(AD.Enquiry, 1, ${MAX_LEN})                    AS enquiryDetails1,\n",
+					"    SUBSTRING(AD.Enquiry, ${MAX_LEN}+1, ${MAX_LEN})         AS enquiryDetails2,\n",
+					"    SUBSTRING(AD.Enquiry, (${MAX_LEN}*2)+1, ${MAX_LEN})     AS enquiryDetails3,\n",
 					"    AD.AdviceFrom                                           AS adviceGivenBy,\n",
 					"    AD.AdviceStatus                                         AS adviceDate,\n",
-					"    AD.Advice                                               AS adviceDetails,\n",
+					"    SUBSTRING(AD.Advice, 1, ${MAX_LEN})                     AS adviceDetails1,\n",
+					"    SUBSTRING(AD.Advice, ${MAX_LEN}+1, ${MAX_LEN})          AS adviceDetails2,\n",
+					"    SUBSTRING(AD.Advice, (${MAX_LEN}*2)+1, ${MAX_LEN})      AS adviceDetails3,\n",
 					"    AD.AdviceStatus                                         AS status,\n",
 					"    \"unredacted\"                                            AS redactionStatus,\n",
 					"    AD.AttachmentID                                         AS attachmentIds\n",
@@ -152,7 +194,7 @@
 					"\t\n",
 					"-- LIMIT ${MAX_LIMIT}"
 				],
-				"execution_count": 28
+				"execution_count": 118
 			},
 			{
 				"cell_type": "markdown",
@@ -187,8 +229,6 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"---TEST TEST TEST----\n",
-					"\n",
 					"CREATE OR REPLACE TABLE odw_curated_db.nsip_s51_advice\n",
 					"\n",
 					"USING delta\n",
@@ -201,7 +241,7 @@
 					"    \n",
 					"FROM odw_curated_db.vw_nsip_s51_advice"
 				],
-				"execution_count": 29
+				"execution_count": 120
 			},
 			{
 				"cell_type": "markdown",
@@ -233,7 +273,7 @@
 					"# %%pyspark\n",
 					"# pip install Faker"
 				],
-				"execution_count": 30
+				"execution_count": 121
 			},
 			{
 				"cell_type": "markdown",
@@ -286,7 +326,7 @@
 					"#         table_loc = \"abfss://odw-curated@\"+storage_account+'nsip_data'\n",
 					"#         df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 31
+				"execution_count": 122
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
