### PR TITLE
Pg/s51 fix

### DIFF
--- a/workspace/notebook/py_raw_to_std.json
+++ b/workspace/notebook/py_raw_to_std.json
@@ -45,8 +45,7 @@
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28,
-				"automaticScaleJobs": false
+				"memory": 28
 			},
 			"sessionKeepAliveTimeout": 30
 		},

--- a/workspace/notebook/py_raw_to_std.json
+++ b/workspace/notebook/py_raw_to_std.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "11fb5991-aac9-483a-9800-6877b5823f1d"
+				"spark.autotune.trackingId": "d2e3a870-767c-4c62-838e-3212a9abfd81"
 			}
 		},
 		"metadata": {
@@ -45,7 +45,8 @@
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -98,7 +99,7 @@
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"raw_container = \"abfss://odw-raw@\" + storage_account"
 				],
-				"execution_count": 35
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -116,7 +117,7 @@
 				"source": [
 					"%run \"1-odw-raw-to-standardised/Fileshare/SAP_HR/py_1_raw_to_standardised_hr_functions\""
 				],
-				"execution_count": 36
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -156,7 +157,7 @@
 					"\n",
 					"delete_existing_table=False"
 				],
-				"execution_count": 37
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -202,7 +203,7 @@
 					"    \n",
 					"    return max(fpaths, key=get_creation_date).replace(path, '')"
 				],
-				"execution_count": 38
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -266,7 +267,7 @@
 					"except Exception as e:  \n",
 					"   print('Raw data unavailable', e)"
 				],
-				"execution_count": 39
+				"execution_count": 5
 			}
 		]
 	}

--- a/workspace/pipeline/pln_service_bus_nsip_s51_advice.json
+++ b/workspace/pipeline/pln_service_bus_nsip_s51_advice.json
@@ -29,7 +29,7 @@
 					},
 					"parameters": {
 						"source_folder": {
-							"value": "ServiceBus",
+							"value": "ServiceBus/nsip-s51-advice",
 							"type": "string"
 						},
 						"source_frequency_folder": {
@@ -46,40 +46,6 @@
 							},
 							"type": "string"
 						}
-					},
-					"snapshot": true,
-					"conf": {
-						"spark.dynamicAllocation.enabled": null,
-						"spark.dynamicAllocation.minExecutors": null,
-						"spark.dynamicAllocation.maxExecutors": null
-					},
-					"numExecutors": null
-				}
-			},
-			{
-				"name": "Std to Hrm",
-				"description": "Ingests the standardised data into the harmonised table",
-				"type": "SynapseNotebook",
-				"dependsOn": [
-					{
-						"activity": "Raw to Std",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"notebook": {
-						"referenceName": "casework_nsip_advice_dim",
-						"type": "NotebookReference"
 					},
 					"snapshot": true,
 					"conf": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
