### PR TITLE
Updating linkedService: ls_preprod_sql_hzn

### DIFF
--- a/workspace/linkedService/ls_preprod_sql_hzn.json
+++ b/workspace/linkedService/ls_preprod_sql_hzn.json
@@ -1,7 +1,12 @@
 {
 	"name": "ls_preprod_sql_hzn",
-	"type": "Microsoft.Synapse/workspaces/linkedservices",
 	"properties": {
+		"description": "horizon linked service ",
+		"parameters": {
+			"connection_string_secret_name": {
+				"type": "string"
+			}
+		},
 		"annotations": [],
 		"type": "SqlServer",
 		"typeProperties": {
@@ -11,13 +16,16 @@
 					"referenceName": "ls_kv",
 					"type": "LinkedServiceReference"
 				},
-				"secretName": "sql-hzn-preprod-connectionstring"
+				"secretName": {
+					"value": "@linkedService().connection_string_secret_name",
+					"type": "Expression"
+				}
 			}
 		},
 		"connectVia": {
 			"referenceName": "PinsIntegrationRuntime",
 			"type": "IntegrationRuntimeReference"
-		},
-		"description": "horizon linked service "
-	}
+		}
+	},
+	"type": "Microsoft.Synapse/workspaces/linkedservices"
 }


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
