### PR TITLE
Mvg/fix/doc tables

### DIFF
--- a/workspace/notebook/document_meta_data.json
+++ b/workspace/notebook/document_meta_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4e0198c2-0eb5-4d96-be51-ef365aee95d8"
+				"spark.autotune.trackingId": "6c46b40f-43d7-4b42-99e9-c95a7b13ab79"
 			}
 		},
 		"metadata": {
@@ -190,6 +190,19 @@
 					"                IFNULL(T1.filter2,'.'),\r\n",
 					"                IFNULL(T1.parentID,'.')\r\n",
 					"            )) <> T3.RowID  -- same record, changed data\r\n",
+					"        THEN 'Y'\r\n",
+					"        \r\n",
+					"        WHEN T1.dataid NOT IN (\r\n",
+					"            SELECT DISTINCT(DataId) \r\n",
+					"            FROM odw_harmonised_db.aie_document_data)\r\n",
+					"        THEN 'Y'\r\n",
+					"        WHEN T1.dataid IN (\r\n",
+					"            SELECT DISTINCT(DataId) \r\n",
+					"            FROM odw_harmonised_db.aie_document_data) AND\r\n",
+					"            T1.Version NOT IN (\r\n",
+					"            SELECT DISTINCT(Version) \r\n",
+					"            FROM odw_harmonised_db.aie_document_data) \r\n",
+					"\r\n",
 					"        THEN 'Y'\r\n",
 					"        WHEN T3.DataID IS NULL -- new record\r\n",
 					"        THEN 'Y'\r\n",

--- a/workspace/notebook/document_meta_data.json
+++ b/workspace/notebook/document_meta_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6c46b40f-43d7-4b42-99e9-c95a7b13ab79"
+				"spark.autotune.trackingId": "e574d196-3048-43f8-9db1-50383e24e14e"
 			}
 		},
 		"metadata": {
@@ -194,14 +194,14 @@
 					"        \r\n",
 					"        WHEN T1.dataid NOT IN (\r\n",
 					"            SELECT DISTINCT(DataId) \r\n",
-					"            FROM odw_harmonised_db.aie_document_data)\r\n",
+					"            FROM odw_harmonised_db.document_meta_data)\r\n",
 					"        THEN 'Y'\r\n",
 					"        WHEN T1.dataid IN (\r\n",
 					"            SELECT DISTINCT(DataId) \r\n",
-					"            FROM odw_harmonised_db.aie_document_data) AND\r\n",
+					"            FROM odw_harmonised_db.document_meta_data) AND\r\n",
 					"            T1.Version NOT IN (\r\n",
 					"            SELECT DISTINCT(Version) \r\n",
-					"            FROM odw_harmonised_db.aie_document_data) \r\n",
+					"            FROM odw_harmonised_db.document_meta_data) \r\n",
 					"\r\n",
 					"        THEN 'Y'\r\n",
 					"        WHEN T3.DataID IS NULL -- new record\r\n",
@@ -212,7 +212,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.document_meta_data)\r\n",
 					";"
 				],
-				"execution_count": 3
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -239,10 +239,9 @@
 					"\n",
 					"-- SELECT * FROM aie_document_data_new WHERE DocumentID = '15325199';\n",
 					"-- SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15325199';\n",
-					"\n",
-					"SELECT * FROM odw_harmonised_db.document_meta_data WHERE DocumentID IS NULL;"
+					""
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/document_meta_data.json
+++ b/workspace/notebook/document_meta_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e574d196-3048-43f8-9db1-50383e24e14e"
+				"spark.autotune.trackingId": "9ccb0db7-2995-49a6-ba29-9cc89e78c71b"
 			}
 		},
 		"metadata": {
@@ -213,35 +213,6 @@
 					";"
 				],
 				"execution_count": 2
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					}
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT count(*) FROM odw_standardised_db.document_meta_data;\n",
-					"SELECT count(*) FROM document_meta_data_new;\n",
-					"SELECT count(*) FROM odw_harmonised_db.document_meta_data;\n",
-					"\n",
-					"-- SELECT * FROM aie_document_data_new WHERE DocumentID = '15325199';\n",
-					"-- SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15325199';\n",
-					""
-				],
-				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
