### PR TITLE
Fix/rbac

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -70,7 +70,8 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "ebcc4498-4abe-4457-8970-7fa08bf87543" # pins-odw-dev-administrators
+    "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
+    "2a302373-df67-4c1e-91a1-f6301b87f42b"  # ODW-DEV-Infrastructure-2a302373-df67-4c1e-91a1-f6301b87f42b
   ],
   "Key Vault Secrets Officer" = [
     "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,7 +27,7 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
+    "48bd5755-6d7d-4a17-b044-7522c54e9c7d"  # pins-odw-dev-dataengineers
   ]
 }
 data_lake_storage_containers = [

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,7 +27,7 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "48bd5755-6d7d-4a17-b044-7522c54e9c7d",  # pins-odw-dev-dataengineers
+    "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
     "875e931a-ee45-425e-acde-1ec24a8a290d"  # Azure DevOps Pipelines - ODW Dev - Infrastructure"
   ]
 }

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -70,8 +70,7 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "875e931a-ee45-425e-acde-1ec24a8a290d"  # Azure DevOps Pipelines - ODW DEV - Infrastructure
+    "ebcc4498-4abe-4457-8970-7fa08bf87543" # pins-odw-dev-administrators
   ],
   "Key Vault Secrets Officer" = [
     "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -28,7 +28,7 @@ data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
     "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
-    "2a302373-df67-4c1e-91a1-f6301b87f42b"  # ODW-DEV-Infrastructure-2a302373-df67-4c1e-91a1-f6301b87f42b
+    "875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
   ]
 }
 data_lake_storage_containers = [
@@ -71,7 +71,7 @@ logic_app_enabled = false
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "2a302373-df67-4c1e-91a1-f6301b87f42b"  # ODW-DEV-Infrastructure-2a302373-df67-4c1e-91a1-f6301b87f42b
+    "875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
   ],
   "Key Vault Secrets Officer" = [
     "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers
@@ -248,7 +248,7 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "6a38f212-3834-4e2e-93fb-f81bb3a3fe49", # pins-odw-data-dev-syn-ws-administrators
-    "2a302373-df67-4c1e-91a1-f6301b87f42b"  # ODW-DEV-Infrastructure-2a302373-df67-4c1e-91a1-f6301b87f42b
+    "875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
   ],
   "Synapse Contributor" = [
     "0a5073e3-b8e9-4786-8e1f-39f2c277aeb2" # pins-odw-data-dev-syn-ws-contributors

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,8 +27,8 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers
-    #"875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
+    "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
+    "875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
   ]
 }
 data_lake_storage_containers = [
@@ -70,8 +70,8 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "ebcc4498-4abe-4457-8970-7fa08bf87543" # pins-odw-dev-administrators
-    #"875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
+    "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
+    "875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
   ],
   "Key Vault Secrets Officer" = [
     "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -28,7 +28,7 @@ data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
     "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
-    "b4dbfba4-b78b-4163-9b39-87ea03e2d5ed"  # planninginspectorate-operational-data-warehouse-ff442a29-fc06-4a13-8e3e-65fd5da513b3
+    "2a302373-df67-4c1e-91a1-f6301b87f42b"  # ODW-DEV-Infrastructure-2a302373-df67-4c1e-91a1-f6301b87f42b
   ]
 }
 data_lake_storage_containers = [
@@ -247,7 +247,7 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "6a38f212-3834-4e2e-93fb-f81bb3a3fe49", # pins-odw-data-dev-syn-ws-administrators
-    "b4dbfba4-b78b-4163-9b39-87ea03e2d5ed"  # planninginspectorate-operational-data-warehouse-ff442a29-fc06-4a13-8e3e-65fd5da513b3
+    "2a302373-df67-4c1e-91a1-f6301b87f42b"  # ODW-DEV-Infrastructure-2a302373-df67-4c1e-91a1-f6301b87f42b
   ],
   "Synapse Contributor" = [
     "0a5073e3-b8e9-4786-8e1f-39f2c277aeb2" # pins-odw-data-dev-syn-ws-contributors

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -54,14 +54,6 @@ function_app = [
         python_version = "3.11"
       }
     }
-  },
-  {
-    name = "fnapp02"
-    site_config = {
-      application_stack = {
-        python_version = "3.11"
-      }
-    }
   }
 ]
 

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,8 +27,7 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
-    "875e931a-ee45-425e-acde-1ec24a8a290d"  # Azure DevOps Pipelines - ODW DEV - Infrastructure 
+    "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers
   ]
 }
 data_lake_storage_containers = [

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,7 +27,7 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers
+    "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
   ]
 }
 data_lake_storage_containers = [

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,7 +27,8 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "48bd5755-6d7d-4a17-b044-7522c54e9c7d"  # pins-odw-dev-dataengineers
+    "48bd5755-6d7d-4a17-b044-7522c54e9c7d",  # pins-odw-dev-dataengineers
+    "875e931a-ee45-425e-acde-1ec24a8a290d"  # Azure DevOps Pipelines - ODW Dev - Infrastructure"
   ]
 }
 data_lake_storage_containers = [

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -27,8 +27,8 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "48bd5755-6d7d-4a17-b044-7522c54e9c7d", # pins-odw-dev-dataengineers
-    "875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
+    "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers
+    #"875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
   ]
 }
 data_lake_storage_containers = [
@@ -70,8 +70,8 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "ebcc4498-4abe-4457-8970-7fa08bf87543", # pins-odw-dev-administrators
-    "875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
+    "ebcc4498-4abe-4457-8970-7fa08bf87543" # pins-odw-dev-administrators
+    #"875e931a-ee45-425e-acde-1ec24a8a290d"  # ODW-DEV-Infrastructure-875e931a-ee45-425e-acde-1ec24a8a290d
   ],
   "Key Vault Secrets Officer" = [
     "48bd5755-6d7d-4a17-b044-7522c54e9c7d" # pins-odw-dev-dataengineers

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -27,12 +27,8 @@ data_lake_retention_days        = 28
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
-<<<<<<< Updated upstream
-    "5c56c7a0-6845-43e7-877c-c8dd527107a3"  # pins-odw-prod-dataengineers
-=======
     "5c56c7a0-6845-43e7-877c-c8dd527107a3", # pins-odw-prod-dataengineers
     "0cad1989-27de-4242-a06b-7cad373497e7"  # Azure DevOps Pipelines - ODW Prod - Infrastructure
->>>>>>> Stashed changes
   ]
 }
 data_lake_storage_containers = [

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -28,7 +28,7 @@ data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
     "5c56c7a0-6845-43e7-877c-c8dd527107a3", # pins-odw-prod-dataengineers
-    "d1761ac5-c65f-4b48-bee9-a2179b989adc"  # planninginspectorate-operational-data-warehouse-a82fd28d-5989-4e06-a0bb-1a5d859f9e0c
+    "75af1e29-416e-4d49-bb18-f904d83fe6fa"  # ODW-PROD-Infrastructure-75af1e29-416e-4d49-bb18-f904d83fe6fa
   ]
 }
 data_lake_storage_containers = [
@@ -236,7 +236,7 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "a2568721-f55c-4cbe-8cef-3d4fa2e1cee7", # pins-odw-data-prod-syn-ws-administrators
-    "d1761ac5-c65f-4b48-bee9-a2179b989adc"  # planninginspectorate-operational-data-warehouse-a82fd28d-5989-4e06-a0bb-1a5d859f9e0c
+    "75af1e29-416e-4d49-bb18-f904d83fe6fa"  # ODW-PROD-Infrastructure-75af1e29-416e-4d49-bb18-f904d83fe6fa
   ],
   "Synapse Contributor" = [
     "76259388-176a-4db7-a5b7-db2861ef7220" # pins-odw-data-prod-syn-ws-contributors

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -46,12 +46,16 @@ devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-prod-ukw"
 environment = "prod"
 
 function_app_enabled = true
-function_app_name    = "fnapp01"
-function_app_site_config = {
-  application_stack = {
-    python_version = "3.11"
+function_app = [
+  {
+    name = "fnapp01"
+    site_config = {
+      application_stack = {
+        python_version = "3.11"
+      }
+    }
   }
-}
+]
 
 location = "uk-south"
 

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -27,7 +27,7 @@ data_lake_retention_days        = 28
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
-    "5c56c7a0-6845-43e7-877c-c8dd527107a3" # pins-odw-prod-dataengineers
+    "5c56c7a0-6845-43e7-877c-c8dd527107a3"  # pins-odw-prod-dataengineers
   ]
 }
 data_lake_storage_containers = [

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -28,7 +28,7 @@ data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
     "5c56c7a0-6845-43e7-877c-c8dd527107a3", # pins-odw-prod-dataengineers
-    "75af1e29-416e-4d49-bb18-f904d83fe6fa"  # ODW-PROD-Infrastructure-75af1e29-416e-4d49-bb18-f904d83fe6fa
+    "0cad1989-27de-4242-a06b-7cad373497e7"  # ODW-PROD-Infrastructure-0cad1989-27de-4242-a06b-7cad373497e7
   ]
 }
 data_lake_storage_containers = [
@@ -59,7 +59,8 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "1fa42635-5dc3-43bc-b5da-77578f3dabb7" # pins-odw-prod-administrators
+    "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
+    "0cad1989-27de-4242-a06b-7cad373497e7"  # ODW-PROD-Infrastructure-0cad1989-27de-4242-a06b-7cad373497e7
   ],
   "Key Vault Secrets Officer" = [
     "5c56c7a0-6845-43e7-877c-c8dd527107a3" # pins-odw-prod-dataengineers
@@ -236,7 +237,7 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "a2568721-f55c-4cbe-8cef-3d4fa2e1cee7", # pins-odw-data-prod-syn-ws-administrators
-    "75af1e29-416e-4d49-bb18-f904d83fe6fa"  # ODW-PROD-Infrastructure-75af1e29-416e-4d49-bb18-f904d83fe6fa
+    "0cad1989-27de-4242-a06b-7cad373497e7"  # ODW-PROD-Infrastructure-0cad1989-27de-4242-a06b-7cad373497e7
   ],
   "Synapse Contributor" = [
     "76259388-176a-4db7-a5b7-db2861ef7220" # pins-odw-data-prod-syn-ws-contributors

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -27,8 +27,7 @@ data_lake_retention_days        = 28
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
-    "5c56c7a0-6845-43e7-877c-c8dd527107a3", # pins-odw-prod-dataengineers
-    "0cad1989-27de-4242-a06b-7cad373497e7"  # ODW-PROD-Infrastructure-0cad1989-27de-4242-a06b-7cad373497e7
+    "5c56c7a0-6845-43e7-877c-c8dd527107a3" # pins-odw-prod-dataengineers
   ]
 }
 data_lake_storage_containers = [
@@ -59,8 +58,7 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
-    "0cad1989-27de-4242-a06b-7cad373497e7"  # ODW-PROD-Infrastructure-0cad1989-27de-4242-a06b-7cad373497e7
+    "1fa42635-5dc3-43bc-b5da-77578f3dabb7" # pins-odw-prod-administrators
   ],
   "Key Vault Secrets Officer" = [
     "5c56c7a0-6845-43e7-877c-c8dd527107a3" # pins-odw-prod-dataengineers
@@ -236,8 +234,7 @@ synapse_data_exfiltration_enabled  = false
 synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
-    "a2568721-f55c-4cbe-8cef-3d4fa2e1cee7", # pins-odw-data-prod-syn-ws-administrators
-    "0cad1989-27de-4242-a06b-7cad373497e7"  # ODW-PROD-Infrastructure-0cad1989-27de-4242-a06b-7cad373497e7
+    "a2568721-f55c-4cbe-8cef-3d4fa2e1cee7" # pins-odw-data-prod-syn-ws-administrators
   ],
   "Synapse Contributor" = [
     "76259388-176a-4db7-a5b7-db2861ef7220" # pins-odw-data-prod-syn-ws-contributors

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -27,7 +27,12 @@ data_lake_retention_days        = 28
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "1fa42635-5dc3-43bc-b5da-77578f3dabb7", # pins-odw-prod-administrators
+<<<<<<< Updated upstream
     "5c56c7a0-6845-43e7-877c-c8dd527107a3"  # pins-odw-prod-dataengineers
+=======
+    "5c56c7a0-6845-43e7-877c-c8dd527107a3", # pins-odw-prod-dataengineers
+    "0cad1989-27de-4242-a06b-7cad373497e7"  # Azure DevOps Pipelines - ODW Prod - Infrastructure
+>>>>>>> Stashed changes
   ]
 }
 data_lake_storage_containers = [
@@ -234,7 +239,8 @@ synapse_data_exfiltration_enabled  = false
 synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
-    "a2568721-f55c-4cbe-8cef-3d4fa2e1cee7" # pins-odw-data-prod-syn-ws-administrators
+    "a2568721-f55c-4cbe-8cef-3d4fa2e1cee7", # pins-odw-data-prod-syn-ws-administrators
+    "0cad1989-27de-4242-a06b-7cad373497e7"  # Azure DevOps Pipelines - ODW Prod - Infrastructure
   ],
   "Synapse Contributor" = [
     "76259388-176a-4db7-a5b7-db2861ef7220" # pins-odw-data-prod-syn-ws-contributors

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -237,10 +237,7 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "be52cb0c-858f-4698-8c40-3a5ec793a2e3", # pins-odw-data-preprod-syn-ws-administrators
-<<<<<<< Updated upstream
-=======
     "9d4c68d1-c43d-4502-b35f-74f31c497757"  # Azure DevOps Pipelines - ODW Test - Infrastructure
->>>>>>> Stashed changes
   ],
   "Synapse Contributor" = [
     "d59a3e85-58db-4b70-8f88-3f4a4a82ee27" # pins-odw-data-preprod-syn-ws-contributors

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -27,8 +27,7 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "8274feca-09ef-41b1-9b4e-5eedc3384df4", # pins-odw-preprod-administrators
-    "7c906e1b-ffbb-44d3-89a1-6772b9c9c148", # pins-odw-preprod-dataengineers
-    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # ODW-TEST-Infrastructure-9d4c68d1-c43d-4502-b35f-74f31c497757
+    "7c906e1b-ffbb-44d3-89a1-6772b9c9c148"  # pins-odw-preprod-dataengineers
   ]
 }
 data_lake_storage_containers = [
@@ -59,8 +58,7 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "8274feca-09ef-41b1-9b4e-5eedc3384df4", # pins-odw-preprod-administrators
-    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # ODW-TEST-Infrastructure-9d4c68d1-c43d-4502-b35f-74f31c497757
+    "8274feca-09ef-41b1-9b4e-5eedc3384df4" # pins-odw-preprod-administrators
   ],
   "Key Vault Secrets Officer" = [
     "7c906e1b-ffbb-44d3-89a1-6772b9c9c148" # pins-odw-preprod-dataengineers
@@ -238,7 +236,6 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "be52cb0c-858f-4698-8c40-3a5ec793a2e3", # pins-odw-data-preprod-syn-ws-administrators
-    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # ODW-TEST-Infrastructure-9d4c68d1-c43d-4502-b35f-74f31c497757
   ],
   "Synapse Contributor" = [
     "d59a3e85-58db-4b70-8f88-3f4a4a82ee27" # pins-odw-data-preprod-syn-ws-contributors

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -28,7 +28,7 @@ data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "8274feca-09ef-41b1-9b4e-5eedc3384df4", # pins-odw-preprod-administrators
     "7c906e1b-ffbb-44d3-89a1-6772b9c9c148", # pins-odw-preprod-dataengineers
-    "51432f9e-c5a2-468f-8421-5984d097d1f9"  # planninginspectorate-operational-data-warehouse-6b18ba9d-2399-48b5-a834-e0f267be122d
+    "26045dd6-f0bf-42ab-9459-6f52afcd7b45"  # ODW-TEST-Infrastructure-26045dd6-f0bf-42ab-9459-6f52afcd7b45
   ]
 }
 data_lake_storage_containers = [
@@ -237,7 +237,7 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "be52cb0c-858f-4698-8c40-3a5ec793a2e3", # pins-odw-data-preprod-syn-ws-administrators
-    "51432f9e-c5a2-468f-8421-5984d097d1f9"  # planninginspectorate-operational-data-warehouse-6b18ba9d-2399-48b5-a834-e0f267be122d
+    "26045dd6-f0bf-42ab-9459-6f52afcd7b45"  # ODW-TEST-Infrastructure-26045dd6-f0bf-42ab-9459-6f52afcd7b45
   ],
   "Synapse Contributor" = [
     "d59a3e85-58db-4b70-8f88-3f4a4a82ee27" # pins-odw-data-preprod-syn-ws-contributors

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -27,7 +27,8 @@ data_lake_retention_days        = 7
 data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "8274feca-09ef-41b1-9b4e-5eedc3384df4", # pins-odw-preprod-administrators
-    "7c906e1b-ffbb-44d3-89a1-6772b9c9c148"  # pins-odw-preprod-dataengineers
+    "7c906e1b-ffbb-44d3-89a1-6772b9c9c148", # pins-odw-preprod-dataengineers
+    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # Azure DevOps Pipelines - ODW Test - Infrastructure
   ]
 }
 data_lake_storage_containers = [
@@ -236,6 +237,10 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "be52cb0c-858f-4698-8c40-3a5ec793a2e3", # pins-odw-data-preprod-syn-ws-administrators
+<<<<<<< Updated upstream
+=======
+    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # Azure DevOps Pipelines - ODW Test - Infrastructure
+>>>>>>> Stashed changes
   ],
   "Synapse Contributor" = [
     "d59a3e85-58db-4b70-8f88-3f4a4a82ee27" # pins-odw-data-preprod-syn-ws-contributors

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -46,12 +46,16 @@ devops_agent_pool_resource_group_name_failover = "pins-rg-devops-odw-test-ukw"
 environment = "test"
 
 function_app_enabled = true
-function_app_name    = "fnapp01"
-function_app_site_config = {
-  application_stack = {
-    python_version = "3.11"
+function_app = [
+  {
+    name = "fnapp01"
+    site_config = {
+      application_stack = {
+        python_version = "3.11"
+      }
+    }
   }
-}
+]
 
 location = "uk-south"
 

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -28,7 +28,7 @@ data_lake_role_assignments = {
   "Storage Blob Data Contributor" = [
     "8274feca-09ef-41b1-9b4e-5eedc3384df4", # pins-odw-preprod-administrators
     "7c906e1b-ffbb-44d3-89a1-6772b9c9c148", # pins-odw-preprod-dataengineers
-    "26045dd6-f0bf-42ab-9459-6f52afcd7b45"  # ODW-TEST-Infrastructure-26045dd6-f0bf-42ab-9459-6f52afcd7b45
+    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # ODW-TEST-Infrastructure-9d4c68d1-c43d-4502-b35f-74f31c497757
   ]
 }
 data_lake_storage_containers = [
@@ -59,7 +59,8 @@ logic_app_enabled = false
 
 key_vault_role_assignments = {
   "Key Vault Administrator" = [
-    "8274feca-09ef-41b1-9b4e-5eedc3384df4" # pins-odw-preprod-administrators
+    "8274feca-09ef-41b1-9b4e-5eedc3384df4", # pins-odw-preprod-administrators
+    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # ODW-TEST-Infrastructure-9d4c68d1-c43d-4502-b35f-74f31c497757
   ],
   "Key Vault Secrets Officer" = [
     "7c906e1b-ffbb-44d3-89a1-6772b9c9c148" # pins-odw-preprod-dataengineers
@@ -237,7 +238,7 @@ synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {
   "Synapse Administrator" = [
     "be52cb0c-858f-4698-8c40-3a5ec793a2e3", # pins-odw-data-preprod-syn-ws-administrators
-    "26045dd6-f0bf-42ab-9459-6f52afcd7b45"  # ODW-TEST-Infrastructure-26045dd6-f0bf-42ab-9459-6f52afcd7b45
+    "9d4c68d1-c43d-4502-b35f-74f31c497757"  # ODW-TEST-Infrastructure-9d4c68d1-c43d-4502-b35f-74f31c497757
   ],
   "Synapse Contributor" = [
     "d59a3e85-58db-4b70-8f88-3f4a4a82ee27" # pins-odw-data-preprod-syn-ws-contributors


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
