### PR TITLE
Mvg/fix/aie document

### DIFF
--- a/workspace/notebook/aie_document_data.json
+++ b/workspace/notebook/aie_document_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d944f18d-abb9-4ed7-8f9e-ab002b87f770"
+				"spark.autotune.trackingId": "5451652e-192b-4074-bb98-f0c057388c04"
 			}
 		},
 		"metadata": {
@@ -226,7 +226,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.aie_document_data)\r\n",
 					";"
 				],
-				"execution_count": 28
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -255,7 +255,7 @@
 					"SELECT * FROM aie_document_data_new WHERE DocumentID = '15325199';\n",
 					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15325199';"
 				],
-				"execution_count": 29
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -399,7 +399,7 @@
 					"AND IsActive = 'Y'; \r\n",
 					""
 				],
-				"execution_count": 2
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -480,7 +480,7 @@
 					"FROM aie_document_data_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 3
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -633,7 +633,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 4
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -717,7 +717,7 @@
 					"FROM odw_harmonised_db.aie_document_data;\r\n",
 					""
 				],
-				"execution_count": 5
+				"execution_count": 8
 			}
 		]
 	}

--- a/workspace/notebook/aie_document_data.json
+++ b/workspace/notebook/aie_document_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b19d3014-e3d2-499d-8bf7-56f554c2f272"
+				"spark.autotune.trackingId": "8f875304-7de6-488b-bfd8-624b38fc65f0"
 			}
 		},
 		"metadata": {
@@ -219,7 +219,7 @@
 					"                \r\n",
 					"            )) <> T3.RowID  -- same record, changed data\r\n",
 					"        THEN 'Y'\r\n",
-					"        WHEN T1.DocumentID IS NULL -- new record\r\n",
+					"        WHEN T3.DocumentID IS NULL -- new record\r\n",
 					"        THEN 'Y'\r\n",
 					"    ELSE 'N'\r\n",
 					"    END  = 'Y' )\r\n",

--- a/workspace/notebook/aie_document_data.json
+++ b/workspace/notebook/aie_document_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8f875304-7de6-488b-bfd8-624b38fc65f0"
+				"spark.autotune.trackingId": "d944f18d-abb9-4ed7-8f9e-ab002b87f770"
 			}
 		},
 		"metadata": {
@@ -216,18 +216,46 @@
 					"                IFNULL(T1.stage\t,'.'),\r\n",
 					"                IFNULL(T1.filter1,'.'),\r\n",
 					"                IFNULL(T1.filter2,'.')\r\n",
-					"                \r\n",
 					"            )) <> T3.RowID  -- same record, changed data\r\n",
 					"        THEN 'Y'\r\n",
-					"        WHEN T3.DocumentID IS NULL -- new record\r\n",
+					"        WHEN T3.DocumentID IS NULL -- AND T3.DateCreated IS NULL-- new record\r\n",
 					"        THEN 'Y'\r\n",
-					"    ELSE 'N'\r\n",
+					"        ELSE 'N'\r\n",
 					"    END  = 'Y' )\r\n",
 					"    AND T1.documentid IS NOT NULL\r\n",
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.aie_document_data)\r\n",
 					";"
 				],
-				"execution_count": 1
+				"execution_count": 28
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT count(*) FROM odw_standardised_db.aie_document_data;\n",
+					"SELECT count(*) FROM aie_document_data_new;\n",
+					"SELECT count(*) FROM odw_harmonised_db.aie_document_data;\n",
+					"\n",
+					"SELECT * FROM aie_document_data_new WHERE DocumentID = '15325199';\n",
+					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15325199';"
+				],
+				"execution_count": 29
 			},
 			{
 				"cell_type": "markdown",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
