### PR TITLE
Fix/odw 1121

### DIFF
--- a/workspace/notebook/casework_nsip_advice_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_advice_dim_legacy.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a2e9d3ba-3519-46ff-9a6d-b615d4552691"
+				"spark.autotune.trackingId": "36ecabd6-d5dd-4735-a100-b20a7c626a23"
 			}
 		},
 		"metadata": {
@@ -104,7 +104,7 @@
 					"    T1.advicestatus                                             AS AdviceStatus,\r\n",
 					"    T1.section51advice                                          AS Section51Advice,\r\n",
 					"    T1.enquirerfirstname                                        AS EnquirerFirstName,\r\n",
-					"    concat(T1.enquirerlastname,' ',T1.enquirerlastname)         AS Enquirer,\r\n",
+					"    concat(T1.enquirerfirstname,' ',T1.enquirerlastname)        AS Enquirer,\r\n",
 					"    T1.enquirerorganisation                                     AS EnquirerOrganisation,\r\n",
 					"    T1.enquirydate                                              AS EnquiryDate,\r\n",
 					"    T1.enqirymethod                                             AS EnquiryMethod,\r\n",

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "nsip_applicant_service_user",
+				"name": "casework_nsip_advice_dim_legacy",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -16,7 +16,34 @@
 				"userProperties": [],
 				"typeProperties": {
 					"notebook": {
-						"referenceName": "nsip_applicant_service_user",
+						"referenceName": "casework_nsip_advice_dim_legacy",
+						"type": "NotebookReference"
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "nsip_s51_advice",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "casework_nsip_advice_dim_legacy",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "nsip_s51_advice",
 						"type": "NotebookReference"
 					},
 					"snapshot": true


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
