### PR TITLE
Fix/service user publish rename

### DIFF
--- a/workspace/notebook/legacy_service_user_dim.json
+++ b/workspace/notebook/legacy_service_user_dim.json
@@ -1,0 +1,157 @@
+{
+	"name": "legacy_service_user_dim",
+	"properties": {
+		"folder": {
+			"name": "odw-harmonised/Casework/Legacy"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "a2c8835b-e2f8-4d2a-b39d-600e219b9afe"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"-- Build the Service User historic info table\n",
+					"\n",
+					"INSERT OVERWRITE odw_harmonised_db.casework_case_involvement_dim (\n",
+					"    CaseInvolvementID,\n",
+					"    ContactID,\n",
+					"    CaseReference,\n",
+					"    SUAreaID,\n",
+					"    Salutation,\n",
+					"    FirstName,\n",
+					"    LastName,\n",
+					"    AddressLine1,\n",
+					"    AddressLine2,\n",
+					"    AddressTown,\n",
+					"    AddressCounty,\n",
+					"    Postcode,\n",
+					"    AddressCountry,\n",
+					"    Organisation,\n",
+					"    OrganisationType,\n",
+					"    ServiceUserType,\n",
+					"    Role,\n",
+					"    TelephoneNumber,\n",
+					"    OtherPhoneNumber,\n",
+					"    FaxNumber,\n",
+					"    EmailAddress,\n",
+					"    Migrated,\n",
+					"    ODTSourceSystem,\n",
+					"    SourceSystemID,\n",
+					"    IngestionDate,\n",
+					"    ValidTo,\n",
+					"    RowID,\n",
+					"    IsActive\n",
+					")\n",
+					"\n",
+					"SELECT DISTINCT\n",
+					"    Row_Number() OVER (ORDER BY T3.case_number NULLS LAST)  AS CaseInvolvementID, -- surrogate key\n",
+					"    T3.contactid                                            AS ContactID,\n",
+					"    T3.case_number                                          AS CaseReference,\n",
+					"    'LegacyID'                                              AS SUAreaID,\n",
+					"    T3.title                                                AS Salutation,\n",
+					"    T3.firstname                                            AS FirstName, \n",
+					"    T3.lastname                                             AS LastName,\n",
+					"    T3.address1                                             AS AddressLine1,\n",
+					"    T3.address2                                             AS AddressLine2,\n",
+					"    T3.city                                                 AS AddressTown,\n",
+					"    T3.county                                               AS AddressCounty,\n",
+					"    T3.postcode                                             AS Postcode,\n",
+					"    T3.country                                              AS AddressCountry,\n",
+					"    T3.organisationname                                     AS Organisation,\n",
+					"    T3.organisationtypename                                 AS OrganisationType,\n",
+					"    T3.typeofinvolvement                                    AS ServiceUserType,\n",
+					"    'No Info'                                               AS Role,\n",
+					"    T3.telephoneoffice                                      AS TelephoneNumber,\n",
+					"    T3.telephonemobile                                      AS OtherPhoneNumber,\n",
+					"    T3.fax                                                  AS FaxNumber,\n",
+					"    T3.email                                                AS EmailAddress,\n",
+					"    \"0\"                                                     AS Migrated,\n",
+					"    \"Horizon\"                                               AS ODTSourceSystem,\n",
+					"    T2.SourceSystemID                                       AS SourceSystemID,\n",
+					"    to_timestamp(T3.expected_from)                          AS IngestionDate,\n",
+					"    NULL                                                    AS ValidTo,\n",
+					"    md5(\n",
+					"        concat(\n",
+					"            IFNULL(T3.case_number,'.'), \n",
+					"            IFNULL(T3.contactid, '.'),\n",
+					"            IFNULL(T3.firstname,'.'), \n",
+					"            IFNULL(T3.lastname,'.'), \n",
+					"            IFNULL(T3.email,'.'), \n",
+					"            IFNULL(T3.postcode,'.'),\n",
+					"            IFNULL(T3.organisationname,'.'),\n",
+					"            IFNULL(T3.typeofinvolvement,'.')\n",
+					"        ))                                                  AS RowID,\n",
+					"    'Y'                                                     AS IsActive\n",
+					"\n",
+					"FROM odw_standardised_db.horizon_case_involvement T3\n",
+					"LEFT JOIN odw_harmonised_db.main_sourcesystem_fact T2 \n",
+					"    ON \"Casework\" = T2.Description\n",
+					"WHERE T3.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_case_involvement)\n",
+					"\n",
+					";"
+				],
+				"execution_count": 1
+			}
+		]
+	}
+}

--- a/workspace/pipeline/pln_horizon_service_user.json
+++ b/workspace/pipeline/pln_horizon_service_user.json
@@ -1,0 +1,137 @@
+{
+	"name": "pln_horizon_service_user",
+	"properties": {
+		"activities": [
+			{
+				"name": "Src to Raw",
+				"description": "Copies migration data from Horizon to odw-raw",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "0_Horizon_Case_Involvement",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "Raw to Std",
+				"description": "Ingests the raw data into the standardised table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Src to Raw",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_raw_to_std",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"source_folder": {
+							"value": "Horizon",
+							"type": "string"
+						},
+						"specific_file": {
+							"value": "CaseInvolvement",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Std to Hrm",
+				"description": "Ingests data from standardised to harmonised",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Raw to Std",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "casework_case_involvement_dim_legacy",
+						"type": "NotebookReference"
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "Hrm to Cur",
+				"description": "Ingests data from harmonised to curated",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Std to Hrm",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "service_user",
+						"type": "NotebookReference"
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			}
+		],
+		"folder": {
+			"name": "service user"
+		},
+		"annotations": []
+	}
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
