### PR TITLE
Mvgame/fix/harmonised folder

### DIFF
--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5c1ae1dd-a126-4af0-923a-a9d43f555e6d"
+				"spark.autotune.trackingId": "f951cee6-247c-4dd1-aaa8-03b4045dd4d5"
 			}
 		},
 		"metadata": {
@@ -151,43 +151,6 @@
 					";"
 				],
 				"execution_count": 55
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"-- DELETE FROM odw_harmonised_db.horizon_folder;\n",
-					"\n",
-					"SELECT count(*) FROM odw_standardised_db.horizon_folder WHERE expected_from = '2024-03-21T00:00:00Z';\n",
-					"\n",
-					"SELECT count(*) FROM horizon_folder_new;\n",
-					"\n",
-					"SELECT count(*) FROM odw_harmonised_db.horizon_folder;\n",
-					"\n",
-					"SELECT DISTINCT(expected_from) FROM odw_standardised_db.horizon_folder;\n",
-					"\n",
-					"SELECT * FROM horizon_folder_new WHERE ID = '29309932';\n",
-					"\n",
-					"-- SELECT * FROM odw_harmonised_db.horizon_folder WHERE ID = '29309932'\n",
-					""
-				],
-				"execution_count": 56
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cd4e1a79-c5d1-4f28-9092-c64857648bc3"
+				"spark.autotune.trackingId": "5c1ae1dd-a126-4af0-923a-a9d43f555e6d"
 			}
 		},
 		"metadata": {
@@ -146,8 +146,7 @@
 					"    ELSE 'N'\r\n",
 					"    END  = 'Y' )\r\n",
 					"    AND T1.id IS NOT NULL\r\n",
-					"    AND NOT(T1.id = '29309932' AND T1.casestage = 'Initial Documents')\r\n",
-					"    -- AND (T1.id != '29309932' AND T1.casestage != 'Initial Documents')\r\n",
+					"    AND NOT(T1.id = '29309932' AND T1.casestage = 'Initial Documents') --- Hardcoded exception as per Gareth request for data consistency\r\n",
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_folder)\r\n",
 					";"
 				],
@@ -484,7 +483,7 @@
 					"FROM odw_harmonised_db.horizon_folder;\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 60
 			}
 		]
 	}

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3ed37e58-28d1-489c-b55d-74d30b295dfb"
+				"spark.autotune.trackingId": "cd4e1a79-c5d1-4f28-9092-c64857648bc3"
 			}
 		},
 		"metadata": {
@@ -146,10 +146,12 @@
 					"    ELSE 'N'\r\n",
 					"    END  = 'Y' )\r\n",
 					"    AND T1.id IS NOT NULL\r\n",
+					"    AND NOT(T1.id = '29309932' AND T1.casestage = 'Initial Documents')\r\n",
+					"    -- AND (T1.id != '29309932' AND T1.casestage != 'Initial Documents')\r\n",
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_folder)\r\n",
 					";"
 				],
-				"execution_count": 29
+				"execution_count": 55
 			},
 			{
 				"cell_type": "code",
@@ -171,18 +173,22 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"SELECT count(*) FROM odw_standardised_db.horizon_folder;\n",
+					"-- DELETE FROM odw_harmonised_db.horizon_folder;\n",
+					"\n",
+					"SELECT count(*) FROM odw_standardised_db.horizon_folder WHERE expected_from = '2024-03-21T00:00:00Z';\n",
 					"\n",
 					"SELECT count(*) FROM horizon_folder_new;\n",
 					"\n",
 					"SELECT count(*) FROM odw_harmonised_db.horizon_folder;\n",
 					"\n",
-					"SELECT * FROM horizon_folder_new;\n",
+					"SELECT DISTINCT(expected_from) FROM odw_standardised_db.horizon_folder;\n",
 					"\n",
-					"SELECT * FROM odw_harmonised_db.horizon_folder WHERE ID = '29309932'\n",
+					"SELECT * FROM horizon_folder_new WHERE ID = '29309932';\n",
+					"\n",
+					"-- SELECT * FROM odw_harmonised_db.horizon_folder WHERE ID = '29309932'\n",
 					""
 				],
-				"execution_count": 32
+				"execution_count": 56
 			},
 			{
 				"cell_type": "markdown",
@@ -266,7 +272,7 @@
 					"FROM odw_harmonised_db.horizon_folder\r\n",
 					"WHERE ID IN (SELECT ID FROM horizon_folder_new WHERE HorizonFolderID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": 25
+				"execution_count": 57
 			},
 			{
 				"cell_type": "code",
@@ -321,7 +327,7 @@
 					"FROM horizon_folder_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 26
+				"execution_count": 58
 			},
 			{
 				"cell_type": "markdown",
@@ -420,7 +426,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 27
+				"execution_count": 59
 			},
 			{
 				"cell_type": "markdown",
@@ -478,7 +484,7 @@
 					"FROM odw_harmonised_db.horizon_folder;\r\n",
 					""
 				],
-				"execution_count": 28
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/legacy_folder_data.json
+++ b/workspace/notebook/legacy_folder_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d7e0e348-fa87-494d-94b8-b50b0aae6759"
+				"spark.autotune.trackingId": "a1451245-759a-4aaf-ad8b-351aebc6c6c2"
 			}
 		},
 		"metadata": {
@@ -161,38 +161,6 @@
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.legacy_folder_data')"
 				],
 				"execution_count": 3
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"-- SELECT count(*) FROM odw_curated_db.legacy_folder_data WHERE id = '30829219';\n",
-					"\n",
-					"SELECT * FROM odw_standardised_db.horizon_folder WHERE parentFolderID = '30829219';\n",
-					"\n",
-					"SELECT * FROM odw_harmonised_db.horizon_folder WHERE ParentFolderID = '30829219';\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.legacy_folder_data WHERE parentFolderId = '30829219';\n",
-					"\n",
-					""
-				],
-				"execution_count": 18
 			}
 		]
 	}

--- a/workspace/notebook/legacy_folder_data.json
+++ b/workspace/notebook/legacy_folder_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "46e9c28a-79b0-4ca6-bd16-875420b182e8"
+				"spark.autotune.trackingId": "d7e0e348-fa87-494d-94b8-b50b0aae6759"
 			}
 		},
 		"metadata": {
@@ -126,7 +126,7 @@
 					"FROM odw_harmonised_db.horizon_folder   AS LFD\n",
 					""
 				],
-				"execution_count": 6
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -160,7 +160,39 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_legacy_folder_data')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.legacy_folder_data')"
 				],
-				"execution_count": 7
+				"execution_count": 3
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"-- SELECT count(*) FROM odw_curated_db.legacy_folder_data WHERE id = '30829219';\n",
+					"\n",
+					"SELECT * FROM odw_standardised_db.horizon_folder WHERE parentFolderID = '30829219';\n",
+					"\n",
+					"SELECT * FROM odw_harmonised_db.horizon_folder WHERE ParentFolderID = '30829219';\n",
+					"\n",
+					"SELECT * FROM odw_curated_db.legacy_folder_data WHERE parentFolderId = '30829219';\n",
+					"\n",
+					""
+				],
+				"execution_count": 18
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
