### PR TITLE
Updating notebook: document_metadata

### DIFF
--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "33ea19c6-980d-4a29-9173-c7896360b08e"
+				"spark.autotune.trackingId": "f95f6438-f8f2-4809-bf9b-21b2a5d07d89"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "35272798-6855-4baa-b325-16fc5cbfe82a"
+				"spark.autotune.trackingId": "33ea19c6-980d-4a29-9173-c7896360b08e"
 			}
 		},
 		"metadata": {
@@ -77,8 +77,8 @@
 					"MD.Name\t                                AS\toriginalFilename,\n",
 					"CAST(MD.DataSize AS INT)\t            AS\tsize,\n",
 					"AMD.mime\t                            AS\tmime,\n",
-					"AMD.documentUri\t                        AS\tdocumentURI,\n",
-					"AMD.documentUri\t\t                    AS\tpublishedDocumentURI,\n",
+					"AMD.DocumentURL\t                        AS\tdocumentURI,\n",
+					"AMD.DocumentURL\t\t                    AS\tpublishedDocumentURI,\n",
 					"MD.virusCheckStatus\t                    AS\tvirusCheckStatus,\n",
 					"AMD.fileMd5\t                            AS\tfileMd5,\n",
 					"MD.CreateDate\t                        AS\tdateCreated,\n",
@@ -107,7 +107,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 4
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -126,7 +126,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": 5
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -158,7 +158,7 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": 6
+				"execution_count": 5
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
