### PR TITLE
Fix/action group change

### DIFF
--- a/infrastructure/modules/synapse-monitoring/README.md
+++ b/infrastructure/modules/synapse-monitoring/README.md
@@ -98,9 +98,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_group_platform_enabled"></a> [alert\_group\_platform\_enabled](#input\_alert\_group\_platform\_enabled) | Determines whether the alert group for platform alerts is enabled | `bool` | `false` | no |
-| <a name="input_alert_group_platform_recipients"></a> [alert\_group\_platform\_recipients](#input\_alert\_group\_platform\_recipients) | A list of email recipients to recieve platform alerts | `list(string)` | `[]` | no |
 | <a name="input_alert_group_synapse_enabled"></a> [alert\_group\_synapse\_enabled](#input\_alert\_group\_synapse\_enabled) | Determines whether the alert group for Synapse alerts is enabled | `bool` | `false` | no |
-| <a name="input_alert_group_synapse_recipients"></a> [alert\_group\_synapse\_recipients](#input\_alert\_group\_synapse\_recipients) | A list of email recipients to recieve Synapse alerts | `list(string)` | `[]` | no |
 | <a name="input_alert_scope_service_health"></a> [alert\_scope\_service\_health](#input\_alert\_scope\_service\_health) | The resource scope at which to alert on service health events | `string` | n/a | yes |
 | <a name="input_alert_threshold_data_lake_capacity_bytes"></a> [alert\_threshold\_data\_lake\_capacity\_bytes](#input\_alert\_threshold\_data\_lake\_capacity\_bytes) | The threshold at which to trigger an alert for exceeding Data Lake capacity in bytes | `number` | `1099511627776` | no |
 | <a name="input_data_lake_account_id"></a> [data\_lake\_account\_id](#input\_data\_lake\_account\_id) | The ID of the Data Lake Storage Account from which to collect diagnostic logs | `string` | n/a | yes |

--- a/infrastructure/modules/synapse-monitoring/alert-groups.tf
+++ b/infrastructure/modules/synapse-monitoring/alert-groups.tf
@@ -2,7 +2,7 @@ resource "azurerm_monitor_action_group" "platform_alerts" {
   name                = "pins-ag-platform-${local.resource_suffix}"
   resource_group_name = var.resource_group_name
   short_name          = "ODW Platform"
-  
+
   # we set emails in the action groups in Azure Portal - to avoid needing to manage
   # emails in terraform
   lifecycle {

--- a/infrastructure/modules/synapse-monitoring/alert-groups.tf
+++ b/infrastructure/modules/synapse-monitoring/alert-groups.tf
@@ -2,17 +2,13 @@ resource "azurerm_monitor_action_group" "platform_alerts" {
   name                = "pins-ag-platform-${local.resource_suffix}"
   resource_group_name = var.resource_group_name
   short_name          = "ODW Platform"
-  enabled             = var.alert_group_platform_enabled
-
-  dynamic "email_receiver" {
-    for_each = toset(var.alert_group_platform_recipients)
-    iterator = mapping
-
-    content {
-      name                    = "Send to ${mapping.key}"
-      email_address           = mapping.key
-      use_common_alert_schema = true
-    }
+  
+  # we set emails in the action groups in Azure Portal - to avoid needing to manage
+  # emails in terraform
+  lifecycle {
+    ignore_changes = [
+      email_receiver
+    ]
   }
 
   tags = local.tags
@@ -24,15 +20,12 @@ resource "azurerm_monitor_action_group" "synapse_alerts" {
   short_name          = "ODW Synapse"
   enabled             = var.alert_group_synapse_enabled
 
-  dynamic "email_receiver" {
-    for_each = toset(var.alert_group_synapse_recipients)
-    iterator = mapping
-
-    content {
-      name                    = "Send to ${mapping.key}"
-      email_address           = mapping.key
-      use_common_alert_schema = true
-    }
+  # we set emails in the action groups in Azure Portal - to avoid needing to manage
+  # emails in terraform
+  lifecycle {
+    ignore_changes = [
+      email_receiver
+    ]
   }
 
   tags = local.tags

--- a/infrastructure/modules/synapse-monitoring/variables.tf
+++ b/infrastructure/modules/synapse-monitoring/variables.tf
@@ -4,22 +4,10 @@ variable "alert_group_platform_enabled" {
   type        = bool
 }
 
-variable "alert_group_platform_recipients" {
-  default     = []
-  description = "A list of email recipients to recieve platform alerts"
-  type        = list(string)
-}
-
 variable "alert_group_synapse_enabled" {
   default     = false
   description = "Determines whether the alert group for Synapse alerts is enabled"
   type        = bool
-}
-
-variable "alert_group_synapse_recipients" {
-  default     = []
-  description = "A list of email recipients to recieve Synapse alerts"
-  type        = list(string)
 }
 
 variable "alert_scope_service_health" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -4,22 +4,10 @@ variable "alert_group_platform_enabled" {
   type        = bool
 }
 
-variable "alert_group_platform_recipients" {
-  default     = []
-  description = "A list of email recipients to recieve platform alerts"
-  type        = list(string)
-}
-
 variable "alert_group_synapse_enabled" {
   default     = false
   description = "Determines whether the alert group for Synapse alerts is enabled"
   type        = bool
-}
-
-variable "alert_group_synapse_recipients" {
-  default     = []
-  description = "A list of email recipients to recieve Synapse alerts"
-  type        = list(string)
 }
 
 variable "alert_scope_service_health" {

--- a/infrastructure/workload-monitoring.tf
+++ b/infrastructure/workload-monitoring.tf
@@ -23,9 +23,7 @@ module "synapse_monitoring" {
   service_name        = local.service_name
 
   alert_group_platform_enabled             = var.alert_group_platform_enabled
-  alert_group_platform_recipients          = var.alert_group_platform_recipients
   alert_group_synapse_enabled              = var.alert_group_synapse_enabled
-  alert_group_synapse_recipients           = var.alert_group_synapse_recipients
   alert_scope_service_health               = var.alert_scope_service_health
   alert_threshold_data_lake_capacity_bytes = var.alert_threshold_data_lake_capacity_bytes
   data_lake_account_id                     = module.synapse_data_lake.data_lake_account_id
@@ -53,9 +51,7 @@ module "synapse_monitoring_failover" {
   service_name        = local.service_name
 
   alert_group_platform_enabled             = var.alert_group_platform_enabled
-  alert_group_platform_recipients          = var.alert_group_platform_recipients
   alert_group_synapse_enabled              = var.alert_group_synapse_enabled
-  alert_group_synapse_recipients           = var.alert_group_synapse_recipients
   alert_scope_service_health               = var.alert_scope_service_health
   alert_threshold_data_lake_capacity_bytes = var.alert_threshold_data_lake_capacity_bytes
   data_lake_account_id                     = module.synapse_data_lake_failover.data_lake_account_id


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
