### PR TITLE
Mvg/fix/nsip document

### DIFF
--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3613c783-747d-4a82-aa91-0bc3e26fbc78"
+				"spark.autotune.trackingId": "566440d0-b9d5-4bf8-bc86-65382351e4a4"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"SELECT DISTINCT \n",
 					"MD.DataId\t                            AS\tdocumentId,\n",
 					"CAST(MD.CaseNodeId AS INT)\t            AS\tcaseId,\n",
-					"MD.caseReference\t                    AS\tcaseReference,\n",
+					"MD.caseReference\t                    AS\tcaseRef,\n",
 					"MD.documentReference\t                AS\tdocumentReference,\n",
 					"CAST(MD.Version AS INT)                 AS\tversion,\n",
 					"AMD.examinationRefNo\t                AS\texaminationRefNo,\n",

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7e554a4d-0fae-4236-b45b-32a71ef8ce03"
+				"spark.autotune.trackingId": "58f5014e-d35b-429a-85e2-fa29e8c03129"
 			}
 		},
 		"metadata": {
@@ -83,8 +83,8 @@
 					"MD.virusCheckStatus\t                    AS virusCheckStatus,\n",
 					"AMD.fileMd5\t                            AS fileMD5,\n",
 					"MD.CreateDate\t                        AS dateCreated,\n",
-					"MD.ModifyDate\t                        AS astModified,\n",
-					"LOWER(MD.CaseworkType)\t                AS aseType,\n",
+					"MD.ModifyDate\t                        AS lastModified,\n",
+					"LOWER(MD.CaseworkType)\t                AS caseType,\n",
 					"CASE\n",
 					"    WHEN AMD.redactedStatus = ' '    \n",
 					"    THEN NULL\n",

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8869d064-f823-4fe3-8e52-45eac3504831"
+				"spark.autotune.trackingId": "7e554a4d-0fae-4236-b45b-32a71ef8ce03"
 			}
 		},
 		"metadata": {
@@ -79,7 +79,7 @@
 					"AMD.mime\t                            AS mime,\n",
 					"AMD.DocumentURI\t                        AS documentURI,\n",
 					"AMD.DocumentURI\t\t                    AS publishedDocumentURI,\n",
-					"NULL                                    AS path,\n",
+					"AMD.Path                                AS path,\n",
 					"MD.virusCheckStatus\t                    AS virusCheckStatus,\n",
 					"AMD.fileMd5\t                            AS fileMD5,\n",
 					"MD.CreateDate\t                        AS dateCreated,\n",
@@ -90,10 +90,14 @@
 					"    THEN NULL\n",
 					"    ELSE AMD.redactedStatus                \n",
 					"END                                     AS redactedStatus,\n",
-					"REPLACE(\n",
-					"    LOWER(MD.PublishedStatus),\n",
-					"    ' ',\n",
-					"    '_')                 \t            AS publishedStatus,\n",
+					"CASE\n",
+					"    WHEN MD.PublishedStatus = 'Depublished'\n",
+					"    THEN 'unpublished'\n",
+					"    ELSE REPLACE(\n",
+					"        LOWER(MD.PublishedStatus),\n",
+					"        ' ',\n",
+					"        '_')\n",
+					"END                  \t                AS publishedStatus,\n",
 					"CAST(MD.DatePublished AS DATE)\t        AS datePublished,\n",
 					"MD.DocumentType\t                        AS documentType,\n",
 					"CASE\n",
@@ -123,31 +127,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 16
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.vw_document_metadata;"
-				],
-				"execution_count": 17
+				"execution_count": 50
 			},
 			{
 				"cell_type": "code",
@@ -166,7 +146,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": 15
+				"execution_count": 52
 			},
 			{
 				"cell_type": "code",
@@ -198,30 +178,7 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": 13
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					}
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.document_meta_data"
-				],
-				"execution_count": 14
+				"execution_count": 53
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d9d423bd-ac8a-43ed-9cc7-3665ed5eb3ee"
+				"spark.autotune.trackingId": "3613c783-747d-4a82-aa91-0bc3e26fbc78"
 			}
 		},
 		"metadata": {
@@ -89,12 +89,23 @@
 					"    THEN NULL\n",
 					"    ELSE AMD.redactedStatus                \n",
 					"END                                     AS\tredactedStatus,\n",
-					"LOWER(MD.PublishedStatus)\t            AS\tpublishedStatus,\n",
+					"REPLACE(\n",
+					"    LOWER(MD.PublishedStatus),\n",
+					"    ' ',\n",
+					"    '_')                 \t            AS\tpublishedStatus,\n",
 					"CAST(MD.DatePublished AS DATE)\t        AS\tdatePublished,\n",
 					"MD.DocumentType\t                        AS\tdocumentType,\n",
-					"AMD.securityClassification\t            AS\tsecurityClassification,\n",
+					"CASE\n",
+					"    WHEN AMD.securityClassification = ' '\n",
+					"    THEN NULL\n",
+					"    ELSE AMD.securityClassification\n",
+					"END\t                                    AS\tsecurityClassification,\n",
 					"MD.SourceSystem\t                        AS\tsourceSystem,\n",
-					"AMD.origin                              AS\torigin,\n",
+					"CASE\n",
+					"    WHEN AMD.origin  = ' '\n",
+					"    THEN NULL\n",
+					"    ELSE AMD.origin\n",
+					"END\t                                    AS\torigin,\n",
 					"AMD.owner                               AS\towner,\n",
 					"MD.Author\t                            AS\tauthor,\n",
 					"MD.Representative\t                    AS\trepresentative,\n",
@@ -111,7 +122,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -130,7 +141,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": 2
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -162,7 +173,7 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": 3
+				"execution_count": 8
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "26f11b85-146c-4949-986c-5eb5a9cf53e3"
+				"spark.autotune.trackingId": "0e2ae5eb-6735-41a5-b1bb-ae6a2e16a9ef"
 			}
 		},
 		"metadata": {
@@ -81,8 +81,7 @@
 					"AMD.DocumentURI\t\t                    AS\tpublishedDocumentURI,\n",
 					"NULL                                    AS path,\n",
 					"MD.virusCheckStatus\t                    AS\tvirusCheckStatus,\n",
-					"NULL                                    AS fileMD5,\n",
-					"AMD.fileMd5\t                            AS\tfileMd5,\n",
+					"AMD.fileMd5\t                            AS\tfileMD5,\n",
 					"MD.CreateDate\t                        AS\tdateCreated,\n",
 					"MD.ModifyDate\t                        AS\tlastModified,\n",
 					"LOWER(MD.CaseworkType)\t                AS\tcaseType,\n",
@@ -124,7 +123,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 13
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -143,7 +142,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -175,7 +174,7 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": null
+				"execution_count": 23
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0e2ae5eb-6735-41a5-b1bb-ae6a2e16a9ef"
+				"spark.autotune.trackingId": "de8a8f85-0db6-41ee-9854-65d9d78b06db"
 			}
 		},
 		"metadata": {
@@ -62,9 +62,9 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"CREATE OR REPLACE VIEW odw_curated_db.vw_document_metadata\n",
+					"-- CREATE OR REPLACE VIEW odw_curated_db.vw_document_metadata\n",
 					"\n",
-					"AS\n",
+					"-- AS\n",
 					"\n",
 					"SELECT DISTINCT \n",
 					"MD.DataId\t                            AS\tdocumentId,\n",
@@ -123,7 +123,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 21
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -142,7 +142,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": 22
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -174,7 +174,30 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": 23
+				"execution_count": 32
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					}
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_curated_db.document_meta_data"
+				],
+				"execution_count": 33
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "de8a8f85-0db6-41ee-9854-65d9d78b06db"
+				"spark.autotune.trackingId": "8869d064-f823-4fe3-8e52-45eac3504831"
 			}
 		},
 		"metadata": {
@@ -62,60 +62,60 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"-- CREATE OR REPLACE VIEW odw_curated_db.vw_document_metadata\n",
+					"CREATE OR REPLACE VIEW odw_curated_db.vw_document_metadata\n",
 					"\n",
-					"-- AS\n",
+					"AS\n",
 					"\n",
 					"SELECT DISTINCT \n",
-					"MD.DataId\t                            AS\tdocumentId,\n",
-					"CAST(MD.CaseNodeId AS INT)\t            AS\tcaseId,\n",
-					"MD.caseReference\t                    AS\tcaseRef,\n",
-					"MD.documentReference\t                AS\tdocumentReference,\n",
-					"CAST(MD.Version AS INT)                 AS\tversion,\n",
-					"AMD.examinationRefNo\t                AS\texaminationRefNo,\n",
-					"MD.Name\t                                AS\tfilename,\n",
-					"MD.Name\t                                AS\toriginalFilename,\n",
-					"CAST(MD.DataSize AS INT)\t            AS\tsize,\n",
-					"AMD.mime\t                            AS\tmime,\n",
-					"AMD.DocumentURI\t                        AS\tdocumentURI,\n",
-					"AMD.DocumentURI\t\t                    AS\tpublishedDocumentURI,\n",
+					"MD.DataId\t                            AS documentId,\n",
+					"CAST(MD.CaseNodeId AS INT)\t            AS caseId,\n",
+					"MD.caseReference\t                    AS caseRef,\n",
+					"MD.documentReference\t                AS documentReference,\n",
+					"CAST(MD.Version AS INT)                 AS version,\n",
+					"AMD.examinationRefNo\t                AS examinationRefNo,\n",
+					"MD.Name\t                                AS filename,\n",
+					"MD.Name\t                                AS originalFilename,\n",
+					"CAST(MD.DataSize AS INT)\t            AS size,\n",
+					"AMD.mime\t                            AS mime,\n",
+					"AMD.DocumentURI\t                        AS documentURI,\n",
+					"AMD.DocumentURI\t\t                    AS publishedDocumentURI,\n",
 					"NULL                                    AS path,\n",
-					"MD.virusCheckStatus\t                    AS\tvirusCheckStatus,\n",
-					"AMD.fileMd5\t                            AS\tfileMD5,\n",
-					"MD.CreateDate\t                        AS\tdateCreated,\n",
-					"MD.ModifyDate\t                        AS\tlastModified,\n",
-					"LOWER(MD.CaseworkType)\t                AS\tcaseType,\n",
+					"MD.virusCheckStatus\t                    AS virusCheckStatus,\n",
+					"AMD.fileMd5\t                            AS fileMD5,\n",
+					"MD.CreateDate\t                        AS dateCreated,\n",
+					"MD.ModifyDate\t                        AS astModified,\n",
+					"LOWER(MD.CaseworkType)\t                AS aseType,\n",
 					"CASE\n",
 					"    WHEN AMD.redactedStatus = ' '    \n",
 					"    THEN NULL\n",
 					"    ELSE AMD.redactedStatus                \n",
-					"END                                     AS\tredactedStatus,\n",
+					"END                                     AS redactedStatus,\n",
 					"REPLACE(\n",
 					"    LOWER(MD.PublishedStatus),\n",
 					"    ' ',\n",
-					"    '_')                 \t            AS\tpublishedStatus,\n",
-					"CAST(MD.DatePublished AS DATE)\t        AS\tdatePublished,\n",
-					"MD.DocumentType\t                        AS\tdocumentType,\n",
+					"    '_')                 \t            AS publishedStatus,\n",
+					"CAST(MD.DatePublished AS DATE)\t        AS datePublished,\n",
+					"MD.DocumentType\t                        AS documentType,\n",
 					"CASE\n",
 					"    WHEN AMD.securityClassification = ' '\n",
 					"    THEN NULL\n",
 					"    ELSE AMD.securityClassification\n",
-					"END\t                                    AS\tsecurityClassification,\n",
-					"MD.SourceSystem\t                        AS\tsourceSystem,\n",
+					"END\t                                    AS securityClassification,\n",
+					"MD.SourceSystem\t                        AS sourceSystem,\n",
 					"CASE\n",
 					"    WHEN AMD.origin  = ' '\n",
 					"    THEN NULL\n",
 					"    ELSE AMD.origin\n",
-					"END\t                                    AS\torigin,\n",
-					"AMD.owner                               AS\towner,\n",
-					"MD.Author\t                            AS\tauthor,\n",
-					"MD.Representative\t                    AS\trepresentative,\n",
-					"MD.DocumentDescription\t                AS\tdescription,\n",
-					"LOWER(MD.DocumentCaseStage)\t            AS\tdocumentCaseStage,\n",
-					"MD.Filter1\t                            AS\tfilter1,\n",
-					"MD.Filter2\t                            AS\tfilter2,\n",
-					"MD.ParentID\t                            AS\thorizonFolderId,\n",
-					"'NULL'\t                                AS\ttranscriptId\t\n",
+					"END\t                                    AS origin,\n",
+					"AMD.owner                               AS owner,\n",
+					"MD.Author\t                            AS author,\n",
+					"MD.Representative\t                    AS representative,\n",
+					"MD.DocumentDescription\t                AS description,\n",
+					"LOWER(MD.DocumentCaseStage)\t            AS documentCaseStage,\n",
+					"MD.Filter1\t                            AS filter1,\n",
+					"MD.Filter2\t                            AS filter2,\n",
+					"MD.ParentID\t                            AS horizonFolderId,\n",
+					"'NULL'\t                                AS transcriptId\t\n",
 					"\n",
 					"FROM odw_harmonised_db.document_meta_data   AS MD\n",
 					"JOIN odw_harmonised_db.aie_document_data    AS AMD\n",
@@ -123,7 +123,31 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 28
+				"execution_count": 16
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_curated_db.vw_document_metadata;"
+				],
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -142,7 +166,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": 29
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -174,7 +198,7 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": 32
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -197,7 +221,7 @@
 					"\n",
 					"SELECT * FROM odw_curated_db.document_meta_data"
 				],
-				"execution_count": 33
+				"execution_count": 14
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "566440d0-b9d5-4bf8-bc86-65382351e4a4"
+				"spark.autotune.trackingId": "26f11b85-146c-4949-986c-5eb5a9cf53e3"
 			}
 		},
 		"metadata": {
@@ -79,7 +79,9 @@
 					"AMD.mime\t                            AS\tmime,\n",
 					"AMD.DocumentURI\t                        AS\tdocumentURI,\n",
 					"AMD.DocumentURI\t\t                    AS\tpublishedDocumentURI,\n",
+					"NULL                                    AS path,\n",
 					"MD.virusCheckStatus\t                    AS\tvirusCheckStatus,\n",
+					"NULL                                    AS fileMD5,\n",
 					"AMD.fileMd5\t                            AS\tfileMd5,\n",
 					"MD.CreateDate\t                        AS\tdateCreated,\n",
 					"MD.ModifyDate\t                        AS\tlastModified,\n",
@@ -122,7 +124,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 6
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -141,7 +143,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -173,7 +175,7 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": 8
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "83e3b765-85c8-4155-ae23-9a42686bb362"
+				"spark.autotune.trackingId": "d9d423bd-ac8a-43ed-9cc7-3665ed5eb3ee"
 			}
 		},
 		"metadata": {
@@ -84,7 +84,11 @@
 					"MD.CreateDate\t                        AS\tdateCreated,\n",
 					"MD.ModifyDate\t                        AS\tlastModified,\n",
 					"LOWER(MD.CaseworkType)\t                AS\tcaseType,\n",
-					"AMD.redactedStatus\t                    AS\tredactedStatus,\n",
+					"CASE\n",
+					"    WHEN AMD.redactedStatus = ' '    \n",
+					"    THEN NULL\n",
+					"    ELSE AMD.redactedStatus                \n",
+					"END                                     AS\tredactedStatus,\n",
 					"LOWER(MD.PublishedStatus)\t            AS\tpublishedStatus,\n",
 					"CAST(MD.DatePublished AS DATE)\t        AS\tdatePublished,\n",
 					"MD.DocumentType\t                        AS\tdocumentType,\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
