### PR TITLE
Fix/app insights

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -216,6 +216,7 @@ The below tables outline the steps in each stage of the `Terraform CD` pipeline:
 
 | Name | Type |
 |------|------|
+| [azurerm_application_insights.function_app_insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_private_dns_zone.back_office_private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.data_lake](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -19,9 +19,6 @@ locals {
       "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"    = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key};EndpointSuffix=core.windows.net"
       "WEBSITE_CONTENTSHARE"                        = var.file_share_name
       "WEBSITE_CONTENTOVERVNET"                     = 1
-      "WEBSITE_RUN_FROM_PACKAGE"                    = 1
-      "ENABLE_ORYX_BUILD"                           = true
-      "SCM_DO_BUILD_DURING_DEPLOYMENT"              = true
     }
   )
 

--- a/infrastructure/modules/function-app/main.tf
+++ b/infrastructure/modules/function-app/main.tf
@@ -65,6 +65,7 @@ resource "azurerm_linux_function_app" "function" {
         action                    = subnet_ids.value["action"]
       }
     }
+    application_insights_key = var.application_insights_key == null ? null : var.application_insights_key
   }
 
   identity {

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -1,6 +1,12 @@
 /*
     Terraform configuration file defining variables
 */
+variable "application_insights_key" {
+  type        = string
+  description = "The key for the application insights instance"
+  default     = null
+  
+}
 variable "environment" {
   type        = string
   description = "The environment name. Used as a tag and in naming the resource group"

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -5,8 +5,8 @@ variable "application_insights_key" {
   type        = string
   description = "The key for the application insights instance"
   default     = null
-  
 }
+
 variable "environment" {
   type        = string
   description = "The environment name. Used as a tag and in naming the resource group"

--- a/infrastructure/modules/synapse-monitoring/README.md
+++ b/infrastructure/modules/synapse-monitoring/README.md
@@ -60,7 +60,6 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [azurerm_application_insights.function_app_insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_application_insights.synapse](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_key_vault_secret.application_insights_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_storage_insights.data_lake](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_storage_insights) | resource |
@@ -123,5 +122,7 @@ No requirements.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#output\_log\_analytics\_workspace\_id) | The ID of the Log Analytics Workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/infrastructure/modules/synapse-monitoring/application-insights.tf
+++ b/infrastructure/modules/synapse-monitoring/application-insights.tf
@@ -8,16 +8,3 @@ resource "azurerm_application_insights" "synapse" {
 
   tags = local.tags
 }
-
-resource "azurerm_application_insights" "function_app_insights" {
-  for_each = var.function_app_ids == null ? {} : var.function_app_ids
-
-  name                = "${each.key}-app-insights"
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  application_type    = "web"
-  retention_in_days   = var.log_retention_days
-  workspace_id        = azurerm_log_analytics_workspace.synapse.id
-
-  tags = local.tags
-}

--- a/infrastructure/modules/synapse-monitoring/output.tf
+++ b/infrastructure/modules/synapse-monitoring/output.tf
@@ -1,0 +1,4 @@
+output "log_analytics_workspace_id" {
+  description = "The ID of the Log Analytics Workspace"
+  value       = azurerm_log_analytics_workspace.synapse.id
+}

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -24,7 +24,7 @@ module "service_plan" {
   resource_group_name = azurerm_resource_group.function_app[0].name
   service_name        = local.service_name
   environment         = var.environment
-  location            = 
+  location            = module.azure_region.location_cli
   tags                = local.tags
 }module.azure_region.location_cli
 

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -147,7 +147,7 @@ resource "azurerm_application_insights" "function_app_insights" {
     for function_app in var.function_app : function_app.name => function_app if var.function_app_enabled == true
   }
 
-  name                = "${each.key}-app-insights"
+  name                = "pins-${each.key}-${local.resource_suffix}-app-insights"
   location            = module.azure_region.location_cli
   resource_group_name = azurerm_resource_group.monitoring.name
   application_type    = "web"

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -26,7 +26,7 @@ module "service_plan" {
   environment         = var.environment
   location            = module.azure_region.location_cli
   tags                = local.tags
-}module.azure_region.location_cli
+}
 
 module "service_plan_failover" {
   count = var.function_app_enabled && var.failover_deployment ? 1 : 0

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -24,9 +24,9 @@ module "service_plan" {
   resource_group_name = azurerm_resource_group.function_app[0].name
   service_name        = local.service_name
   environment         = var.environment
-  location            = module.azure_region.location_cli
+  location            = 
   tags                = local.tags
-}
+}module.azure_region.location_cli
 
 module "service_plan_failover" {
   count = var.function_app_enabled && var.failover_deployment ? 1 : 0
@@ -148,7 +148,7 @@ resource "azurerm_application_insights" "function_app_insights" {
   }
 
   name                = "${each.key}-app-insights"
-  location            = var.location
+  location            = module.azure_region.location_cli
   resource_group_name = azurerm_resource_group.monitoring.name
   application_type    = "web"
   retention_in_days   = 30

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -152,7 +152,7 @@ resource "azurerm_application_insights" "function_app_insights" {
   resource_group_name = azurerm_resource_group.monitoring.name
   application_type    = "web"
   retention_in_days   = 30
-  workspace_id        = module.synapse_monitoring.log_analytics_workspace.id
+  workspace_id        = module.synapse_monitoring.log_analytics_workspace_id
 
   tags = local.tags
 }

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -139,3 +139,18 @@ resource "azurerm_role_assignment" "servicebus_receiver" {
   role_definition_name = "Azure Service Bus Data Receiver"
   principal_id         = module.function_app[each.value.name].identity[0].principal_id
 }
+
+resource "azurerm_application_insights" "function_app_insights" {
+  for_each = {
+    for function_app in var.function_app : function_app.name => function_app if var.function_app_enabled == true
+  }
+
+  name                = "${each.key}-app-insights"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.monitoring.name
+  application_type    = "web"
+  retention_in_days   = 30
+  workspace_id        = module.synapse_monitoring.log_analytics_workspace.id
+
+  tags = local.tags
+}

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -100,6 +100,7 @@ module "function_app" {
   environment                = var.environment
   location                   = module.azure_region.location_cli
   tags                       = local.tags
+  application_insights_key   = azurerm_application_insights.function_app_insights[each.key].instrumentation_key
   synapse_vnet_subnet_names  = module.synapse_network.vnet_subnets
   app_settings               = try(each.value.app_settings, null)
   site_config                = each.value.site_config
@@ -123,6 +124,7 @@ module "function_app_failover" {
   environment                = var.environment
   location                   = module.azure_region.paired_location.location_cli
   tags                       = local.tags
+  application_insights_key   = azurerm_application_insights.function_app_insights[each.key].instrumentation_key
   synapse_vnet_subnet_names  = module.synapse_network_failover.vnet_subnets
   app_settings               = try(each.value.app_settings, null)
   site_config                = each.value.site_config


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
