### PR TITLE
Updating notebook: document_metadata

### DIFF
--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "58f5014e-d35b-429a-85e2-fa29e8c03129"
+				"spark.autotune.trackingId": "cc5dfca8-1808-4d8b-b6f8-b020230ea806"
 			}
 		},
 		"metadata": {
@@ -115,7 +115,11 @@
 					"MD.Author\t                            AS author,\n",
 					"MD.Representative\t                    AS representative,\n",
 					"MD.DocumentDescription\t                AS description,\n",
-					"LOWER(MD.DocumentCaseStage)\t            AS documentCaseStage,\n",
+					"CASE\n",
+					"    WHEN MD.DocumentCaseStage = \"Developer's Application\"\n",
+					"    THEN 'developers_application'\n",
+					"    ELSE LOWER(MD.DocumentCaseStage)\t            \n",
+					"END                                     AS documentCaseStage,\n",
 					"MD.Filter1\t                            AS filter1,\n",
 					"MD.Filter2\t                            AS filter2,\n",
 					"MD.ParentID\t                            AS horizonFolderId,\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
