### PR TITLE
Fix/install opencensus lib in logger

### DIFF
--- a/workspace/notebook/nsip-project-subscribe.json
+++ b/workspace/notebook/nsip-project-subscribe.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6db63cb6-252b-4b40-8d4e-0d4944c0b5a6"
+				"spark.autotune.trackingId": "8a4ecd11-9df6-400b-949b-25a8f7e7c100"
 			}
 		},
 		"metadata": {
@@ -68,37 +68,6 @@
 					"See https://learn.microsoft.com/en-us/samples/azure/azure-sdk-for-python/servicebus-samples/ for servicebus samples\n",
 					""
 				]
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"## Import Logging"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 59
 			},
 			{
 				"cell_type": "markdown",
@@ -211,7 +180,6 @@
 					"collapsed": false
 				},
 				"source": [
-					"@logging_to_appins\n",
 					"def saveFromSubscription():\n",
 					"    from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
 					"    import json\n",

--- a/workspace/notebook/outstanding_files_add_entry.json
+++ b/workspace/notebook/outstanding_files_add_entry.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1ae244ce-754b-4140-8f3c-64c3e6c176b9"
+				"spark.autotune.trackingId": "cc832a75-5f07-4462-bd94-a288cf958e4d"
 			}
 		},
 		"metadata": {
@@ -52,24 +52,6 @@
 			"sessionKeepAliveTimeout": 30
 		},
 		"cells": [
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 1
-			},
 			{
 				"cell_type": "code",
 				"source": [
@@ -120,7 +102,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def add_file_to_table(jsonId, year, month, day, hour, minute, second):\r\n",
 					"    try:\r\n",
 					"        from datetime import datetime\r\n",

--- a/workspace/notebook/py_0_create_config_tables.json
+++ b/workspace/notebook/py_0_create_config_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "66a2b89d-c1f8-434a-b3bd-c2e2558ddab3"
+				"spark.autotune.trackingId": "89a3d51f-b8cf-4670-8025-8c2e9d37d4d9"
 			}
 		},
 		"metadata": {
@@ -72,25 +72,6 @@
 					}
 				},
 				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 2
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"@logging_to_appins\r\n",
 					"def create_config_tables():\r\n",
 					"    '''\r\n",
 					"    Parameters:\r\n",

--- a/workspace/notebook/py_0_log_copy_activity_output.json
+++ b/workspace/notebook/py_0_log_copy_activity_output.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e331fdce-b61f-472f-ae0b-370e06de47cd"
+				"spark.autotune.trackingId": "d5a5fff0-a2c6-42f3-9447-23aa8a4f5d3d"
 			}
 		},
 		"metadata": {
@@ -41,24 +41,17 @@
 				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
-					"authResource": "https://dev.azuresynapse.net",
-					"authHeader": null
+					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.2",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
-				"extraHeader": null
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
 		"cells": [
-			{
-				"cell_type": "code",
-				"source": [
-					"%run /utils/py_logging_decorator"
-				]
-			},
 			{
 				"cell_type": "code",
 				"metadata": {
@@ -86,7 +79,8 @@
 					"kv_linked_service=\"ls_kv\"\r\n",
 					"share_name =\"datalab\"\r\n",
 					""
-				]
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -105,7 +99,8 @@
 					"from pyspark.sql import SparkSession\r\n",
 					"spark = SparkSession.builder.getOrCreate()\r\n",
 					"akv_name=spark.sparkContext.environment.get('keyVaultName', 'get')"
-				]
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -121,7 +116,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def log_copy_output(output:str, filepath:str, akv_name:str, secret_name:str, kv_linked_service:str, share_name:str, jsonschema:str, db_name:str, table_name:str):\r\n",
 					"    '''\r\n",
 					"\r\n",
@@ -152,7 +146,8 @@
 					"    else:\r\n",
 					"        raise Exception(f\"S2R-SAPHR: Transfer to raw for file {filepath} has failed\")\r\n",
 					""
-				]
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -169,7 +164,8 @@
 				},
 				"source": [
 					"log_copy_output(output, filepath, akv_name, secret_name, kv_linked_service, share_name, jsonschema, db_name, table_name)"
-				]
+				],
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_0_log_notebook_output.json
+++ b/workspace/notebook/py_0_log_notebook_output.json
@@ -17,7 +17,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4df1c6de-5e9c-431c-9084-c8df0cd4cd41"
+				"spark.autotune.trackingId": "e8a0cdf5-1871-4bad-9076-7b5053973204"
 			}
 		},
 		"metadata": {
@@ -35,25 +35,7 @@
 		"cells": [
 			{
 				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
 				"source": [
-					"%run /utils/py_logging_decorator"
-				]
-			},
-			{
-				"cell_type": "code",
-				"source": [
-					"@logging_to_appins\r\n",
 					"def log_notebook_output():\r\n",
 					"    '''\r\n",
 					"    Function to log that no new files are present in the AzureFileshare\r\n",
@@ -75,7 +57,8 @@
 					"    logger = logging.getLogger(__name__)\r\n",
 					"    logger.info(\"S2R-SAPHR: No new files in datalabs\")\r\n",
 					""
-				]
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -92,7 +75,8 @@
 				},
 				"source": [
 					"log_notebook_output()"
-				]
+				],
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_0_source_to_raw_hr_functions.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c6400950-1d0d-46e8-ab8f-88fd1f32314a"
+				"spark.autotune.trackingId": "87651131-596e-45c5-be4e-a8beed1091c1"
 			}
 		},
 		"metadata": {
@@ -41,25 +41,17 @@
 				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
-					"authResource": "https://dev.azuresynapse.net",
-					"authHeader": null
+					"authResource": "https://dev.azuresynapse.net"
 				},
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
-				"extraHeader": null
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
 		"cells": [
-			{
-				"cell_type": "code",
-				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 1
-			},
 			{
 				"cell_type": "code",
 				"metadata": {
@@ -74,7 +66,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def azfileshare_new_files(akv_name:str, secret_name:str, kv_linked_service:str, share_name:str, directory_path:str, jsonschema:str, target_container:str, target_folder:str, db_name:str, table_name:str):\r\n",
 					"    '''\r\n",
 					"    Function which determines if any new files are available in the datalabs environment\r\n",
@@ -175,7 +166,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def create_table_from_schema(jsonschema:str, db_name:str, table_name:str, target_container:str, target_folder:str, change_data_feed=False):\r\n",
 					"    '''\r\n",
 					"    Function to create a table from a schema definition. Schema merge is disabled.\r\n",

--- a/workspace/notebook/py_0_source_to_raw_hr_tests.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_tests.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4db6d3e3-a973-4d6c-9e75-ce0d566e78c3"
+				"spark.autotune.trackingId": "27a81623-f716-4bea-b9a7-0e72e6f1075b"
 			}
 		},
 		"metadata": {
@@ -41,14 +41,13 @@
 				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
-					"authResource": "https://dev.azuresynapse.net",
-					"authHeader": null
+					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.2",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
-				"extraHeader": null
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -230,25 +229,6 @@
 					}
 				},
 				"source": [
-					"%run \"utils/py_logging_decorator\""
-				],
-				"execution_count": 15
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"@logging_to_appins\r\n",
 					"def raise_exception(output):\r\n",
 					"    import logging\r\n",
 					"    logger = logging.getLogger(__name__)\r\n",
@@ -293,7 +273,8 @@
 				},
 				"source": [
 					""
-				]
+				],
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_1_initial_run_raw_to_standardised_scheduling.json
+++ b/workspace/notebook/py_1_initial_run_raw_to_standardised_scheduling.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "61ff317d-4cbe-41e4-a601-7d3e1eb7c6d9"
+				"spark.autotune.trackingId": "806d1dda-0e36-4144-8be2-d30fa802033d"
 			}
 		},
 		"metadata": {
@@ -84,25 +84,6 @@
 					}
 				},
 				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 226
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"@logging_to_appins\r\n",
 					"def ingest_raw_to_standardised(source_id):\r\n",
 					"    '''\r\n",
 					"    Function reads all the schedules for all files, and processes any new files into standardised, and adds outstanding files into an outstanding files table\r\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e115f751-908d-4b9d-927b-83f6efe5f928"
+				"spark.autotune.trackingId": "a3573728-d07a-432e-971e-2da92dabb99e"
 			}
 		},
 		"metadata": {
@@ -66,24 +66,6 @@
 					}
 				},
 				"source": [
-					"%run \"utils/py_logging_decorator\""
-				],
-				"execution_count": 20
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"%run  /0-odw-source-to-raw/Fileshare/SAP_HR/py_0_source_to_raw_hr_functions"
 				],
 				"execution_count": null
@@ -102,7 +84,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def validate_parameters(storage_acc, raw_container, raw_source_folder, raw_name, standardised_container, standardised_source_folder, standardised_name, linked_service, sheet_name=0, header_row=0):\r\n",
 					"    \r\n",
 					"    ''' \r\n",
@@ -209,7 +190,6 @@
 					"        \r\n",
 					"    return df.astype(str, errors='ignore')\r\n",
 					"\r\n",
-					"@logging_to_appins\r\n",
 					"def ingest_excel_to_parquet(storage_acc, raw_container, raw_source_folder, raw_name, standardised_container, standardised_source_folder, standardised_name, linked_service, sheet_name=0, header=0):\r\n",
 					"\r\n",
 					"    '''\r\n",
@@ -267,7 +247,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def enable_delta_on_parquet(standardised_container, standardised_source_folder):\r\n",
 					"    '''\r\n",
 					"    Take a standard parquet file and enable delta lake capabiltiies on the file\r\n",
@@ -305,7 +284,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def lakedb_table_sparksql(db_name,delta_lake_table_name,standardised_container, standardised_source_folder):\r\n",
 					"    '''\r\n",
 					"    Make delta parquet file available in lake database\r\n",
@@ -342,7 +320,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\n",
 					"def ingest_adhoc(storage_account, definition, folder_path, filename, expected_from, expected_to):\n",
 					"\n",
 					"    from pyspark.sql import SparkSession\n",

--- a/workspace/notebook/py_1_raw_to_standardised_scheduling.json
+++ b/workspace/notebook/py_1_raw_to_standardised_scheduling.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "aa37db4b-a101-4e90-9c4d-c8f36a160c55"
+				"spark.autotune.trackingId": "e54aa070-08c9-4a64-9e54-45d9f99aee9e"
 			}
 		},
 		"metadata": {
@@ -81,24 +81,6 @@
 						"transient": {
 							"deleting": false
 						}
-					}
-				},
-				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 26
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
 					},
 					"tags": [
 						"parameters"
@@ -123,7 +105,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def ingest_raw_to_standardised():\r\n",
 					"    '''\r\n",
 					"    Function reads all the schedules for all files, and processes any new files into standardised, and adds outstanding files into an outstanding files table\r\n",

--- a/workspace/notebook/py_change_table.json
+++ b/workspace/notebook/py_change_table.json
@@ -17,7 +17,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4a5b5a06-8b4c-40ae-aa20-fce1d91171a3"
+				"spark.autotune.trackingId": "5ae6d3c2-dbcd-45fa-ac07-ed3afc0edcae"
 			}
 		},
 		"metadata": {
@@ -59,24 +59,6 @@
 						"transient": {
 							"deleting": false
 						}
-					}
-				},
-				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 20
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
 					},
 					"tags": [
 						"parameters"
@@ -102,7 +84,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def new_schema_cast_columns(old_schema:dict, new_schema:str, db_name:str, table_name:str):\r\n",
 					"    '''\r\n",
 					"    '''\r\n",
@@ -135,7 +116,6 @@
 					"    else:\r\n",
 					"        logger.info(\"no columns have changed type\")\r\n",
 					"\r\n",
-					"@logging_to_appins\r\n",
 					"def apply_new_schema(db_name: str, table_name: str):\r\n",
 					"    '''\r\n",
 					"    Description:\r\n",

--- a/workspace/notebook/py_create_schema_from_raw.json
+++ b/workspace/notebook/py_create_schema_from_raw.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "848022ef-6a61-48a2-90e0-e6f929c005e4"
+				"spark.autotune.trackingId": "9be4a3d4-ae2c-4cdb-a56c-fe2555dd755e"
 			}
 		},
 		"metadata": {
@@ -92,24 +92,6 @@
 					}
 				},
 				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 126
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"%run  /0-odw-source-to-raw/Fileshare/SAP_HR/py_0_source_to_raw_hr_functions"
 				],
 				"execution_count": 127
@@ -153,7 +135,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\n",
 					"def get_latest_file(definition):\n",
 					"    import calendar\n",
 					"    from datetime import datetime, timedelta, date\n",
@@ -194,7 +175,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\n",
 					"def generate_schema(file, definition):\n",
 					"\n",
 					"    import pandas as pd\n",

--- a/workspace/notebook/py_daily_files_into_date_folders.json
+++ b/workspace/notebook/py_daily_files_into_date_folders.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b50aa556-3645-44c8-9dbf-178a1e81b5e5"
+				"spark.autotune.trackingId": "f4c02c9c-629c-4961-aac4-6f8e70e4ce17"
 			}
 		},
 		"metadata": {
@@ -72,31 +72,12 @@
 					}
 				},
 				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 2
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"from pyspark.sql import SparkSession\n",
 					"from notebookutils import mssparkutils\n",
 					"import datetime\n",
 					"import logging\n",
 					"logger = logging.getLogger(__name__)\n",
 					"\n",
-					"@logging_to_appins\n",
 					"def move_files_in_dated_folders(container_name, relative_path, folders_to_check):\n",
 					"\n",
 					"    '''\n",

--- a/workspace/notebook/py_delete_table.json
+++ b/workspace/notebook/py_delete_table.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c70cd961-97cc-4724-a03a-e2c575dcf870"
+				"spark.autotune.trackingId": "fc856fc4-718a-4c49-a2ad-980d9cf00ac6"
 			}
 		},
 		"metadata": {
@@ -101,25 +101,6 @@
 					}
 				},
 				"source": [
-					"%run \"utils/py_logging_decorator\""
-				],
-				"execution_count": 14
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"@logging_to_appins\r\n",
 					"def delete_table(db_name, table_name):\r\n",
 					"    import logging\r\n",
 					"    logger = logging.getLogger(__name__)\r\n",

--- a/workspace/notebook/py_delete_table_contents.json
+++ b/workspace/notebook/py_delete_table_contents.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d3df58e0-80e2-40b4-acb3-779ddcbd8588"
+				"spark.autotune.trackingId": "1cf723ec-836e-4d54-8cbd-90c321545897"
 			}
 		},
 		"metadata": {
@@ -87,25 +87,6 @@
 					}
 				},
 				"source": [
-					"%run \"utils/py_logging_decorator\""
-				],
-				"execution_count": 16
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"@logging_to_appins\r\n",
 					"def delete_table_contents(db_name, table_name):\r\n",
 					"    import logging\r\n",
 					"    logger = logging.getLogger(__name__)\r\n",

--- a/workspace/notebook/py_delete_view.json
+++ b/workspace/notebook/py_delete_view.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cbe760c0-26ed-4422-94b2-38705c224f73"
+				"spark.autotune.trackingId": "7cccb6e6-3190-4fed-ac81-3e1c425f61f5"
 			}
 		},
 		"metadata": {
@@ -72,24 +72,6 @@
 					"view_name=\"example_mock_data\""
 				],
 				"execution_count": 1
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run \"utils/py_logging_decorator\""
-				],
-				"execution_count": 16
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_fail_activity_logging.json
+++ b/workspace/notebook/py_fail_activity_logging.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6cc15acd-3689-4557-81c5-e56c4a820426"
+				"spark.autotune.trackingId": "58c6826e-f9db-4d4d-a3d1-3d07ed7fd3d4"
 			}
 		},
 		"metadata": {
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.2",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
@@ -87,25 +87,6 @@
 					}
 				},
 				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"@logging_to_appins\r\n",
 					"def logging_fail_activity_appins(output):\r\n",
 					"    import logging\r\n",
 					"    logger = logging.getLogger(__name__)\r\n",

--- a/workspace/notebook/py_logging_decorator.json
+++ b/workspace/notebook/py_logging_decorator.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "13074727-e988-432f-9bf3-448bdb2ab232"
+				"spark.autotune.trackingId": "ce0084ae-1651-4bd8-8252-9059064ece67"
 			}
 		},
 		"metadata": {
@@ -52,6 +52,24 @@
 			"sessionKeepAliveTimeout": 30
 		},
 		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"%pip install opencensus-ext-azure"
+				],
+				"execution_count": null
+			},
 			{
 				"cell_type": "code",
 				"source": [

--- a/workspace/notebook/py_odw_curated_table_creation.json
+++ b/workspace/notebook/py_odw_curated_table_creation.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e9760c0c-2ce8-499b-a6f1-09a77452ffa2"
+				"spark.autotune.trackingId": "c7481186-59ca-4c40-8be6-1532c475d922"
 			}
 		},
 		"metadata": {
@@ -74,13 +74,6 @@
 			},
 			{
 				"cell_type": "code",
-				"source": [
-					"%run \"utils/py_logging_decorator\""
-				],
-				"execution_count": 1
-			},
-			{
-				"cell_type": "code",
 				"metadata": {
 					"jupyter": {
 						"source_hidden": false,
@@ -111,7 +104,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def automation_table_creation():\r\n",
 					"    '''\r\n",
 					"    This function check for existing table for specific json file in a delta folder and if the data has been already used, \r\n",

--- a/workspace/notebook/py_odw_harmonised_table_creation.json
+++ b/workspace/notebook/py_odw_harmonised_table_creation.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "aea3af54-80c5-4c94-9055-63e09c023266"
+				"spark.autotune.trackingId": "20e1e6c2-cf7e-4be4-8008-302b472ec323"
 			}
 		},
 		"metadata": {
@@ -53,13 +53,6 @@
 			"sessionKeepAliveTimeout": 30
 		},
 		"cells": [
-			{
-				"cell_type": "code",
-				"source": [
-					"%run \"utils/py_logging_decorator\""
-				],
-				"execution_count": 38
-			},
 			{
 				"cell_type": "code",
 				"metadata": {
@@ -113,7 +106,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def automation_table_creation():\r\n",
 					"    '''\r\n",
 					"    This function check for existing table for specific json file in a delta folder and if the data has been already used, \r\n",
@@ -170,9 +162,6 @@
 					"   \r\n",
 					"#calling the function \r\n",
 					"automation_table_creation()\r\n",
-					"   \r\n",
-					"\r\n",
-					"\r\n",
 					"   "
 				],
 				"execution_count": 41

--- a/workspace/notebook/py_process_raw_to_standardised_validate.json
+++ b/workspace/notebook/py_process_raw_to_standardised_validate.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f6da3b73-8276-4eba-9c2f-9a698b688556"
+				"spark.autotune.trackingId": "b55b9a44-2c4b-42d6-a0e7-32d14111104a"
 			}
 		},
 		"metadata": {
@@ -42,14 +42,13 @@
 				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
-					"authResource": "https://dev.azuresynapse.net",
-					"authHeader": null
+					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.2",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
-				"extraHeader": null
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -72,24 +71,6 @@
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
 				"execution_count": 2
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run utils/py_logging_decorator"
-				],
-				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -135,7 +116,6 @@
 					"\"SAP_Leavers_20220831.xlsx\" : \"leavers\", \"Specialisms - 220831.xlsx\" : \"specialisms\"}\r\n",
 					"\r\n",
 					"\r\n",
-					"@logging_to_appins\r\n",
 					"def validate_data():\r\n",
 					"    print('---Validation started---')\r\n",
 					"    for file, table in file_table_mapping.items():\r\n",

--- a/workspace/notebook/zendesk-subscribe.json
+++ b/workspace/notebook/zendesk-subscribe.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8e74d871-0eb1-47bf-8ec6-bed8ee8483d9"
+				"spark.autotune.trackingId": "ae04d774-4a67-449b-8d56-d147aa345f26"
 			}
 		},
 		"metadata": {
@@ -68,37 +68,6 @@
 					"See https://learn.microsoft.com/en-us/samples/azure/azure-sdk-for-python/servicebus-samples/ for servicebus samples\n",
 					""
 				]
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"## Import Logging"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 16
 			},
 			{
 				"cell_type": "markdown",
@@ -212,7 +181,6 @@
 					"collapsed": false
 				},
 				"source": [
-					"@logging_to_appins\n",
 					"def saveFromSubscription():\n",
 					"    from azure.servicebus import ServiceBusClient, ServiceBusMessage\n",
 					"    import json\n",

--- a/workspace/notebook/zendesk_harmonised_export.json
+++ b/workspace/notebook/zendesk_harmonised_export.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "25e70c28-94b1-4075-aa8e-b56469d92ed5"
+				"spark.autotune.trackingId": "b1595b08-d769-464f-8b77-b2aab85ea8bb"
 			}
 		},
 		"metadata": {
@@ -72,24 +72,6 @@
 					"from pyspark.sql.window import Window"
 				],
 				"execution_count": 55
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 56
 			},
 			{
 				"cell_type": "code",
@@ -163,7 +145,6 @@
 					"import jsonschema\r\n",
 					"from jsonschema import validate\r\n",
 					"list_with_all_zendesk_dict = []\r\n",
-					"@logging_to_appins\r\n",
 					"def read_zendesk():\r\n",
 					"    for i in range(2918):\r\n",
 					"            with open(f\"/synfs/{jobId}/zendesk_items/output_{i}.json\", \"r\",encoding='utf-8') as big_json:\r\n",
@@ -250,29 +231,28 @@
 						"3bdf619d-6e98-4047-8495-94d579792d6b": {
 							"text": " the",
 							"start": {
-								"line": 14,
+								"line": 13,
 								"column": 73
 							},
 							"end": {
-								"line": 14,
+								"line": 13,
 								"column": 77
 							}
 						},
 						"437e3dbd-79c9-4db6-bfb3-2bce1e8ea056": {
 							"text": " comments_and_attachments():",
 							"start": {
-								"line": 2,
+								"line": 1,
 								"column": 4
 							},
 							"end": {
-								"line": 2,
+								"line": 1,
 								"column": 32
 							}
 						}
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def comments_and_attachments():\r\n",
 					"    FlatCommentsDictList=[]\r\n",
 					"    FlatCommentsDictAttachmentsList=[]\r\n",
@@ -342,18 +322,17 @@
 						"52e648f1-d6c1-4fdb-a508-ed450b8ca1cb": {
 							"text": "from pyspark.sql.types import StructType, StructField, String",
 							"start": {
-								"line": 25,
+								"line": 24,
 								"column": 5
 							},
 							"end": {
-								"line": 25,
+								"line": 24,
 								"column": 66
 							}
 						}
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def assignee_table():\r\n",
 					"    assigneelist=[]\r\n",
 					"    for i in range(2918):\r\n",
@@ -405,7 +384,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def submitter_table():\r\n",
 					"    submitterlist=[]\r\n",
 					"    for i in range(2918):\r\n",
@@ -458,7 +436,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def requester_table():\r\n",
 					"    requesterlist=[]\r\n",
 					"    for i in range(2918):\r\n",
@@ -510,7 +487,6 @@
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def collaborator_table():\r\n",
 					"    collaboratorlist=[]\r\n",
 					"    for i in range(2918):\r\n",

--- a/workspace/notebook/zendesk_raw_to_standerdised.json
+++ b/workspace/notebook/zendesk_raw_to_standerdised.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8fec9bff-d9e4-4640-923c-51f776728804"
+				"spark.autotune.trackingId": "4df112f1-963a-49ab-9b16-056fb18027d7"
 			}
 		},
 		"metadata": {
@@ -210,7 +210,6 @@
 				},
 				"source": [
 					"import pyspark.sql.functions as F \r\n",
-					"@logging_to_appins\r\n",
 					"def fields_table():\r\n",
 					"    fields = sparkDF.select(\r\n",
 					"    \"id\", F.explode(\"fields\").alias(\"fields\")\r\n",
@@ -248,7 +247,6 @@
 				},
 				"source": [
 					"import pyspark.sql.functions as F \r\n",
-					"@logging_to_appins\r\n",
 					"def custom_fields_table():\r\n",
 					"    custom_fields = sparkDF.select(\r\n",
 					"    \"id\", F.explode(\"custom_fields\").alias(\"custom_fields\")\r\n",

--- a/workspace/notebook/zendesk_standardised_and_harmonised.json
+++ b/workspace/notebook/zendesk_standardised_and_harmonised.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7f7c38e5-64c5-42e4-8989-d7dd6166ca30"
+				"spark.autotune.trackingId": "6ea62415-c07e-4540-a8c7-bdc2c371722d"
 			}
 		},
 		"metadata": {
@@ -97,26 +97,7 @@
 					}
 				},
 				"source": [
-					"%run /utils/py_logging_decorator"
-				],
-				"execution_count": 8
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"_FLAG_FIRST = object()\r\n",
-					"@logging_to_appins\r\n",
 					"#flatteb dict function\r\n",
 					"def flattenDict(d, join=add, lift=lambda x:(x,)):\r\n",
 					"    results = []\r\n",
@@ -293,29 +274,28 @@
 						"357b88a3-d6dc-47c2-aa6f-99567564b7f8": {
 							"text": "write_to_single_file():",
 							"start": {
-								"line": 2,
+								"line": 1,
 								"column": 5
 							},
 							"end": {
-								"line": 2,
+								"line": 1,
 								"column": 28
 							}
 						},
 						"3e53afea-ddf1-41a5-9671-4f69f1292c03": {
 							"text": "zendesk_items/export-2023-03-15-1051-10932060-13758561992081e5c3.json\"",
 							"start": {
-								"line": 5,
+								"line": 4,
 								"column": 32
 							},
 							"end": {
-								"line": 5,
+								"line": 4,
 								"column": 102
 							}
 						}
 					}
 				},
 				"source": [
-					"@logging_to_appins\r\n",
 					"def write_to_single_file():\r\n",
 					"    \r\n",
 					"\r\n",
@@ -422,33 +402,33 @@
 						"45a7f6d4-05e7-4918-a6d5-0820c6fb600b": {
 							"text": "        if i == 2802:\n#             i=i+1",
 							"start": {
-								"line": 8,
+								"line": 7,
 								"column": 3
 							},
 							"end": {
-								"line": 9,
+								"line": 8,
 								"column": 20
 							}
 						},
 						"f0a638a9-885a-4769-bb2b-b06f4fc38d58": {
 							"text": "                except jsonschema.exceptions.ValidationError as err:\n#                     print(\"Schema could not validate file number:\")\n#                     print(i)",
 							"start": {
-								"line": 15,
+								"line": 14,
 								"column": 3
 							},
 							"end": {
-								"line": 17,
+								"line": 16,
 								"column": 31
 							}
 						},
 						"c95e30e1-6b8f-4606-9cee-e5ccbc004783": {
 							"text": "def read_zendesk(schema_dict):",
 							"start": {
-								"line": 6,
+								"line": 5,
 								"column": 3
 							},
 							"end": {
-								"line": 6,
+								"line": 5,
 								"column": 33
 							}
 						}
@@ -459,7 +439,6 @@
 					"# import jsonschema\r\n",
 					"# from jsonschema import validate\r\n",
 					"# list_with_all_zendesk_dict = []\r\n",
-					"# @logging_to_appins\r\n",
 					"# def read_zendesk(schema_dict):\r\n",
 					"#     for i in range(2918):\r\n",
 					"#         if i == 2802:\r\n",
@@ -586,7 +565,6 @@
 				},
 				"source": [
 					"# import pyspark.sql.functions as F \r\n",
-					"# @logging_to_appins\r\n",
 					"# def fields_table():\r\n",
 					"#     fields = shows.select(\r\n",
 					"#     \"id\", F.explode(\"fields\").alias(\"fields\")\r\n",
@@ -624,7 +602,6 @@
 				},
 				"source": [
 					"# import pyspark.sql.functions as F \r\n",
-					"# @logging_to_appins\r\n",
 					"# def custom_fields_table():\r\n",
 					"#     custom_fields = shows.select(\r\n",
 					"#     \"id\", F.explode(\"custom_fields\").alias(\"custom_fields\")\r\n",
@@ -723,40 +700,39 @@
 						"3bdf619d-6e98-4047-8495-94d579792d6b": {
 							"text": "tick",
 							"start": {
-								"line": 17,
+								"line": 16,
 								"column": 33
 							},
 							"end": {
-								"line": 17,
+								"line": 16,
 								"column": 37
 							}
 						},
 						"437e3dbd-79c9-4db6-bfb3-2bce1e8ea056": {
 							"text": " comments_and_attachments():",
 							"start": {
-								"line": 2,
+								"line": 1,
 								"column": 6
 							},
 							"end": {
-								"line": 2,
+								"line": 1,
 								"column": 34
 							}
 						},
 						"99e88483-8d34-41b4-882e-7e79a22f8872": {
 							"text": "sFlatCommentsDictList.write.saveAsTable(\"odw_harmonised_db.zendesk_comments\")",
 							"start": {
-								"line": 36,
+								"line": 35,
 								"column": 7
 							},
 							"end": {
-								"line": 36,
+								"line": 35,
 								"column": 84
 							}
 						}
 					}
 				},
 				"source": [
-					"# @logging_to_appins\r\n",
 					"# def comments_and_attachments():\r\n",
 					"#     #create empty list to store the values of the comments \r\n",
 					"#     FlatCommentsDictList=[]\r\n",
@@ -832,18 +808,17 @@
 						"52e648f1-d6c1-4fdb-a508-ed450b8ca1cb": {
 							"text": "schema = StructType([StructField(\"foo\", StringType(), True)])",
 							"start": {
-								"line": 24,
+								"line": 23,
 								"column": 7
 							},
 							"end": {
-								"line": 24,
+								"line": 23,
 								"column": 68
 							}
 						}
 					}
 				},
 				"source": [
-					"# @logging_to_appins\r\n",
 					"# def assignee_table(list_with_all_zendesk_dict):\r\n",
 					"#     assigneelist=[]\r\n",
 					"#     for assigneecolumn in list_with_all_zendesk_dict:\r\n",
@@ -891,7 +866,6 @@
 					}
 				},
 				"source": [
-					"# @logging_to_appins\r\n",
 					"# def submitter_table(list_with_all_zendesk_dict):\r\n",
 					"#     submitterlist=[]\r\n",
 					"#     for submittercolumn in list_with_all_zendesk_dict:\r\n",
@@ -939,7 +913,6 @@
 					}
 				},
 				"source": [
-					"# @logging_to_appins\r\n",
 					"# def requester_table(list_with_all_zendesk_dict):\r\n",
 					"#     requesterlist=[]\r\n",
 					"#     for requestercolumn in list_with_all_zendesk_dict:\r\n",
@@ -987,7 +960,6 @@
 					}
 				},
 				"source": [
-					"# @logging_to_appins\r\n",
 					"# def collaborator_table(list_with_all_zendesk_dict):\r\n",
 					"#     collaboratorlist=[]\r\n",
 					"#     for collaboratorcolumn in list_with_all_zendesk_dict:\r\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
