### PR TITLE
Mvg/fix/folder harmonised

### DIFF
--- a/workspace/notebook/casework_nsip_advice_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_advice_dim_legacy.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e70352a5-7a8a-40ba-a7f2-182d536f8741"
+				"spark.autotune.trackingId": "4904683b-3852-4f2d-b62d-8ed15e613a6c"
 			}
 		},
 		"metadata": {
@@ -199,7 +199,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_nsip_advice)\r\n",
 					";"
 				],
-				"execution_count": 2
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -328,7 +328,7 @@
 					") \r\n",
 					"AND IsActive = 'Y'; "
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -401,7 +401,7 @@
 					"FROM casework_nsip_advice_dim_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -521,7 +521,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -597,7 +597,7 @@
 					"    FROM odw_harmonised_db.casework_nsip_advice_dim;\r\n",
 					""
 				],
-				"execution_count": 11
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/casework_nsip_advice_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_advice_dim_legacy.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4904683b-3852-4f2d-b62d-8ed15e613a6c"
+				"spark.autotune.trackingId": "f68e05d0-fb6d-483e-9cff-4e775f73da4a"
 			}
 		},
 		"metadata": {
@@ -200,6 +200,29 @@
 					";"
 				],
 				"execution_count": 3
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					}
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_harmonised_db.casework_nsip_advice_dim;"
+				],
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/casework_nsip_advice_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_advice_dim_legacy.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "36ecabd6-d5dd-4735-a100-b20a7c626a23"
+				"spark.autotune.trackingId": "e70352a5-7a8a-40ba-a7f2-182d536f8741"
 			}
 		},
 		"metadata": {
@@ -102,6 +102,7 @@
 					"    T1.casereference                                            AS CaseReference,\r\n",
 					"    T1.advicereference                                          AS AdviceReference,\r\n",
 					"    T1.advicestatus                                             AS AdviceStatus,\r\n",
+					"    NULL                                                        AS RedactionStatus,\r\n",
 					"    T1.section51advice                                          AS Section51Advice,\r\n",
 					"    T1.enquirerfirstname                                        AS EnquirerFirstName,\r\n",
 					"    concat(T1.enquirerfirstname,' ',T1.enquirerlastname)        AS Enquirer,\r\n",
@@ -198,7 +199,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_nsip_advice)\r\n",
 					";"
 				],
-				"execution_count": 7
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -248,6 +249,7 @@
 					"    CaseReference,\r\n",
 					"    AdviceReference,\r\n",
 					"    AdviceStatus,\r\n",
+					"    RedactionStatus,\r\n",
 					"    Section51Advice,\r\n",
 					"    Enquirer,\r\n",
 					"    EnquirerOrganisation,\r\n",
@@ -284,6 +286,7 @@
 					"    CaseReference,\r\n",
 					"    AdviceReference,\r\n",
 					"    AdviceStatus,\r\n",
+					"    RedactionStatus,\r\n",
 					"    Section51Advice,\r\n",
 					"    Enquirer,\r\n",
 					"    EnquirerOrganisation,\r\n",
@@ -369,6 +372,7 @@
 					"    CaseReference,\n",
 					"    AdviceReference,\n",
 					"    AdviceStatus,\n",
+					"    RedactionStatus,\n",
 					"    Section51Advice,\n",
 					"    Enquirer,\n",
 					"    EnquirerOrganisation,\n",
@@ -458,6 +462,7 @@
 					"        CaseReference,\r\n",
 					"        AdviceReference,\r\n",
 					"        AdviceStatus,\r\n",
+					"        RedactionStatus,\r\n",
 					"        Section51Advice,\r\n",
 					"        Enquirer,\r\n",
 					"        EnquirerOrganisation,\r\n",
@@ -489,6 +494,7 @@
 					"        Source.CaseReference,\r\n",
 					"        Source.AdviceReference,\r\n",
 					"        Source.AdviceStatus,\r\n",
+					"        Source.RedactionStatus,\r\n",
 					"        Source.Section51Advice,\r\n",
 					"        Source.Enquirer,\r\n",
 					"        Source.EnquirerOrganisation,\r\n",
@@ -563,6 +569,7 @@
 					"    CaseReference,\r\n",
 					"    AdviceReference,\r\n",
 					"    AdviceStatus,\r\n",
+					"    RedactionStatus,\r\n",
 					"    Section51Advice,\r\n",
 					"    Enquirer,\r\n",
 					"    EnquirerOrganisation,\r\n",

--- a/workspace/notebook/casework_nsip_advice_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_advice_dim_legacy.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f68e05d0-fb6d-483e-9cff-4e775f73da4a"
+				"spark.autotune.trackingId": "47fd84cc-8605-4bf9-abc2-60e329849ca0"
 			}
 		},
 		"metadata": {
@@ -199,7 +199,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_nsip_advice)\r\n",
 					";"
 				],
-				"execution_count": 3
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "dd2ce6fa-26c9-45ef-9125-4d5851d24642"
+				"spark.autotune.trackingId": "d2a05e60-9645-4587-86aa-0af396a3331c"
 			}
 		},
 		"metadata": {
@@ -93,7 +93,7 @@
 					"\r\n",
 					"SELECT DISTINCT\r\n",
 					"    CASE\r\n",
-					"        WHEN T1.casereference IS NULL\r\n",
+					"        WHEN T1.id IS NULL\r\n",
 					"        THEN T3.HorizonFolderID\r\n",
 					"        ELSE NULL\r\n",
 					"    END                             AS HorizonFolderID,\r\n",
@@ -149,7 +149,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_folder)\r\n",
 					";"
 				],
-				"execution_count": 8
+				"execution_count": 12
 			},
 			{
 				"cell_type": "markdown",
@@ -233,7 +233,7 @@
 					"FROM odw_harmonised_db.horizon_folder\r\n",
 					"WHERE ID IN (SELECT ID FROM horizon_folder_new WHERE HorizonFolderID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": 9
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -288,7 +288,7 @@
 					"FROM horizon_folder_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 10
+				"execution_count": 14
 			},
 			{
 				"cell_type": "markdown",
@@ -387,7 +387,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 11
+				"execution_count": 15
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "485622e7-3021-45ee-86d6-84eaf813b746"
+				"spark.autotune.trackingId": "3ed37e58-28d1-489c-b55d-74d30b295dfb"
 			}
 		},
 		"metadata": {
@@ -149,7 +149,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_folder)\r\n",
 					";"
 				],
-				"execution_count": 23
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -176,9 +176,13 @@
 					"SELECT count(*) FROM horizon_folder_new;\n",
 					"\n",
 					"SELECT count(*) FROM odw_harmonised_db.horizon_folder;\n",
+					"\n",
+					"SELECT * FROM horizon_folder_new;\n",
+					"\n",
+					"SELECT * FROM odw_harmonised_db.horizon_folder WHERE ID = '29309932'\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 32
 			},
 			{
 				"cell_type": "markdown",
@@ -262,7 +266,7 @@
 					"FROM odw_harmonised_db.horizon_folder\r\n",
 					"WHERE ID IN (SELECT ID FROM horizon_folder_new WHERE HorizonFolderID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": null
+				"execution_count": 25
 			},
 			{
 				"cell_type": "code",
@@ -317,7 +321,7 @@
 					"FROM horizon_folder_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": null
+				"execution_count": 26
 			},
 			{
 				"cell_type": "markdown",
@@ -416,7 +420,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": null
+				"execution_count": 27
 			},
 			{
 				"cell_type": "markdown",
@@ -474,7 +478,7 @@
 					"FROM odw_harmonised_db.horizon_folder;\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 28
 			}
 		]
 	}

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "511c1a33-4daf-4ead-9774-7d17273e14b9"
+				"spark.autotune.trackingId": "f403b9d2-2fbd-40c6-92f5-9b6070024f6b"
 			}
 		},
 		"metadata": {
@@ -343,7 +343,7 @@
 					"MERGE INTO odw_harmonised_db.horizon_folder AS Target\r\n",
 					"USING horizon_folder_changed_rows_final AS Source\r\n",
 					"\r\n",
-					"ON Source.CaseReference = Target.CaseReference\r\n",
+					"ON Source.ID = Target.ID\r\n",
 					"\r\n",
 					"-- For Updates existing rows\r\n",
 					"\r\n",

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f403b9d2-2fbd-40c6-92f5-9b6070024f6b"
+				"spark.autotune.trackingId": "dd2ce6fa-26c9-45ef-9125-4d5851d24642"
 			}
 		},
 		"metadata": {
@@ -149,7 +149,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_folder)\r\n",
 					";"
 				],
-				"execution_count": 1
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -233,7 +233,7 @@
 					"FROM odw_harmonised_db.horizon_folder\r\n",
 					"WHERE ID IN (SELECT ID FROM horizon_folder_new WHERE HorizonFolderID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": 10
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -288,7 +288,7 @@
 					"FROM horizon_folder_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 11
+				"execution_count": 10
 			},
 			{
 				"cell_type": "markdown",
@@ -343,7 +343,7 @@
 					"MERGE INTO odw_harmonised_db.horizon_folder AS Target\r\n",
 					"USING horizon_folder_changed_rows_final AS Source\r\n",
 					"\r\n",
-					"ON Source.ID = Target.ID\r\n",
+					"ON Source.ID = Target.ID AND Target.IsActive = 'Y'\r\n",
 					"\r\n",
 					"-- For Updates existing rows\r\n",
 					"\r\n",
@@ -387,7 +387,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 12
+				"execution_count": 11
 			},
 			{
 				"cell_type": "markdown",
@@ -445,7 +445,7 @@
 					"FROM odw_harmonised_db.horizon_folder;\r\n",
 					""
 				],
-				"execution_count": 13
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d2a05e60-9645-4587-86aa-0af396a3331c"
+				"spark.autotune.trackingId": "485622e7-3021-45ee-86d6-84eaf813b746"
 			}
 		},
 		"metadata": {
@@ -149,7 +149,36 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_folder)\r\n",
 					";"
 				],
-				"execution_count": 12
+				"execution_count": 23
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT count(*) FROM odw_standardised_db.horizon_folder;\n",
+					"\n",
+					"SELECT count(*) FROM horizon_folder_new;\n",
+					"\n",
+					"SELECT count(*) FROM odw_harmonised_db.horizon_folder;\n",
+					""
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -233,7 +262,7 @@
 					"FROM odw_harmonised_db.horizon_folder\r\n",
 					"WHERE ID IN (SELECT ID FROM horizon_folder_new WHERE HorizonFolderID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -288,7 +317,7 @@
 					"FROM horizon_folder_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -387,7 +416,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
