### PR TITLE
Mvg/fix/relev rep curated

### DIFF
--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cdfc8212-5a94-4a92-b692-8180a89ba537"
+				"spark.autotune.trackingId": "f849936e-b919-4e8f-9bcd-576b85443345"
 			}
 		},
 		"metadata": {
@@ -79,8 +79,8 @@
 				"source": [
 					"%%sql\r\n",
 					"\r\n",
-					"-- CREATE OR REPLACE VIEW odw_curated_db.vw_relevant_representation\r\n",
-					"-- AS\r\n",
+					"CREATE OR REPLACE VIEW odw_curated_db.vw_relevant_representation\r\n",
+					"AS\r\n",
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"\r\n",
@@ -127,7 +127,7 @@
 					"\r\n",
 					"WHERE RR.ISActive = 'Y'"
 				],
-				"execution_count": 7
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -161,7 +161,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_relevant_representation')\r\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.relevant_representation')"
 				],
-				"execution_count": 2
+				"execution_count": 9
 			}
 		]
 	}

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1c07e466-bae9-4c70-8050-ef1f2cffe6fc"
+				"spark.autotune.trackingId": "cdfc8212-5a94-4a92-b692-8180a89ba537"
 			}
 		},
 		"metadata": {
@@ -72,20 +72,20 @@
 						"language": "sparksql"
 					},
 					"jupyter": {
-						"outputs_hidden": true
+						"outputs_hidden": false
 					},
 					"collapsed": false
 				},
 				"source": [
 					"%%sql\r\n",
 					"\r\n",
-					"CREATE OR REPLACE VIEW odw_curated_db.vw_relevant_representation\r\n",
-					"AS\r\n",
+					"-- CREATE OR REPLACE VIEW odw_curated_db.vw_relevant_representation\r\n",
+					"-- AS\r\n",
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"\r\n",
 					"CAST(RR.RelevantRepID AS INT)                                          AS representationId,\r\n",
-					"RR.CaseReference + RR.RelevantRepID                                    AS referenceId,\r\n",
+					"concat(RR.CaseReference,RR.RelevantRepID)                              AS referenceId,\r\n",
 					"''                                                                     AS examinationLibraryRef,\r\n",
 					"RR.CaseReference                                                       AS caseRef,\r\n",
 					"CAST(RR.CaseNodeID AS INT)                                             AS caseId,\r\n",
@@ -127,7 +127,7 @@
 					"\r\n",
 					"WHERE RR.ISActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
