### PR TITLE
backing out website_run_from_package

### DIFF
--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -19,7 +19,6 @@ locals {
       "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"    = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key};EndpointSuffix=core.windows.net"
       "WEBSITE_CONTENTSHARE"                        = var.file_share_name
       "WEBSITE_CONTENTOVERVNET"                     = 1
-      "WEBSITE_RUN_FROM_PACKAGE"                    = 1
     }
   )
 


### PR DESCRIPTION
Backing out the WEBSITE_RUN_FROM_PACKAGE flag as it broke the app and functions were no longer visible.