### PR TITLE
fix: repoint all objects in linked service and rename it

### DIFF
--- a/workspace/dataset/AzureSqlTable2.json
+++ b/workspace/dataset/AzureSqlTable2.json
@@ -2,7 +2,7 @@
 	"name": "AzureSqlTable2",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/BIS_AddAdditionalData.json
+++ b/workspace/dataset/BIS_AddAdditionalData.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"description": "Connection to the AddAdditinalData view in Horizon",
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/BIS_HZN_AppealsAddtionalData.json
+++ b/workspace/dataset/BIS_HZN_AppealsAddtionalData.json
@@ -2,7 +2,7 @@
 	"name": "BIS_HZN_AppealsAddtionalData",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/CaseReference.json
+++ b/workspace/dataset/CaseReference.json
@@ -2,7 +2,7 @@
 	"name": "CaseReference",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/Contacts_Organisation.json
+++ b/workspace/dataset/Contacts_Organisation.json
@@ -2,7 +2,7 @@
 	"name": "Contacts_Organisation",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/Doc_Folder.json
+++ b/workspace/dataset/Doc_Folder.json
@@ -2,7 +2,7 @@
 	"name": "Doc_Folder",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/Document_Metadata.json
+++ b/workspace/dataset/Document_Metadata.json
@@ -2,7 +2,7 @@
 	"name": "Document_Metadata",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/Folder_Entity.json
+++ b/workspace/dataset/Folder_Entity.json
@@ -2,7 +2,7 @@
 	"name": "Folder_Entity",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZNSpecialCircumstance.json
+++ b/workspace/dataset/HZNSpecialCircumstance.json
@@ -2,7 +2,7 @@
 	"name": "HZNSpecialCircumstance",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"folder": {

--- a/workspace/dataset/HZNSpecialism.json
+++ b/workspace/dataset/HZNSpecialism.json
@@ -2,7 +2,7 @@
 	"name": "HZNSpecialism",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"folder": {

--- a/workspace/dataset/HZN_AdditionalFields.json
+++ b/workspace/dataset/HZN_AdditionalFields.json
@@ -2,7 +2,7 @@
 	"name": "HZN_AdditionalFields",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_AppSubTypeCaseName.json
+++ b/workspace/dataset/HZN_AppSubTypeCaseName.json
@@ -2,7 +2,7 @@
 	"name": "HZN_AppSubTypeCaseName",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_BIS_DecisionIssues.json
+++ b/workspace/dataset/HZN_BIS_DecisionIssues.json
@@ -2,7 +2,7 @@
 	"name": "HZN_BIS_DecisionIssues",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"folder": {

--- a/workspace/dataset/HZN_CaseDates.json
+++ b/workspace/dataset/HZN_CaseDates.json
@@ -2,7 +2,7 @@
 	"name": "HZN_CaseDates",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_CaseInfo.json
+++ b/workspace/dataset/HZN_CaseInfo.json
@@ -2,7 +2,7 @@
 	"name": "HZN_CaseInfo",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_CaseOfficerAddDetail.json
+++ b/workspace/dataset/HZN_CaseOfficerAddDetail.json
@@ -2,7 +2,7 @@
 	"name": "HZN_CaseOfficerAddDetail",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_CommonLand.json
+++ b/workspace/dataset/HZN_CommonLand.json
@@ -2,7 +2,7 @@
 	"name": "HZN_CommonLand",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_EnforcementGroundsForAppeal.json
+++ b/workspace/dataset/HZN_EnforcementGroundsForAppeal.json
@@ -2,7 +2,7 @@
 	"name": "HZN_EnforcementGroundsForAppeal",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"folder": {

--- a/workspace/dataset/HZN_Event.json
+++ b/workspace/dataset/HZN_Event.json
@@ -2,7 +2,7 @@
 	"name": "HZN_Event",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_InspectorCases.json
+++ b/workspace/dataset/HZN_InspectorCases.json
@@ -2,7 +2,7 @@
 	"name": "HZN_InspectorCases",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_LPARResponsability.json
+++ b/workspace/dataset/HZN_LPARResponsability.json
@@ -2,7 +2,7 @@
 	"name": "HZN_LPARResponsability",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"folder": {

--- a/workspace/dataset/HZN_NSIPRedactions.json
+++ b/workspace/dataset/HZN_NSIPRedactions.json
@@ -2,7 +2,7 @@
 	"name": "HZN_NSIPRedactions",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_NSIP_Query.json
+++ b/workspace/dataset/HZN_NSIP_Query.json
@@ -2,7 +2,7 @@
 	"name": "HZN_NSIP_Query",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_ProjInfoInternal.json
+++ b/workspace/dataset/HZN_ProjInfoInternal.json
@@ -2,7 +2,7 @@
 	"name": "HZN_ProjInfoInternal",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecCaseDates.json
+++ b/workspace/dataset/HZN_SpecCaseDates.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecCaseDates",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecCaseString.json
+++ b/workspace/dataset/HZN_SpecCaseString.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecCaseString",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecCoastalAccess.json
+++ b/workspace/dataset/HZN_SpecCoastalAccess.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecCoastalAccess",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecEnvironment.json
+++ b/workspace/dataset/HZN_SpecEnvironment.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecEnvironment",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecHighCourt.json
+++ b/workspace/dataset/HZN_SpecHighCourt.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecHighCourt",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecMods.json
+++ b/workspace/dataset/HZN_SpecMods.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecMods",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecPurchaseNotice.json
+++ b/workspace/dataset/HZN_SpecPurchaseNotice.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecPurchaseNotice",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HZN_SpecRecharge.json
+++ b/workspace/dataset/HZN_SpecRecharge.json
@@ -2,7 +2,7 @@
 	"name": "HZN_SpecRecharge",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HorizonContactInformation.json
+++ b/workspace/dataset/HorizonContactInformation.json
@@ -2,7 +2,7 @@
 	"name": "HorizonContactInformation",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/HorizonData_BIS_AllAppeals.json
+++ b/workspace/dataset/HorizonData_BIS_AllAppeals.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"description": "This is connecting to the AllAppeals view within Horizon",
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"folder": {

--- a/workspace/dataset/Horizon_TypeOfCaseSQL.json
+++ b/workspace/dataset/Horizon_TypeOfCaseSQL.json
@@ -2,7 +2,7 @@
 	"name": "Horizon_TypeOfCaseSQL",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/Hzn_AdvertDetails.json
+++ b/workspace/dataset/Hzn_AdvertDetails.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"description": "Horizon AdvertDetails view to be brought into ODW Raw",
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"folder": {

--- a/workspace/dataset/NSIP_Advice.json
+++ b/workspace/dataset/NSIP_Advice.json
@@ -2,7 +2,7 @@
 	"name": "NSIP_Advice",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_hzn",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/dataset/VW_Inspector_Cases.json
+++ b/workspace/dataset/VW_Inspector_Cases.json
@@ -2,7 +2,7 @@
 	"name": "VW_Inspector_Cases",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "sql_hzn_tables",
+			"referenceName": "ls_preprod_sql_hzn",
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],

--- a/workspace/linkedService/ls_sql_hzn.json
+++ b/workspace/linkedService/ls_sql_hzn.json
@@ -1,5 +1,5 @@
 {
-	"name": "ls_sql_hzn",
+	"name": "ls_preprod_sql_hzn",
 	"type": "Microsoft.Synapse/workspaces/linkedservices",
 	"properties": {
 		"annotations": [],

--- a/workspace/linkedService/sql_hzn_tables.json
+++ b/workspace/linkedService/sql_hzn_tables.json
@@ -1,5 +1,5 @@
 {
-	"name": "sql_hzn_tables",
+	"name": "ls_preprod_sql_hzn",
 	"type": "Microsoft.Synapse/workspaces/linkedservices",
 	"properties": {
 		"description": "Linked Service For Horizon SQL Tables",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
