### PR TITLE
Fix/service user publishing

### DIFF
--- a/workspace/notebook/service_user_dim.json
+++ b/workspace/notebook/service_user_dim.json
@@ -1,0 +1,524 @@
+{
+	"name": "service_user_dim",
+	"properties": {
+		"folder": {
+			"name": "odw-harmonised/Casework"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "03346430-b4f5-4d7f-bb72-c94f6020bd41"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Build comment_type_reference_dim table\r\n",
+					"-- Gets modified or deleted from source rows\r\n",
+					"\r\n",
+					"CREATE OR REPLACE TEMPORARY VIEW casework_case_involvement_dim_new\r\n",
+					"\r\n",
+					"    AS\r\n",
+					"\r\n",
+					"-- gets data that matches of SourceID and flags that it is modified based on a row (md5) hash. Flags as \"NewData\"\r\n",
+					"-- gets data that is in the target but not in source. Flags as \"DeletedData\"\r\n",
+					"\r\n",
+					"SELECT DISTINCT\r\n",
+					"    CASE\r\n",
+					"        WHEN T3.casereference IS NULL\r\n",
+					"        THEN T1.CaseInvolvementID\r\n",
+					"        ELSE NULL\r\n",
+					"    END                                 AS CaseInvolvementID, -- surrogate key\r\n",
+					"    T3.id                               AS ContactID,\r\n",
+					"    T3.casereference                    AS CaseReference,\r\n",
+					"    T3.sourcesuid                       AS SUAreaID,\r\n",
+					"    T3.salutation                       AS Salutation,\r\n",
+					"    T3.firstname                        AS FirstName, \r\n",
+					"    T3.lastname                         AS LastName,\r\n",
+					"    T3.addressline1                     AS AddressLine1,\r\n",
+					"    T3.addressline2                     AS AddressLine2,\r\n",
+					"    T3.addresstown                      AS AddressTown,\r\n",
+					"    T3.addresscounty                    AS AddressCounty,\r\n",
+					"    T3.postcode                         AS Postcode,\r\n",
+					"    'United Kingdom'                    AS AddressCountry,\r\n",
+					"    T3.organisation                     AS Organisation,\r\n",
+					"    T3.organisationtype                 AS OrganisationType,\r\n",
+					"    T3.serviceusertype                  AS ServiceUserType,\r\n",
+					"    T3.role                             AS Role,\r\n",
+					"    T3.telephonenumber                  AS TelephoneNumber,\r\n",
+					"    T3.otherphonenumber                 AS OtherPhoneNumber,\r\n",
+					"    T3.faxnumber                        AS FaxNumber,\r\n",
+					"    T3.emailaddress                     AS EmailAddress,\r\n",
+					"    '1'                                 AS Migrated,\r\n",
+					"    T3.sourcesystem                     AS ODTSourceSystem,\r\n",
+					"    T2.SourceSystemID                   AS SourceSystemID, -- NOT CORRECT\r\n",
+					"    to_timestamp(T3.ingested_datetime)  AS IngestionDate,\r\n",
+					"    NULL                                AS ValidTo,\r\n",
+					"    md5(\r\n",
+					"        concat(\r\n",
+					"            IFNULL(T3.casereference,'.'), \r\n",
+					"            IFNULL(T3.id, '.'),\r\n",
+					"            IFNULL(T3.firstname,'.'), \r\n",
+					"            IFNULL(T3.lastname,'.'), \r\n",
+					"            IFNULL(T3.emailaddress,'.'), \r\n",
+					"            IFNULL(T3.postcode,'.'),\r\n",
+					"            IFNULL(T3.organisation,'.'),\r\n",
+					"            IFNULL(T3.serviceusertype,'.')\r\n",
+					"        ))                          AS RowID,\r\n",
+					"    'Y'                             AS IsActive,\r\n",
+					"    T1.IsActive                     AS HistoricIsActive\r\n",
+					"\r\n",
+					"FROM odw_harmonised_db.casework_case_involvement_dim T1\r\n",
+					"LEFT JOIN odw_harmonised_db.main_sourcesystem_fact T2 \r\n",
+					"    ON T1.SourceSystemID = T2.SourceSystemID\r\n",
+					"FULL JOIN odw_standardised_db.service_user T3 \r\n",
+					"    ON T1.CaseReference = T3.casereference\r\n",
+					"        AND T1.ContactID = T3.id\r\n",
+					"        AND T1.IsActive = 'Y'\r\n",
+					"\r\n",
+					"WHERE\r\n",
+					"    (-- flags new data        \r\n",
+					"        (CASE\r\n",
+					"            WHEN T3.casereference = T1.CaseReference \r\n",
+					"            AND md5(\r\n",
+					"                concat(\r\n",
+					"                    IFNULL(T3.casereference,'.'),\r\n",
+					"                    IFNULL(T3.id, '.'),\r\n",
+					"                    IFNULL(T3.firstname,'.'), \r\n",
+					"                    IFNULL(T3.lastname,'.'), \r\n",
+					"                    IFNULL(T3.emailaddress,'.'), \r\n",
+					"                    IFNULL(T3.postcode,'.'),\r\n",
+					"                    IFNULL(T3.organisation,'.'),\r\n",
+					"                    IFNULL(T3.serviceusertype,'.')\r\n",
+					"                )) <> T1.RowID\r\n",
+					"            THEN 'Y'\r\n",
+					"            WHEN T1.CaseInvolvementID IS NULL\r\n",
+					"            THEN 'Y'\r\n",
+					"            ELSE 'N'\r\n",
+					"        END  = 'Y' )\r\n",
+					"    )\r\n",
+					"    AND T3.casereference IS NOT NULL\r\n",
+					"    AND T3.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.service_user)\r\n",
+					";\r\n",
+					""
+				],
+				"execution_count": 3
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Create new and updated dataset\r\n",
+					"\r\n",
+					"CREATE OR REPLACE TEMPORARY  VIEW casework_case_involvement_dim_changed_rows\r\n",
+					"\r\n",
+					"    AS\r\n",
+					"\r\n",
+					"-- gets updated, deleted and new rows \r\n",
+					"\r\n",
+					"Select\r\n",
+					"    CaseInvolvementID,\r\n",
+					"    ContactID,\r\n",
+					"    CaseReference,\r\n",
+					"    SUAreaID,\r\n",
+					"    Salutation,\r\n",
+					"    FirstName,\r\n",
+					"    LastName,\r\n",
+					"    AddressLine1,\r\n",
+					"    AddressLine2,\r\n",
+					"    AddressTown,\r\n",
+					"    AddressCounty,\r\n",
+					"    Postcode,\r\n",
+					"    AddressCountry,\r\n",
+					"    Organisation,\r\n",
+					"    OrganisationType,\r\n",
+					"    ServiceUserType,\r\n",
+					"    Role,\r\n",
+					"    TelephoneNumber,\r\n",
+					"    OtherPhoneNumber,\r\n",
+					"    FaxNumber,\r\n",
+					"    EmailAddress,\r\n",
+					"    Migrated,\r\n",
+					"    ODTSourceSystem,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"From casework_case_involvement_dim_new WHERE HistoricIsActive = 'Y' or HistoricIsActive IS NULL\r\n",
+					"\r\n",
+					"    UNION ALL\r\n",
+					"\r\n",
+					"-- gets original versions of updated rows so we can update EndDate and set IsActive flag to 'N'\r\n",
+					"\r\n",
+					"SELECT\r\n",
+					"    CaseInvolvementID,\r\n",
+					"    ContactID,\r\n",
+					"    CaseReference,\r\n",
+					"    SUAreaID,\r\n",
+					"    Salutation,\r\n",
+					"    FirstName,\r\n",
+					"    LastName,\r\n",
+					"    AddressLine1,\r\n",
+					"    AddressLine2,\r\n",
+					"    AddressTown,\r\n",
+					"    AddressCounty,\r\n",
+					"    Postcode,\r\n",
+					"    AddressCountry,\r\n",
+					"    Organisation,\r\n",
+					"    OrganisationType,\r\n",
+					"    ServiceUserType,\r\n",
+					"    Role,\r\n",
+					"    TelephoneNumber,\r\n",
+					"    OtherPhoneNumber,\r\n",
+					"    FaxNumber,\r\n",
+					"    EmailAddress,\r\n",
+					"    Migrated,\r\n",
+					"    ODTSourceSystem,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"FROM odw_harmonised_db.casework_case_involvement_dim T1\r\n",
+					"WHERE CaseReference IN (SELECT CaseReference FROM casework_case_involvement_dim_new WHERE CaseInvolvementID IS NULL) \r\n",
+					"    AND ContactID IN (SELECT ContactID FROM casework_case_involvement_dim_new WHERE CaseReference = T1.CaseReference AND CaseReference IS NULL)\r\n",
+					"    AND IsActive = 'Y'; \r\n",
+					""
+				],
+				"execution_count": 5
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"CREATE OR REPLACE TEMPORARY VIEW Loading_month\n",
+					"\n",
+					"    AS\n",
+					"\n",
+					"SELECT DISTINCT\n",
+					"    IngestionDate AS IngestionDate,\n",
+					"    to_timestamp(date_sub(IngestionDate,1)) AS ClosingDate,\n",
+					"    'Y' AS IsActive\n",
+					"\n",
+					"FROM casework_case_involvement_dim_new;\n",
+					"\n",
+					"CREATE OR REPLACE TEMPORARY VIEW casework_case_involvement_dim_changed_rows_final\n",
+					"\n",
+					"    AS\n",
+					"\n",
+					"SELECT \n",
+					"    CaseInvolvementID,\n",
+					"    ContactID,\n",
+					"    CaseReference,\n",
+					"    SUAreaID,\n",
+					"    Salutation,\n",
+					"    FirstName,\n",
+					"    LastName,\n",
+					"    AddressLine1,\n",
+					"    AddressLine2,\n",
+					"    AddressTown,\n",
+					"    AddressCounty,\n",
+					"    Postcode,\n",
+					"    AddressCountry,\n",
+					"    Organisation,\n",
+					"    OrganisationType,\n",
+					"    ServiceUserType,\n",
+					"    Role,\n",
+					"    TelephoneNumber,\n",
+					"    OtherPhoneNumber,\n",
+					"    FaxNumber,\n",
+					"    EmailAddress,\n",
+					"    Migrated,\n",
+					"    ODTSourceSystem,\n",
+					"    T1.SourceSystemID,\n",
+					"    T1.IngestionDate,\n",
+					"    T1.ValidTo,\n",
+					"    T1.RowID,\n",
+					"    T1.IsActive,\n",
+					"    T2.ClosingDate\n",
+					"FROM casework_case_involvement_dim_changed_rows T1\n",
+					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive\n",
+					";"
+				],
+				"execution_count": 7
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"TokenLibrary"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"\n",
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM casework_case_involvement_dim_changed_rows_final;\n",
+					""
+				],
+				"execution_count": 11
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"\r\n",
+					"-- merge into fact table\r\n",
+					"\r\n",
+					"MERGE INTO odw_harmonised_db.casework_case_involvement_dim AS Target\r\n",
+					"USING casework_case_involvement_dim_changed_rows_final AS Source\r\n",
+					"\r\n",
+					"ON Source.CaseInvolvementID = Target.CaseInvolvementID\r\n",
+					"\r\n",
+					"-- For Updates existing rows\r\n",
+					"WHEN MATCHED\r\n",
+					"    THEN \r\n",
+					"    UPDATE SET\r\n",
+					"    Target.ValidTo = to_timestamp(ClosingDate),\r\n",
+					"    Target.IsActive = 'N'\r\n",
+					"\r\n",
+					"-- Insert completely new rows\r\n",
+					"WHEN NOT MATCHED \r\n",
+					"    THEN INSERT (CaseInvolvementID,\r\n",
+					"        ContactID,\r\n",
+					"        CaseReference,\r\n",
+					"        SUAreaID,\r\n",
+					"        Salutation,\r\n",
+					"        FirstName,\r\n",
+					"        LastName,\r\n",
+					"        AddressLine1,\r\n",
+					"        AddressLine2,\r\n",
+					"        AddressTown,\r\n",
+					"        AddressCounty,\r\n",
+					"        Postcode,\r\n",
+					"        AddressCountry,\r\n",
+					"        Organisation,\r\n",
+					"        OrganisationType,\r\n",
+					"        ServiceUserType,\r\n",
+					"        Role,\r\n",
+					"        TelephoneNumber,\r\n",
+					"        OtherPhoneNumber,\r\n",
+					"        FaxNumber,\r\n",
+					"        EmailAddress,\r\n",
+					"        Migrated,\r\n",
+					"        ODTSourceSystem,\r\n",
+					"        SourceSystemID,\r\n",
+					"        IngestionDate,\r\n",
+					"        ValidTo,\r\n",
+					"        RowID,\r\n",
+					"        IsActive)  \r\n",
+					"        VALUES (Source.CaseInvolvementID,\r\n",
+					"        Source.ContactID,\r\n",
+					"        Source.CaseReference,\r\n",
+					"        Source.SUAreaID,\r\n",
+					"        Source.Salutation,\r\n",
+					"        Source.FirstName,\r\n",
+					"        Source.LastName,\r\n",
+					"        Source.AddressLine1,\r\n",
+					"        Source.AddressLine2,\r\n",
+					"        Source.AddressTown,\r\n",
+					"        Source.AddressCounty,\r\n",
+					"        Source.Postcode,\r\n",
+					"        Source.AddressCountry,\r\n",
+					"        Source.Organisation,\r\n",
+					"        Source.OrganisationType,\r\n",
+					"        Source.ServiceUserType,\r\n",
+					"        Source.Role,\r\n",
+					"        Source.TelephoneNumber,\r\n",
+					"        Source.OtherPhoneNumber,\r\n",
+					"        Source.FaxNumber,\r\n",
+					"        Source.EmailAddress,\r\n",
+					"        Source.Migrated,\r\n",
+					"        Source.ODTSourceSystem,\r\n",
+					"        Source.SourceSystemID, \r\n",
+					"        Source.IngestionDate, \r\n",
+					"        Source.ValidTo, \r\n",
+					"        Source.RowID, \r\n",
+					"        Source.IsActive)\r\n",
+					";  "
+				],
+				"execution_count": 9
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Insert new SXOID\r\n",
+					"\r\n",
+					"INSERT OVERWRITE odw_harmonised_db.casework_case_involvement_dim\r\n",
+					"\r\n",
+					"SELECT \r\n",
+					"    ROW_NUMBER() OVER (ORDER BY CaseInvolvementID NULLS LAST) AS CaseInvolvementID,\r\n",
+					"    ContactID,\r\n",
+					"    CaseReference,\r\n",
+					"    SUAreaID,\r\n",
+					"    Salutation,\r\n",
+					"    FirstName,\r\n",
+					"    LastName,\r\n",
+					"    AddressLine1,\r\n",
+					"    AddressLine2,\r\n",
+					"    AddressTown,\r\n",
+					"    AddressCounty,\r\n",
+					"    Postcode,\r\n",
+					"    AddressCountry,\r\n",
+					"    Organisation,\r\n",
+					"    OrganisationType,\r\n",
+					"    ServiceUserType,\r\n",
+					"    Role,\r\n",
+					"    TelephoneNumber,\r\n",
+					"    OtherPhoneNumber,\r\n",
+					"    FaxNumber,\r\n",
+					"    EmailAddress,\r\n",
+					"    Migrated,\r\n",
+					"    ODTSourceSystem,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"FROM odw_harmonised_db.casework_case_involvement_dim;\r\n",
+					""
+				],
+				"execution_count": 10
+			}
+		]
+	}
+}

--- a/workspace/pipeline/0_Horizon_Case_Involvement.json
+++ b/workspace/pipeline/0_Horizon_Case_Involvement.json
@@ -1,0 +1,446 @@
+{
+	"name": "0_Horizon_Case_Involvement",
+	"properties": {
+		"description": "Pipeline to ingest service user information into Raw",
+		"activities": [
+			{
+				"name": "HZN_Case_Involvement",
+				"description": "This is getting the case involvement information using a SQL query. The purpose of this data is to be used in conjunction with Zendesk data for the Service User entity",
+				"type": "Copy",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [
+					{
+						"name": "Source",
+						"value": "dbo.Horizon_CaseReference"
+					},
+					{
+						"name": "Destination",
+						"value": "odw-raw/@{concat('Horizon', '/', formatDateTime(utcnow(), 'yyyy-MM-dd'))}/@{'<FileName>'}"
+					}
+				],
+				"typeProperties": {
+					"source": {
+						"type": "AzureSqlSource",
+						"sqlReaderQuery": "WITH cases AS\n(\nSELECT DISTINCT\n      cases.CaseNodeId, \n\t  dtree.SubType,  \n\t  cases.CaseReference, \n\t  cases.CaseUniqueId \t\t\t\t\t\tAS case_number\n      \nFROM\n      Horizon_CaseReference cases\n      INNER JOIN DTree dtree \t\t\tON cases.CaseNodeId = dtree.DataID\n      INNER JOIN Horizon_TypeOfCase t \tON cases.CaseTypeId = t.ID\nWHERE\n\t  dtree.OwnerID != '-235834' \t-- Recycle bin ownerid\n)\n,\ncase_involvement(DataId, ContactID, ContactDetails, TypeOfInvolvement) AS\n       (SELECT DISTINCT d.DataId AS DataId, ll1.ValStr AS [ContactID], ll2.ValStr AS [ContactDetails], ll3.ValStr AS [TypeOfInvolvement]\n       FROM DTree d\n\t\t   INNER JOIN llattrdata ll1 ON d.DataId = ll1.Id\n\t\t   INNER JOIN llattrdata ll2 ON d.DataId = ll2.Id\n\t\t   INNER JOIN llattrdata ll3 ON d.DataId = ll3.Id\n       WHERE\n\t\t   ll1.DefId = 95501 AND ll1.AttrId = 20\n\t\t   AND ll2.DefId = 95501 AND ll2.AttrId = 19\n\t\t   AND ll3.DefId = 95501 AND ll3.AttrId = 3 \n\t\t   AND ll1.ParentKeyId = ll2.ParentKeyId\n\t\t   AND ll1.ParentKeyId = ll3.ParentKeyId)\n\nSELECT\n\tcr.case_number,\n\tD.CreateDate as case_created_date,\n\tci.ContactID,\n\tci.TypeOfInvolvement,\n\tv.ContactType,\n\tv.FirstName,\n\tv.LastName,\n\tv.PostName,\n\tv.Title,\n\tv.Salutation,\n\tv.Suffix,\n\tv.POBox,\n\tv.Address1,\n\tv.Address2,\n\tv.City,\n\tv.County,\n\tv.Postcode,\n\tv.Country,\n\tv.TelephoneOffice,\n\tv.TelephoneMobile,\n\tv.Fax,\n\tv.Email,\n\tv.LPACode,\n\tv.OrganisationName,\n\tt.OrganisationTypeName\nFROM \n\tcases cr WITH (NOLOCK)\n\t\tINNER JOIN DTree D  WITH (NOLOCK) ON cr.CaseNodeId = D.DataID\n\t\tINNER JOIN case_involvement ci on D.DataID = ci.DataId\n\t\tLEFT JOIN [dbo].[Horizon_vw_AllContacts] v on ci.ContactID =v.Id\n\t\tLEFT JOIN Contacts_OrganisationType t on v.OrganisationTypeID = t.ID",
+						"queryTimeout": "02:00:00",
+						"isolationLevel": "ReadCommitted",
+						"partitionOption": "None"
+					},
+					"sink": {
+						"type": "DelimitedTextSink",
+						"storeSettings": {
+							"type": "AzureBlobFSWriteSettings"
+						},
+						"formatSettings": {
+							"type": "DelimitedTextWriteSettings",
+							"quoteAllText": true,
+							"fileExtension": ".txt"
+						}
+					},
+					"enableStaging": false,
+					"translator": {
+						"type": "TabularTranslator",
+						"mappings": [
+							{
+								"source": {
+									"name": "case_number",
+									"type": "Int32",
+									"physicalType": "int"
+								},
+								"sink": {
+									"name": "case_number",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "case_created_date",
+									"type": "DateTime",
+									"physicalType": "datetime"
+								},
+								"sink": {
+									"name": "case_created_date",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "ContactID",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "ContactID",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "TypeOfInvolvement",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "TypeOfInvolvement",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "ContactType",
+									"type": "String",
+									"physicalType": "varchar"
+								},
+								"sink": {
+									"name": "ContactType",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "FirstName",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "FirstName",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "LastName",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "LastName",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "PostName",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "PostName",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Title",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Title",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Salutation",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Salutation",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Suffix",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Suffix",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "POBox",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "POBox",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Address1",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Address1",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Address2",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Address2",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "City",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "City",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "County",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "County",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Postcode",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Postcode",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Country",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Country",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "TelephoneOffice",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "TelephoneOffice",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "TelephoneMobile",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "TelephoneMobile",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Fax",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Fax",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "Email",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "Email",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "LPACode",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "LPACode",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "OrganisationName",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "OrganisationName",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
+									"name": "OrganisationTypeName",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "OrganisationTypeName",
+									"type": "String",
+									"physicalType": "String"
+								}
+							}
+						],
+						"typeConversion": true,
+						"typeConversionSettings": {
+							"allowDataTruncation": true,
+							"treatBooleanAsNumber": false
+						}
+					}
+				},
+				"inputs": [
+					{
+						"referenceName": "AzureSqlTable2",
+						"type": "DatasetReference"
+					}
+				],
+				"outputs": [
+					{
+						"referenceName": "Horizon_Case_Involvement",
+						"type": "DatasetReference",
+						"parameters": {
+							"FileName": "CaseInvolvement.csv"
+						}
+					}
+				]
+			},
+			{
+				"name": "Case_Involvement_Data_Copy_Failure",
+				"description": "The copy activity from Horizon has failed",
+				"type": "Fail",
+				"dependsOn": [
+					{
+						"activity": "HZN_Case_Involvement",
+						"dependencyConditions": [
+							"Failed"
+						]
+					}
+				],
+				"userProperties": [
+					{
+						"name": "Michael Cross",
+						"value": "michael.cross@planninginspectorate.gov.uk"
+					}
+				],
+				"typeProperties": {
+					"message": "Case Involvement copy to Raw has failed",
+					"errorCode": "HZN_Data_Copy_CaseInvolvement"
+				}
+			},
+			{
+				"name": "Logging Failed Activities",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Case_Involvement_Data_Copy_Failure",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_fail_activity_logging",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"output": {
+							"value": {
+								"value": "@activity('Case_Involvement_Data_Copy_Failure').output.message",
+								"type": "Expression"
+							},
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": false,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			}
+		],
+		"folder": {
+			"name": "casework/layers/0-raw"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_horizon_case_involvement.json
+++ b/workspace/pipeline/pln_horizon_case_involvement.json
@@ -10,7 +10,7 @@
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "0_Horizon_Service_User",
+						"referenceName": "0_Horizon_Case_Involvement",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
