### PR TITLE
Fix/ls type to sql server table

### DIFF
--- a/workspace/dataset/AzureSqlTable2.json
+++ b/workspace/dataset/AzureSqlTable2.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "CaseUniqueId",

--- a/workspace/dataset/Contacts_Organisation.json
+++ b/workspace/dataset/Contacts_Organisation.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "ID",

--- a/workspace/dataset/Doc_Folder.json
+++ b/workspace/dataset/Doc_Folder.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "OwnerID",

--- a/workspace/dataset/Document_Metadata.json
+++ b/workspace/dataset/Document_Metadata.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "DataId",

--- a/workspace/dataset/Folder_Entity.json
+++ b/workspace/dataset/Folder_Entity.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "id",

--- a/workspace/dataset/HZN_AdditionalFields.json
+++ b/workspace/dataset/HZN_AdditionalFields.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_AppSubTypeCaseName.json
+++ b/workspace/dataset/HZN_AppSubTypeCaseName.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "appeal_reference_number",

--- a/workspace/dataset/HZN_CaseInfo.json
+++ b/workspace/dataset/HZN_CaseInfo.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_CaseOfficerAddDetail.json
+++ b/workspace/dataset/HZN_CaseOfficerAddDetail.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_CommonLand.json
+++ b/workspace/dataset/HZN_CommonLand.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_Event.json
+++ b/workspace/dataset/HZN_Event.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_InspectorCases.json
+++ b/workspace/dataset/HZN_InspectorCases.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_NSIPRedactions.json
+++ b/workspace/dataset/HZN_NSIPRedactions.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "case_reference",

--- a/workspace/dataset/HZN_NSIP_Query.json
+++ b/workspace/dataset/HZN_NSIP_Query.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": []
 	}
 }

--- a/workspace/dataset/HZN_ProjInfoInternal.json
+++ b/workspace/dataset/HZN_ProjInfoInternal.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "CaseReference",

--- a/workspace/dataset/HZN_SpecCaseDates.json
+++ b/workspace/dataset/HZN_SpecCaseDates.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_SpecCaseString.json
+++ b/workspace/dataset/HZN_SpecCaseString.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_SpecCoastalAccess.json
+++ b/workspace/dataset/HZN_SpecCoastalAccess.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_SpecEnvironment.json
+++ b/workspace/dataset/HZN_SpecEnvironment.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_SpecHighCourt.json
+++ b/workspace/dataset/HZN_SpecHighCourt.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_SpecMods.json
+++ b/workspace/dataset/HZN_SpecMods.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_SpecPurchaseNotice.json
+++ b/workspace/dataset/HZN_SpecPurchaseNotice.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HZN_SpecRecharge.json
+++ b/workspace/dataset/HZN_SpecRecharge.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",

--- a/workspace/dataset/HorizonContactInformation.json
+++ b/workspace/dataset/HorizonContactInformation.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": []
 	}
 }

--- a/workspace/dataset/Horizon_TypeOfCaseSQL.json
+++ b/workspace/dataset/Horizon_TypeOfCaseSQL.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "ID",

--- a/workspace/dataset/VW_Inspector_Cases.json
+++ b/workspace/dataset/VW_Inspector_Cases.json
@@ -6,7 +6,7 @@
 			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
-		"type": "AzureSqlTable",
+		"type": "SqlServerTable",
 		"schema": [
 			{
 				"name": "AppealRefNumber",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
