### PR TITLE
Feat/deploy entites to test

### DIFF
--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f2db6bcd-a662-4fa4-9cfe-abfa01b13d45"
+				"spark.autotune.trackingId": "aecc7a05-cbad-49cd-b868-f397b48a164a"
 			}
 		},
 		"metadata": {
@@ -111,7 +111,7 @@
 					"\n",
 					"FROM odw_harmonised_db.casework_nsip_advice_dim \t        AS AD"
 				],
-				"execution_count": 9
+				"execution_count": 14
 			},
 			{
 				"cell_type": "markdown",
@@ -145,7 +145,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
-				"execution_count": null
+				"execution_count": 15
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "15daf4b6-4c84-44e3-8068-becbca5c9d59"
+				"spark.autotune.trackingId": "f2db6bcd-a662-4fa4-9cfe-abfa01b13d45"
 			}
 		},
 		"metadata": {
@@ -92,26 +92,26 @@
 					"\n",
 					"SELECT DISTINCT\n",
 					"\n",
-					"    AD.NSIPAdviceID\t\t\t\t\t\t\t\t\t\t    AS adviceId,\n",
-					"    AD.AdviceNodeID                                         AS caseId,\n",
+					"    CAST(AD.NSIPAdviceID as INT)\t\t\t\t\t\t    AS adviceId,\n",
+					"    CAST(AD.AdviceNodeID as INT)                            AS caseId,\n",
 					"    AD.AdviceReference\t\t\t\t\t\t\t\t\t    AS adviceReference,\n",
 					"    AD.CaseReference\t\t\t\t\t\t\t\t\t    AS caseReference,\n",
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
 					"    AD.Enquirer                                             AS from,\n",
 					"    AD.EnquirerOrganisation                                 AS agent,\n",
-					"    AD.EnquiryMethod                                        AS method,\n",
+					"    LOWER(AD.EnquiryMethod)                                 AS method,\n",
 					"    AD.EnquiryDate                                          AS enquiryDate,\n",
 					"    AD.Enquiry                                              AS enquiryDetails,\n",
 					"    AD.AdviceFrom                                           AS adviceGivenBy,\n",
-					"    AD.AdviceStatus                                         AS adviceDate,\n",
+					"    AD.AdviceDate                                           AS adviceDate,\n",
 					"    AD.Advice                                               AS adviceDetails,\n",
-					"    AD.AdviceStatus                                         AS status,\n",
+					"    LOWER(AD.AdviceStatus)                                  AS status,\n",
 					"    \"unredacted\"                                            AS redactionStatus,\n",
 					"    AD.AttachmentID                                         AS attachmentIds\n",
 					"\n",
 					"FROM odw_harmonised_db.casework_nsip_advice_dim \t        AS AD"
 				],
-				"execution_count": 12
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -145,7 +145,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
-				"execution_count": 13
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6c3c3bf9-824d-4b40-aa93-20a7d11d7953"
+				"spark.autotune.trackingId": "085f6845-db55-4d62-8a44-0c931c59866e"
 			}
 		},
 		"metadata": {
@@ -62,47 +62,6 @@
 					}
 				},
 				"source": [
-					"## Checking the Environment\n",
-					"#### If dev or test, limiting the number of output rows and anonymisation of the sensitive fields is required."
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"from notebookutils import mssparkutils\n",
-					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
-					"\n",
-					"is_dev = 'dev' in storage_account\n",
-					"is_test = 'test' in storage_account\n",
-					"\n",
-					"# limiting the number of output to 20 rows for dev environment\n",
-					"max_limit = 20 if is_dev else 100000000\n",
-					"\n",
-					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
-				],
-				"execution_count": 5
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"## View odw_curated_db.vw_relevant_representation is created"
 				]
 			},
@@ -125,18 +84,14 @@
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"\r\n",
-					"RR.RelevantRepID                                                       AS representationId,\r\n",
+					"CAST(RR.RelevantRepID AS INT)                                          AS representationId,\r\n",
 					"RR.CaseReference + RR.RelevantRepID                                    AS referenceId,\r\n",
 					"''                                                                     AS examinationLibraryRef,\r\n",
-					"RR.CaseReference                                                       AS caseReference,\r\n",
-					"RR.CaseNodeID                                                          AS caseId,\r\n",
+					"RR.CaseReference                                                       AS caseRef,\r\n",
+					"CAST(RR.CaseNodeID AS INT)                                             AS caseId,\r\n",
 					"RR.RelevantRepStatus                                                   AS Status,\r\n",
 					"RR.RepresentationOriginal                                              AS originalRepresentation,\r\n",
-					"CASE \r\n",
-					"    WHEN RR.RepresentationRedacted IS NULL\r\n",
-					"    THEN '0'\r\n",
-					"    ELSE '1'\r\n",
-					"END                                                                    AS redacted,\r\n",
+					"RR.RepresentationRedacted IS NOT NULL                                  AS redacted,\r\n",
 					"RR.RepresentationRedacted                                              AS redactedRepresentation,\r\n",
 					"RR.RedactedBy                                                          AS redactedBy,\r\n",
 					"RR.Notes                                                               AS redactedNotes,\r\n",
@@ -162,13 +117,9 @@
 					"\r\n",
 					"WHERE RR.ISActive = 'Y'\r\n",
 					"\r\n",
-					"--RR.CaseReference = 'TR020002'\r\n",
-					"\r\n",
-					"\r\n",
-					"\r\n",
-					""
+					"--RR.CaseReference = 'TR020002'"
 				],
-				"execution_count": 6
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -202,7 +153,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_relevant_representation')\r\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.relevant_representation')"
 				],
-				"execution_count": 7
+				"execution_count": 8
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
