### PR TITLE
Mvg/fix/rr status

### DIFF
--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6211a03e-cf28-47e6-845e-8062703d0e64"
+				"spark.autotune.trackingId": "c808326b-c1f8-477b-872e-7cb67b5e5584"
 			}
 		},
 		"metadata": {
@@ -89,7 +89,15 @@
 					"''                                                                     AS examinationLibraryRef,\r\n",
 					"RR.CaseReference                                                       AS caseRef,\r\n",
 					"CAST(RR.CaseNodeID AS INT)                                             AS caseId,\r\n",
-					"RR.RelevantRepStatus                                                   AS status,\r\n",
+					"CASE\r\n",
+					"    WHEN RR.RelevantRepStatus = 'New' OR RR.RelevantRepStatus = 'In Progress'                                                   \r\n",
+					"    THEN 'awaiting_review'\r\n",
+					"    WHEN RR.RelevantRepStatus = 'Complete'\r\n",
+					"    THEN 'valid'\r\n",
+					"    WHEN RR.RelevantRepStatus = 'Do Not Publish'\r\n",
+					"    THEN 'invalid'\r\n",
+					"    ELSE LOWER(RR.RelevantRepStatus)\r\n",
+					"END                                                                    AS status,\r\n",
 					"RR.RepresentationOriginal                                              AS originalRepresentation,\r\n",
 					"RR.RepresentationRedacted IS NOT NULL                                  AS redacted,\r\n",
 					"RR.RepresentationRedacted                                              AS redactedRepresentation,\r\n",
@@ -132,7 +140,7 @@
 					"    ON SU2.ID = RR.AgentContactID\r\n",
 					"WHERE RR.ISActive = 'Y'"
 				],
-				"execution_count": 19
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c808326b-c1f8-477b-872e-7cb67b5e5584"
+				"spark.autotune.trackingId": "7e3d3a04-478a-4559-a5cd-7e4285f5c5e9"
 			}
 		},
 		"metadata": {
@@ -140,95 +140,7 @@
 					"    ON SU2.ID = RR.AgentContactID\r\n",
 					"WHERE RR.ISActive = 'Y'"
 				],
-				"execution_count": 1
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.vw_relevant_representation WHERE representationId ='30225';\n",
-					"SELECT DISTINCT(representationType) FROM odw_curated_db.vw_relevant_representation;\n",
-					"\n",
-					"-- SELECT * FROM odw_curated_db.vw_relevant_representation WHERE caseRef = 'TR020002' AND representativeID = '33307';\n",
-					"\n",
-					"-- SELECT DISTINCT(status) FROM odw_curated_db.vw_relevant_representation;\n",
-					"\n",
-					"-- SELECT count(*) FROM odw_curated_db.nsip_service_user WHERE caseReference = 'TR020002';\n",
-					"\n",
-					"-- SELECT count(*) FROM odw_harmonised_db.casework_nsip_relevant_representation_dim WHERE CaseReference = 'TR020002';\n",
-					"\n",
-					"-- SELECT count(*) FROM odw_curated_db.vw_relevant_representation WHERE caseRef = 'TR020002'; --- it should be 2210\n",
-					"\n",
-					"-- SELECT count(*) FROM odw_curated_db.vw_relevant_representation\n",
-					"-- WHERE caseRef = 'TR020002'\n",
-					"-- AND status = 'Published'; --- it should be 2052\n",
-					"\n",
-					"-- SELECT count(*) FROM odw_curated_db.vw_relevant_representation\n",
-					"-- WHERE caseRef = 'TR020002' AND (representativeId is not null OR representativeId != ''); --- should be 53\n",
-					"\n",
-					"-- SELECT count(*) FROM odw_curated_db.vw_relevant_representation\n",
-					"-- WHERE caseRef = 'TR020002'\n",
-					"-- AND representationFrom = 'AGENT'; --- should be 53\n",
-					""
-				],
-				"execution_count": 20
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT count(*) \n",
-					"FROM odw_curated_db.nsip_service_user \n",
-					"WHERE caseReference = 'TR020002' \n",
-					"    AND ID NOT IN (\n",
-					"        SELECT ContactID \n",
-					"        FROM odw_harmonised_db.casework_nsip_relevant_representation_dim \n",
-					"        WHERE CaseReference = 'TR020002');\n",
-					"\n",
-					"\n",
-					"SELECT * \n",
-					"FROM odw_curated_db.nsip_service_user \n",
-					"WHERE caseReference = 'TR020002' \n",
-					"    AND ID NOT IN (\n",
-					"        SELECT ContactID \n",
-					"        FROM odw_harmonised_db.casework_nsip_relevant_representation_dim \n",
-					"        WHERE CaseReference = 'TR020002');\n",
-					"\n",
-					""
-				],
-				"execution_count": 21
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -262,7 +174,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_relevant_representation')\r\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.relevant_representation')"
 				],
-				"execution_count": 22
+				"execution_count": 5
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
