### PR TITLE
Feat/odw 1046 add stages to function app deploy pipeline to deploy to test and prod

### DIFF
--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -189,7 +189,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: $(environment)
-        armServiceConnectionName: $(armServiceConnectionName)
+        armServiceConnectionName: ${{ variables.armServiceConnectionName }}
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -113,7 +113,7 @@ stages:
     value: dev
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(${{ variables.environment }})) }}
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -113,7 +113,7 @@ stages:
     value: dev
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', variables.environment) }}
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', ${{ variables.environment }}) }}
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -123,7 +123,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: "dev"
-        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
+        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment)) }}
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -4,40 +4,14 @@
 ###
 
 ---
-# Set environment parameter. This can be set at runtime if running manually.
+# Set function app parameter, in case there are multiple apps
 parameters:
-#   - name: environment
-#     displayName: Environment
-#     type: string
-#     default: Dev
-#     values:
-#     - Dev
-#     - Test
-#     - Prod
   - name: appname
     displayName: Function App Name
     type: string
     default: fnapp01
     values:
     - fnapp01
-
-# Create variables to be used in further pipeline jobs / tasks.
-# variables:
-#   # Set service connection for the environment to deploy to.
-# - name: armServiceConnectionName
-#   value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-#   # Set the resource group where the function app resides, adding the environment as a parameter.
-# - name: resourceGroup
-#   value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
-#   # Set the name of the function app, adding the environment as a parameter.
-# - name: functionApp
-#   value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
-#   # Set the name of the zip file containing the funciton app code to deploy.
-# - name: zipFile
-#   value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
-#   # Set the agent pool
-# - name: poolName
-#   value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
 # Github branch to trigger the running of this pipeline.
 # Any code change in this branch will trigger this pipeline.
@@ -56,10 +30,6 @@ trigger:
 
 # Disable pull request triggers, i.e. it will not be triggered by any pull requests.
 pr: none
-
-# Specify the agent pool
-# pool:
-#     '$(poolName)'
 
 stages:
 
@@ -103,49 +73,49 @@ stages:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'FunctionCode'
 
-# - stage: DeployToDev
-#   dependsOn: BuildStage
-#   displayName: Deploy to Dev
+- stage: DeployToDev
+  dependsOn: BuildStage
+  displayName: Deploy to Dev
 
-#   variables:
-#     - name: environment
-#       value: dev
-#       # Set service connection for the environment to deploy to.
-#     - name: armServiceConnectionName
-#       value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-#       # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
-#       # Set the resource group where the function app resides, adding the environment as a parameter.
-#     - name: resourceGroup
-#       value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
-#       # Set the name of the function app, adding the environment as a parameter.
-#     - name: functionApp
-#       value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
-#       # Set the name of the zip file containing the funciton app code to deploy.
-#     - name: zipFile
-#       value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
-#       # Set the agent pool
-#     - name: poolName
-#       value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
+  variables:
+    - name: environment
+      value: dev
+      # Set service connection for the environment to deploy to.
+    - name: armServiceConnectionName
+      value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+      # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+      # Set the resource group where the function app resides, adding the environment as a parameter.
+    - name: resourceGroup
+      value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+      # Set the name of the function app, adding the environment as a parameter.
+    - name: functionApp
+      value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+      # Set the name of the zip file containing the funciton app code to deploy.
+    - name: zipFile
+      value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+      # Set the agent pool
+    - name: poolName
+      value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
-#   jobs:
+  jobs:
 
-#   # Job to deploy the zip file to an existing Azure Function App.
-#   - job: DeployToAzureFunctions
-#     displayName: 'Deploy to Azure Functions'
+  # Job to deploy the zip file to an existing Azure Function App.
+  - job: DeployToAzureFunctions
+    displayName: 'Deploy to Azure Functions'
     
-#     steps:
+    steps:
 
-#     # Download the artifact first - the zip file.
-#     - template: steps/download_function_code.yaml
+    # Download the artifact first - the zip file.
+    - template: steps/download_function_code.yaml
 
-#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
-#     - template: steps/deploy_to_function_app.yaml
-#       parameters:
-#         environment: $(environment)
-#         armServiceConnectionName: ${{ variables.armServiceConnectionName }}
-#         resourceGroup: $(resourceGroup)
-#         functionApp: $(functionApp)
-#         zipFile: $(zipFile)
+    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+    - template: steps/deploy_to_function_app.yaml
+      parameters:
+        environment: $(environment)
+        armServiceConnectionName: ${{ variables.armServiceConnectionName }}
+        resourceGroup: $(resourceGroup)
+        functionApp: $(functionApp)
+        zipFile: $(zipFile)
 
 - stage: DeployToTest
   dependsOn: BuildStage
@@ -194,7 +164,7 @@ stages:
 - stage: DeployToProd
   dependsOn: DeployToTest
   displayName: Deploy to Prod
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
   variables:
   - name: environment

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -22,7 +22,7 @@ parameters:
     - fnapp01
 
 # Create variables to be used in further pipeline jobs / tasks.
-variables:
+# variables:
 # The variable group can be seen in the portal and contains environment variables for the service connection and are used in azure-login.yaml.
 # - group: Terraform ${{ parameters.environment }}
 # - name: environment

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -34,8 +34,8 @@ variables:
 # - name: resourceGroup
 #   value: 'pins-rg-function-app-odw-$(environment)-uks'
 # Set the agent pool name
-- name: poolName
-  value: 'pins-agent-pool-odw-$(environment)-uks'
+# - name: poolName
+#   value: 'pins-agent-pool-odw-$(environment)-uks'
 # Set the name of the function app, adding the environment as a parameter.
 # - name: functionApp
 #   value: 'pins-${{ parameters.appname }}-odw-$(environment)-uks'
@@ -62,12 +62,15 @@ trigger:
 pr: none
 
 # Specify the agent pool
-pool:
-    '$(poolName)'
+# pool:
+#     '$(poolName)'
 
 stages:
 
 - stage: BuildStage
+
+  pool: 
+    'pins-agent-pool-odw-dev-uks'
 
   jobs:
 

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -48,15 +48,15 @@ variables:
 trigger:
   branches:
     include:
-      - 'main'
+      - 'feat/ODW-1046-Add-stages-to-function-app-deploy-pipeline-to-deploy-to-test-and-prod'
 
-# Only code in the below paths will trigger the pipeline.
-# All files in the functions folder but not files in subfolders.
-  paths:
-    include:
-      - 'functions/*'
-    exclude:
-      - 'functions/*/*'
+  # Only code in the below paths will trigger the pipeline.
+  # All files in the functions folder but not files in subfolders.
+  # paths:
+  #   include:
+  #     - 'functions/*'
+  #   exclude:
+  #     - 'functions/*/*'
 
 # Disable pull request triggers, i.e. it will not be triggered by any pull requests.
 pr: none
@@ -77,11 +77,11 @@ stages:
 
     steps:
 
-  # Checkout the Github repo, in this case ODW-Service.
+    # Checkout the Github repo, in this case ODW-Service.
     - checkout: self
       displayName: 'Checkout repo'
 
-  # Switch to functions directory and create a file containing a list of all files in the top level folder.
+    # Switch to functions directory and create a file containing a list of all files in the top level folder.
     - script: |
 
         cd $(Build.SourcesDirectory)/functions
@@ -89,7 +89,7 @@ stages:
 
       displayName: 'Creating top level files list'
 
-  # Create a zip file of all the files in the filelist.
+    # Create a zip file of all the files in the filelist.
     - script: |
 
           cd $(Build.SourcesDirectory)/functions
@@ -97,7 +97,7 @@ stages:
 
       displayName: 'Archive top level files'
 
-  # Publish the zip file as an artifact to be used further in the pipeline.
+    # Publish the zip file as an artifact to be used further in the pipeline.
     - task: PublishBuildArtifacts@1
       displayName: 'Publish build artifact'
       inputs:
@@ -118,51 +118,55 @@ stages:
     steps:
 
     # Download the artifact first - the zip file.
-
     - template: steps/download_function_code.yaml
 
     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
-
     - template: steps/deploy_to_function_app.yaml
+      parameters:
+        environment: "dev"
+        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
+        resourceGroup: $(resourceGroup)
+        functionApp: $(functionApp)
+        zipFile: $(zipFile)
 
-- stage: DeployToTest
-  dependsOn: DeployToDev
-  displayName: Deploy to Test
+# - stage: DeployToTest
+#   dependsOn: DeployToDev
+#   displayName: Deploy to Test
 
-  jobs:
+#   jobs:
 
-  # Job to deploy the zip file to an existing Azure Function App.
-  - job: DeployToAzureFunctions
-    displayName: 'Deploy to Azure Functions'
-    dependsOn: BuildAndPackage
+#   # Job to deploy the zip file to an existing Azure Function App.
+#   - job: DeployToAzureFunctions
+#     displayName: 'Deploy to Azure Functions'
+#     dependsOn: BuildAndPackage
     
-    steps:
+#     steps:
 
-    # Download the artifact first - the zip file.
+#     # Download the artifact first - the zip file.
 
-    - template: steps/download_function_code.yaml
+#     - template: steps/download_function_code.yaml
 
-    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
 
-    - template: steps/deploy_to_function_app.yaml
+#     - template: steps/deploy_to_function_app.yaml
 
-- stage: DeployToProd
-  dependsOn: DeployToTest
-  displayName: Deploy to Prod
+# - stage: DeployToProd
+#   dependsOn: DeployToTest
+#   displayName: Deploy to Prod
 
-  jobs:
+#   jobs:
 
-  # Job to deploy the zip file to an existing Azure Function App.
-  - job: DeployToAzureFunctions
-    displayName: 'Deploy to Azure Functions'
-    dependsOn: BuildAndPackage
+#   # Job to deploy the zip file to an existing Azure Function App.
+#   - job: DeployToAzureFunctions
+#     displayName: 'Deploy to Azure Functions'
+#     dependsOn: BuildAndPackage
     
-    steps:
+#     steps:
 
-    # Download the artifact first - the zip file.
+#     # Download the artifact first - the zip file.
 
-    - template: steps/download_function_code.yaml
+#     - template: steps/download_function_code.yaml
 
-    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
 
-    - template: steps/deploy_to_function_app.yaml
+#     - template: steps/deploy_to_function_app.yaml

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -22,22 +22,22 @@ parameters:
     - fnapp01
 
 # Create variables to be used in further pipeline jobs / tasks.
-variables:
-  # Set service connection for the environment to deploy to.
-- name: armServiceConnectionName
-  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-  # Set the resource group where the function app resides, adding the environment as a parameter.
-- name: resourceGroup
-  value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
-  # Set the name of the function app, adding the environment as a parameter.
-- name: functionApp
-  value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
-  # Set the name of the zip file containing the funciton app code to deploy.
-- name: zipFile
-  value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
-  # Set the agent pool
-- name: poolName
-  value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
+# variables:
+#   # Set service connection for the environment to deploy to.
+# - name: armServiceConnectionName
+#   value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+#   # Set the resource group where the function app resides, adding the environment as a parameter.
+# - name: resourceGroup
+#   value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+#   # Set the name of the function app, adding the environment as a parameter.
+# - name: functionApp
+#   value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+#   # Set the name of the zip file containing the funciton app code to deploy.
+# - name: zipFile
+#   value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+#   # Set the agent pool
+# - name: poolName
+#   value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
 # Github branch to trigger the running of this pipeline.
 # Any code change in this branch will trigger this pipeline.
@@ -103,72 +103,29 @@ stages:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'FunctionCode'
 
-# - stage: DeployToDev
-#   dependsOn: BuildStage
-#   displayName: Deploy to Dev
-
-#   variables:
-#   - name: environment
-#     value: dev
-#     # Set service connection for the environment to deploy to.
-#   - name: armServiceConnectionName
-#     value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-#     # Set the resource group where the function app resides, adding the environment as a parameter.
-#   - name: resourceGroup
-#     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
-#     # Set the name of the function app, adding the environment as a parameter.
-#   - name: functionApp
-#     value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
-#     # Set the name of the zip file containing the funciton app code to deploy.
-#   - name: zipFile
-#     value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
-#     # Set the agent pool
-#   - name: poolName
-#     value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
-
-#   jobs:
-
-#   # Job to deploy the zip file to an existing Azure Function App.
-#   - job: DeployToAzureFunctions
-#     displayName: 'Deploy to Azure Functions'
-    
-#     steps:
-
-#     # Download the artifact first - the zip file.
-#     - template: steps/download_function_code.yaml
-
-#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
-#     - template: steps/deploy_to_function_app.yaml
-#       parameters:
-#         environment: $(environment)
-#         armServiceConnectionName: $(armServiceConnectionName)
-#         resourceGroup: $(resourceGroup)
-#         functionApp: $(functionApp)
-#         zipFile: $(zipFile)
-
-- stage: DeployToTest
+- stage: DeployToDev
   dependsOn: BuildStage
-  displayName: Deploy to Test
+  displayName: Deploy to Dev
 
   variables:
-  - name: environment
-    value: test
-  #   # Set service connection for the environment to deploy to.
-  # - name: armServiceConnectionName
-  #   value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-  #   # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
-  #   # Set the resource group where the function app resides, adding the environment as a parameter.
-  # - name: resourceGroup
-  #   value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
-  #   # Set the name of the function app, adding the environment as a parameter.
-  # - name: functionApp
-  #   value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
-  #   # Set the name of the zip file containing the funciton app code to deploy.
-  # - name: zipFile
-  #   value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
-  #   # Set the agent pool
-  # - name: poolName
-  #   value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
+    - name: environment
+      value: dev
+      # Set service connection for the environment to deploy to.
+    - name: armServiceConnectionName
+      value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+      # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+      # Set the resource group where the function app resides, adding the environment as a parameter.
+    - name: resourceGroup
+      value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+      # Set the name of the function app, adding the environment as a parameter.
+    - name: functionApp
+      value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+      # Set the name of the zip file containing the funciton app code to deploy.
+    - name: zipFile
+      value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+      # Set the agent pool
+    - name: poolName
+      value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
   jobs:
 
@@ -190,23 +147,91 @@ stages:
         functionApp: $(functionApp)
         zipFile: $(zipFile)
 
-# - stage: DeployToProd
-#   dependsOn: DeployToTest
-#   displayName: Deploy to Prod
+- stage: DeployToTest
+  dependsOn: DeployToDev
+  displayName: Deploy to Test
 
-#   jobs:
+  variables:
+  - name: environment
+    value: test
+    # Set service connection for the environment to deploy to.
+  - name: armServiceConnectionName
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+    # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+    # Set the resource group where the function app resides, adding the environment as a parameter.
+  - name: resourceGroup
+    value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+    # Set the name of the function app, adding the environment as a parameter.
+  - name: functionApp
+    value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+    # Set the name of the zip file containing the funciton app code to deploy.
+  - name: zipFile
+    value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+    # Set the agent pool
+  - name: poolName
+    value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
-#   # Job to deploy the zip file to an existing Azure Function App.
-#   - job: DeployToAzureFunctions
-#     displayName: 'Deploy to Azure Functions'
-#     dependsOn: BuildAndPackage
+  jobs:
+
+  # Job to deploy the zip file to an existing Azure Function App.
+  - job: DeployToAzureFunctions
+    displayName: 'Deploy to Azure Functions'
     
-#     steps:
+    steps:
 
-#     # Download the artifact first - the zip file.
+    # Download the artifact first - the zip file.
+    - template: steps/download_function_code.yaml
 
-#     - template: steps/download_function_code.yaml
+    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+    - template: steps/deploy_to_function_app.yaml
+      parameters:
+        environment: $(environment)
+        armServiceConnectionName: ${{ variables.armServiceConnectionName }}
+        resourceGroup: $(resourceGroup)
+        functionApp: $(functionApp)
+        zipFile: $(zipFile)
 
-#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+- stage: DeployToProd
+  dependsOn: DeployToTest
+  displayName: Deploy to Prod
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'))
 
-#     - template: steps/deploy_to_function_app.yaml
+  variables:
+  - name: environment
+    value: test
+    # Set service connection for the environment to deploy to.
+  - name: armServiceConnectionName
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+    # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+    # Set the resource group where the function app resides, adding the environment as a parameter.
+  - name: resourceGroup
+    value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+    # Set the name of the function app, adding the environment as a parameter.
+  - name: functionApp
+    value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+    # Set the name of the zip file containing the funciton app code to deploy.
+  - name: zipFile
+    value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+    # Set the agent pool
+  - name: poolName
+    value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
+
+  jobs:
+
+  # Job to deploy the zip file to an existing Azure Function App.
+  - job: DeployToAzureFunctions
+    displayName: 'Deploy to Azure Functions'
+    
+    steps:
+
+    # Download the artifact first - the zip file.
+    - template: steps/download_function_code.yaml
+
+    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+    - template: steps/deploy_to_function_app.yaml
+      parameters:
+        environment: $(environment)
+        armServiceConnectionName: ${{ variables.armServiceConnectionName }}
+        resourceGroup: $(resourceGroup)
+        functionApp: $(functionApp)
+        zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -113,7 +113,7 @@ stages:
     value: dev
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', ${{ variables.environment }}) }}
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(${{ variables.environment }})) }}
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -6,14 +6,14 @@
 ---
 # Set environment parameter. This can be set at runtime if running manually.
 parameters:
-  - name: environment
-    displayName: Environment
-    type: string
-    default: Dev
-    values:
-    - Dev
-    - Test
-    - Prod
+#   - name: environment
+#     displayName: Environment
+#     type: string
+#     default: Dev
+#     values:
+#     - Dev
+#     - Test
+#     - Prod
   - name: appname
     displayName: Function App Name
     type: string
@@ -123,34 +123,34 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: "dev"
-        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
+        armServiceConnectionName: '$(armServiceConnectionName)'
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)
 
-- stage: DeployToTest
-  dependsOn: DeployToDev
-  displayName: Deploy to Test
+# - stage: DeployToTest
+#   dependsOn: DeployToDev
+#   displayName: Deploy to Test
 
-  jobs:
+#   jobs:
 
-  # Job to deploy the zip file to an existing Azure Function App.
-  - job: DeployToAzureFunctions
-    displayName: 'Deploy to Azure Functions'
+#   # Job to deploy the zip file to an existing Azure Function App.
+#   - job: DeployToAzureFunctions
+#     displayName: 'Deploy to Azure Functions'
     
-    steps:
+#     steps:
 
-    # Download the artifact first - the zip file.
-    - template: steps/download_function_code.yaml
+#     # Download the artifact first - the zip file.
+#     - template: steps/download_function_code.yaml
 
-    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
-    - template: steps/deploy_to_function_app.yaml
-      parameters:
-        environment: "test"
-        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
-        resourceGroup: $(resourceGroup)
-        functionApp: $(functionApp)
-        zipFile: $(zipFile)
+#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+#     - template: steps/deploy_to_function_app.yaml
+#       parameters:
+#         environment: "test"
+#         armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
+#         resourceGroup: $(resourceGroup)
+#         functionApp: $(functionApp)
+#         zipFile: $(zipFile)
 
 # - stage: DeployToProd
 #   dependsOn: DeployToTest

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -113,7 +113,6 @@ stages:
   # Job to deploy the zip file to an existing Azure Function App.
   - job: DeployToAzureFunctions
     displayName: 'Deploy to Azure Functions'
-    dependsOn: BuildAndPackage
     
     steps:
 

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -123,7 +123,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: "dev"
-        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper($(environment))) }}
+        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -104,13 +104,56 @@ stages:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'FunctionCode'
 
-- stage: DeployToDev
+# - stage: DeployToDev
+#   dependsOn: BuildStage
+#   displayName: Deploy to Dev
+
+#   variables:
+#   - name: environment
+#     value: dev
+#     # Set service connection for the environment to deploy to.
+#   - name: armServiceConnectionName
+#     value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+#     # Set the resource group where the function app resides, adding the environment as a parameter.
+#   - name: resourceGroup
+#     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+#     # Set the name of the function app, adding the environment as a parameter.
+#   - name: functionApp
+#     value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+#     # Set the name of the zip file containing the funciton app code to deploy.
+#   - name: zipFile
+#     value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+#     # Set the agent pool
+#   - name: poolName
+#     value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
+
+#   jobs:
+
+#   # Job to deploy the zip file to an existing Azure Function App.
+#   - job: DeployToAzureFunctions
+#     displayName: 'Deploy to Azure Functions'
+    
+#     steps:
+
+#     # Download the artifact first - the zip file.
+#     - template: steps/download_function_code.yaml
+
+#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+#     - template: steps/deploy_to_function_app.yaml
+#       parameters:
+#         environment: $(environment)
+#         armServiceConnectionName: $(armServiceConnectionName)
+#         resourceGroup: $(resourceGroup)
+#         functionApp: $(functionApp)
+#         zipFile: $(zipFile)
+
+- stage: DeployToTest
   dependsOn: BuildStage
-  displayName: Deploy to Dev
+  displayName: Deploy to Test
 
   variables:
   - name: environment
-    value: dev
+    value: test
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
     value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
@@ -146,30 +189,6 @@ stages:
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)
-
-# - stage: DeployToTest
-#   dependsOn: DeployToDev
-#   displayName: Deploy to Test
-
-#   jobs:
-
-#   # Job to deploy the zip file to an existing Azure Function App.
-#   - job: DeployToAzureFunctions
-#     displayName: 'Deploy to Azure Functions'
-    
-#     steps:
-
-#     # Download the artifact first - the zip file.
-#     - template: steps/download_function_code.yaml
-
-#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
-#     - template: steps/deploy_to_function_app.yaml
-#       parameters:
-#         environment: "test"
-#         armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
-#         resourceGroup: $(resourceGroup)
-#         functionApp: $(functionApp)
-#         zipFile: $(zipFile)
 
 # - stage: DeployToProd
 #   dependsOn: DeployToTest

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -113,19 +113,19 @@ stages:
     value: dev
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper($(environment))) }}
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', variables.environment) }}
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
-    value: 'pins-rg-function-app-odw-$(environment)-uks'
+    value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
     # Set the name of the function app, adding the environment as a parameter.
   - name: functionApp
-    value: 'pins-${{ parameters.appname }}-odw-$(environment)-uks'
+    value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
     # Set the name of the zip file containing the funciton app code to deploy.
   - name: zipFile
     value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
     # Set the agent pool
   - name: poolName
-    value: 'pins-agent-pool-odw-$(environment)-uks'
+    value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
   jobs:
 

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -156,7 +156,8 @@ stages:
     value: test
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+    # value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+    value: 'Azure DevOps Pipelines - ODW TEST - Infrastructure'
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -159,8 +159,8 @@ stages:
     value: test
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    # value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-    value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+    # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -128,26 +128,29 @@ stages:
         functionApp: $(functionApp)
         zipFile: $(zipFile)
 
-# - stage: DeployToTest
-#   dependsOn: DeployToDev
-#   displayName: Deploy to Test
+- stage: DeployToTest
+  dependsOn: DeployToDev
+  displayName: Deploy to Test
 
-#   jobs:
+  jobs:
 
-#   # Job to deploy the zip file to an existing Azure Function App.
-#   - job: DeployToAzureFunctions
-#     displayName: 'Deploy to Azure Functions'
-#     dependsOn: BuildAndPackage
+  # Job to deploy the zip file to an existing Azure Function App.
+  - job: DeployToAzureFunctions
+    displayName: 'Deploy to Azure Functions'
     
-#     steps:
+    steps:
 
-#     # Download the artifact first - the zip file.
+    # Download the artifact first - the zip file.
+    - template: steps/download_function_code.yaml
 
-#     - template: steps/download_function_code.yaml
-
-#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
-
-#     - template: steps/deploy_to_function_app.yaml
+    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+    - template: steps/deploy_to_function_app.yaml
+      parameters:
+        environment: "test"
+        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
+        resourceGroup: $(resourceGroup)
+        functionApp: $(functionApp)
+        zipFile: $(zipFile)
 
 # - stage: DeployToProd
 #   dependsOn: DeployToTest

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -22,26 +22,22 @@ parameters:
     - fnapp01
 
 # Create variables to be used in further pipeline jobs / tasks.
-# variables:
-# The variable group can be seen in the portal and contains environment variables for the service connection and are used in azure-login.yaml.
-# - group: Terraform ${{ parameters.environment }}
-# - name: environment
-#   value: ${{ lower(parameters.environment) }}
-# Set service connection for the environment to deploy to.
-# - name: armServiceConnectionName
-#   value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment)) }}
-# # Set the resource group where the function app resides, adding the environment as a parameter.
-# - name: resourceGroup
-#   value: 'pins-rg-function-app-odw-$(environment)-uks'
-# Set the agent pool name
-# - name: poolName
-#   value: 'pins-agent-pool-odw-$(environment)-uks'
-# Set the name of the function app, adding the environment as a parameter.
-# - name: functionApp
-#   value: 'pins-${{ parameters.appname }}-odw-$(environment)-uks'
-# # Set the name of the zip file containing the funciton app code to deploy.
-# - name: zipFile
-#   value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+variables:
+  # Set service connection for the environment to deploy to.
+- name: armServiceConnectionName
+  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+  # Set the resource group where the function app resides, adding the environment as a parameter.
+- name: resourceGroup
+  value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+  # Set the name of the function app, adding the environment as a parameter.
+- name: functionApp
+  value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+  # Set the name of the zip file containing the funciton app code to deploy.
+- name: zipFile
+  value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+  # Set the agent pool
+- name: poolName
+  value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
 # Github branch to trigger the running of this pipeline.
 # Any code change in this branch will trigger this pipeline.
@@ -157,22 +153,22 @@ stages:
   variables:
   - name: environment
     value: test
-    # Set service connection for the environment to deploy to.
-  - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-    # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
-    # Set the resource group where the function app resides, adding the environment as a parameter.
-  - name: resourceGroup
-    value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
-    # Set the name of the function app, adding the environment as a parameter.
-  - name: functionApp
-    value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
-    # Set the name of the zip file containing the funciton app code to deploy.
-  - name: zipFile
-    value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
-    # Set the agent pool
-  - name: poolName
-    value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
+  #   # Set service connection for the environment to deploy to.
+  # - name: armServiceConnectionName
+  #   value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+  #   # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+  #   # Set the resource group where the function app resides, adding the environment as a parameter.
+  # - name: resourceGroup
+  #   value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+  #   # Set the name of the function app, adding the environment as a parameter.
+  # - name: functionApp
+  #   value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+  #   # Set the name of the zip file containing the funciton app code to deploy.
+  # - name: zipFile
+  #   value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+  #   # Set the agent pool
+  # - name: poolName
+  #   value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
   jobs:
 

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -186,7 +186,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: $(environment)
-        armServiceConnectionName: $(armServiceConnectionName)
+        # armServiceConnectionName: $(armServiceConnectionName)
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -157,7 +157,7 @@ stages:
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
     # value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-    value: 'Azure DevOps Pipelines - ODW TEST - Infrastructure'
+    value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -20,7 +20,6 @@ parameters:
     default: fnapp01
     values:
     - fnapp01
-    - fnapp02
 
 # Create variables to be used in further pipeline jobs / tasks.
 variables:
@@ -62,71 +61,108 @@ trigger:
 # Disable pull request triggers, i.e. it will not be triggered by any pull requests.
 pr: none
 
-# Specify the Microsoft hosted image we want to use.
+# Specify the agent pool
 pool:
-  '$(poolName)'
+    '$(poolName)'
 
-jobs:
+stages:
 
-# Build and package the code.
-- job: BuildAndPackage
-  displayName: 'Build and Package'
-  # dependsOn: AzureLogin
+- stage: BuildStage
 
-  steps:
+  jobs:
 
-# Checkout the Github repo, in this case ODW-Service.
-  - checkout: self
-    displayName: 'Checkout repo'
+  # Build and package the code.
+  - job: BuildAndPackage
+    displayName: 'Build and Package'
 
-# Switch to functions directory and create a file containing a list of all files in the top level folder.
-  - script: |
+    steps:
 
-      cd $(Build.SourcesDirectory)/functions
-      find . -maxdepth 1 -type f | sed 's|^\./||' > $(Build.SourcesDirectory)/functions/filelist.txt
+  # Checkout the Github repo, in this case ODW-Service.
+    - checkout: self
+      displayName: 'Checkout repo'
 
-    displayName: 'Creating top level files list'
-
-# Create a zip file of all the files in the filelist.
-  - script: |
+  # Switch to functions directory and create a file containing a list of all files in the top level folder.
+    - script: |
 
         cd $(Build.SourcesDirectory)/functions
-        cat $(Build.SourcesDirectory)/functions/filelist.txt | xargs zip -r $(Build.ArtifactStagingDirectory)/functions.zip
+        find . -maxdepth 1 -type f | sed 's|^\./||' > $(Build.SourcesDirectory)/functions/filelist.txt
 
-    displayName: 'Archive top level files'
+      displayName: 'Creating top level files list'
 
-# Publish the zip file as an artifact to be used further in the pipeline.
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish build artifact'
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'FunctionCode'
+  # Create a zip file of all the files in the filelist.
+    - script: |
 
-# Job to deploy the zip file to an existing Azure Function App.
-- job: DeployToAzureFunctions
-  displayName: 'Deploy to Azure Functions'
-  dependsOn: BuildAndPackage
-  
-  steps:
+          cd $(Build.SourcesDirectory)/functions
+          cat $(Build.SourcesDirectory)/functions/filelist.txt | xargs zip -r $(Build.ArtifactStagingDirectory)/functions.zip
 
-# Download the artifact first - the zip file.
-  - task: DownloadBuildArtifacts@1
-    displayName: 'Download build artifact'
-    inputs:
-      buildType: 'current'
-      artifactName: 'FunctionCode'
-      downloadPath: '$(System.ArtifactsDirectory)'
+      displayName: 'Archive top level files'
 
-# Use the Azure CLI to deploy the zip file to the Function App in Azure.
-  - task: AzureCLI@2
-    displayName: 'Deploy to function app'
-    inputs:
-      azureSubscription: '$(armServiceConnectionName)'
-      scriptType: 'bash'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        az functionapp deployment source config-zip \
-        --resource-group $(resourceGroup) \
-        --name $(functionApp) \
-        --src $(zipFile) \
-        --build-remote true
+  # Publish the zip file as an artifact to be used further in the pipeline.
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish build artifact'
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'FunctionCode'
+
+- stage: DeployToDev
+  dependsOn: BuildStage
+  displayName: Deploy to Dev
+
+  jobs:
+
+  # Job to deploy the zip file to an existing Azure Function App.
+  - job: DeployToAzureFunctions
+    displayName: 'Deploy to Azure Functions'
+    dependsOn: BuildAndPackage
+    
+    steps:
+
+    # Download the artifact first - the zip file.
+
+    - template: steps/download_function_code.yaml
+
+    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+
+    - template: steps/deploy_to_function_app.yaml
+
+- stage: DeployToTest
+  dependsOn: DeployToDev
+  displayName: Deploy to Test
+
+  jobs:
+
+  # Job to deploy the zip file to an existing Azure Function App.
+  - job: DeployToAzureFunctions
+    displayName: 'Deploy to Azure Functions'
+    dependsOn: BuildAndPackage
+    
+    steps:
+
+    # Download the artifact first - the zip file.
+
+    - template: steps/download_function_code.yaml
+
+    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+
+    - template: steps/deploy_to_function_app.yaml
+
+- stage: DeployToProd
+  dependsOn: DeployToTest
+  displayName: Deploy to Prod
+
+  jobs:
+
+  # Job to deploy the zip file to an existing Azure Function App.
+  - job: DeployToAzureFunctions
+    displayName: 'Deploy to Azure Functions'
+    dependsOn: BuildAndPackage
+    
+    steps:
+
+    # Download the artifact first - the zip file.
+
+    - template: steps/download_function_code.yaml
+
+    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+
+    - template: steps/deploy_to_function_app.yaml

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -189,7 +189,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: $(environment)
-        # armServiceConnectionName: $(armServiceConnectionName)
+        armServiceConnectionName: $(armServiceConnectionName)
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -28,8 +28,8 @@ variables:
 # - name: environment
 #   value: ${{ lower(parameters.environment) }}
 # Set service connection for the environment to deploy to.
-- name: armServiceConnectionName
-  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment)) }}
+# - name: armServiceConnectionName
+#   value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment)) }}
 # Set the resource group where the function app resides, adding the environment as a parameter.
 - name: resourceGroup
   value: 'pins-rg-function-app-odw-$(environment)-uks'
@@ -123,7 +123,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: "dev"
-        armServiceConnectionName: '$(armServiceConnectionName)'
+        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper($(environment))) }}
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -29,7 +29,7 @@ variables:
 #   value: ${{ lower(parameters.environment) }}
 # Set service connection for the environment to deploy to.
 - name: armServiceConnectionName
-  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment))) }}
+  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment)) }}
 # Set the resource group where the function app resides, adding the environment as a parameter.
 - name: resourceGroup
   value: 'pins-rg-function-app-odw-$(environment)-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -18,15 +18,15 @@ parameters:
 trigger:
   branches:
     include:
-      - 'feat/ODW-1046-Add-stages-to-function-app-deploy-pipeline-to-deploy-to-test-and-prod'
+      - 'main'
 
   # Only code in the below paths will trigger the pipeline.
   # All files in the functions folder but not files in subfolders.
-  # paths:
-  #   include:
-  #     - 'functions/*'
-  #   exclude:
-  #     - 'functions/*/*'
+  paths:
+    include:
+      - 'functions/*'
+    exclude:
+      - 'functions/*/*'
 
 # Disable pull request triggers, i.e. it will not be triggered by any pull requests.
 pr: none

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -30,18 +30,18 @@ variables:
 # Set service connection for the environment to deploy to.
 # - name: armServiceConnectionName
 #   value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment)) }}
-# Set the resource group where the function app resides, adding the environment as a parameter.
-- name: resourceGroup
-  value: 'pins-rg-function-app-odw-$(environment)-uks'
+# # Set the resource group where the function app resides, adding the environment as a parameter.
+# - name: resourceGroup
+#   value: 'pins-rg-function-app-odw-$(environment)-uks'
 # Set the agent pool name
 - name: poolName
   value: 'pins-agent-pool-odw-$(environment)-uks'
 # Set the name of the function app, adding the environment as a parameter.
-- name: functionApp
-  value: 'pins-${{ parameters.appname }}-odw-$(environment)-uks'
-# Set the name of the zip file containing the funciton app code to deploy.
-- name: zipFile
-  value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+# - name: functionApp
+#   value: 'pins-${{ parameters.appname }}-odw-$(environment)-uks'
+# # Set the name of the zip file containing the funciton app code to deploy.
+# - name: zipFile
+#   value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
 
 # Github branch to trigger the running of this pipeline.
 # Any code change in this branch will trigger this pipeline.
@@ -108,6 +108,25 @@ stages:
   dependsOn: BuildStage
   displayName: Deploy to Dev
 
+  variables:
+  - name: environment
+    value: dev
+    # Set service connection for the environment to deploy to.
+  - name: armServiceConnectionName
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper($(environment))) }}
+    # Set the resource group where the function app resides, adding the environment as a parameter.
+  - name: resourceGroup
+    value: 'pins-rg-function-app-odw-$(environment)-uks'
+    # Set the name of the function app, adding the environment as a parameter.
+  - name: functionApp
+    value: 'pins-${{ parameters.appname }}-odw-$(environment)-uks'
+    # Set the name of the zip file containing the funciton app code to deploy.
+  - name: zipFile
+    value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+    # Set the agent pool
+  - name: poolName
+    value: 'pins-agent-pool-odw-$(environment)-uks'
+
   jobs:
 
   # Job to deploy the zip file to an existing Azure Function App.
@@ -122,8 +141,8 @@ stages:
     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
     - template: steps/deploy_to_function_app.yaml
       parameters:
-        environment: "dev"
-        armServiceConnectionName: Azure DevOps Pipelines - ODW DEV - Infrastructure
+        environment: $(environment)
+        armServiceConnectionName: $(armServiceConnectionName)
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -113,7 +113,7 @@ stages:
     value: dev
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(${{ variables.environment }})) }}
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper('${{ variables.environment }}')) }}
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -24,12 +24,12 @@ parameters:
 # Create variables to be used in further pipeline jobs / tasks.
 variables:
 # The variable group can be seen in the portal and contains environment variables for the service connection and are used in azure-login.yaml.
-- group: Terraform ${{ parameters.environment }}
+# - group: Terraform ${{ parameters.environment }}
 - name: environment
   value: ${{ lower(parameters.environment) }}
 # Set service connection for the environment to deploy to.
 - name: armServiceConnectionName
-  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(parameters.environment)) }}
+  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper($(environment))) }}
 # Set the resource group where the function app resides, adding the environment as a parameter.
 - name: resourceGroup
   value: 'pins-rg-function-app-odw-$(environment)-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -123,7 +123,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: "dev"
-        armServiceConnectionName: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment)) }}
+        armServiceConnectionName: 'Azure DevOps Pipelines - ODW DEV - Infrastructure'
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -123,7 +123,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: "dev"
-        armServiceConnectionName: 'Azure DevOps Pipelines - ODW DEV - Infrastructure'
+        armServiceConnectionName: "Azure DevOps Pipelines - ODW DEV - Infrastructure"
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -25,11 +25,11 @@ parameters:
 variables:
 # The variable group can be seen in the portal and contains environment variables for the service connection and are used in azure-login.yaml.
 # - group: Terraform ${{ parameters.environment }}
-- name: environment
-  value: ${{ lower(parameters.environment) }}
+# - name: environment
+#   value: ${{ lower(parameters.environment) }}
 # Set service connection for the environment to deploy to.
 - name: armServiceConnectionName
-  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper($(environment))) }}
+  value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(environment))) }}
 # Set the resource group where the function app resides, adding the environment as a parameter.
 - name: resourceGroup
   value: 'pins-rg-function-app-odw-$(environment)-uks'

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -103,52 +103,52 @@ stages:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'FunctionCode'
 
-- stage: DeployToDev
-  dependsOn: BuildStage
-  displayName: Deploy to Dev
+# - stage: DeployToDev
+#   dependsOn: BuildStage
+#   displayName: Deploy to Dev
 
-  variables:
-    - name: environment
-      value: dev
-      # Set service connection for the environment to deploy to.
-    - name: armServiceConnectionName
-      value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
-      # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
-      # Set the resource group where the function app resides, adding the environment as a parameter.
-    - name: resourceGroup
-      value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
-      # Set the name of the function app, adding the environment as a parameter.
-    - name: functionApp
-      value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
-      # Set the name of the zip file containing the funciton app code to deploy.
-    - name: zipFile
-      value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
-      # Set the agent pool
-    - name: poolName
-      value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
+#   variables:
+#     - name: environment
+#       value: dev
+#       # Set service connection for the environment to deploy to.
+#     - name: armServiceConnectionName
+#       value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(variables.environment)) }}
+#       # value: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+#       # Set the resource group where the function app resides, adding the environment as a parameter.
+#     - name: resourceGroup
+#       value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'
+#       # Set the name of the function app, adding the environment as a parameter.
+#     - name: functionApp
+#       value: 'pins-${{ parameters.appname }}-odw-${{ variables.environment }}-uks'
+#       # Set the name of the zip file containing the funciton app code to deploy.
+#     - name: zipFile
+#       value: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'
+#       # Set the agent pool
+#     - name: poolName
+#       value: 'pins-agent-pool-odw-${{ variables.environment }}-uks'
 
-  jobs:
+#   jobs:
 
-  # Job to deploy the zip file to an existing Azure Function App.
-  - job: DeployToAzureFunctions
-    displayName: 'Deploy to Azure Functions'
+#   # Job to deploy the zip file to an existing Azure Function App.
+#   - job: DeployToAzureFunctions
+#     displayName: 'Deploy to Azure Functions'
     
-    steps:
+#     steps:
 
-    # Download the artifact first - the zip file.
-    - template: steps/download_function_code.yaml
+#     # Download the artifact first - the zip file.
+#     - template: steps/download_function_code.yaml
 
-    # Use the Azure CLI to deploy the zip file to the Function App in Azure.
-    - template: steps/deploy_to_function_app.yaml
-      parameters:
-        environment: $(environment)
-        armServiceConnectionName: ${{ variables.armServiceConnectionName }}
-        resourceGroup: $(resourceGroup)
-        functionApp: $(functionApp)
-        zipFile: $(zipFile)
+#     # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+#     - template: steps/deploy_to_function_app.yaml
+#       parameters:
+#         environment: $(environment)
+#         armServiceConnectionName: ${{ variables.armServiceConnectionName }}
+#         resourceGroup: $(resourceGroup)
+#         functionApp: $(functionApp)
+#         zipFile: $(zipFile)
 
 - stage: DeployToTest
-  dependsOn: DeployToDev
+  dependsOn: BuildStage
   displayName: Deploy to Test
 
   variables:

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -123,7 +123,7 @@ stages:
     - template: steps/deploy_to_function_app.yaml
       parameters:
         environment: "dev"
-        armServiceConnectionName: "Azure DevOps Pipelines - ODW DEV - Infrastructure"
+        armServiceConnectionName: Azure DevOps Pipelines - ODW DEV - Infrastructure
         resourceGroup: $(resourceGroup)
         functionApp: $(functionApp)
         zipFile: $(zipFile)

--- a/pipelines/function_app_deploy.yaml
+++ b/pipelines/function_app_deploy.yaml
@@ -113,7 +113,7 @@ stages:
     value: dev
     # Set service connection for the environment to deploy to.
   - name: armServiceConnectionName
-    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper('${{ variables.environment }}')) }}
+    value: ${{ format('Azure DevOps Pipelines - ODW {0} - Infrastructure', upper(${{ variables.environment }})) }}
     # Set the resource group where the function app resides, adding the environment as a parameter.
   - name: resourceGroup
     value: 'pins-rg-function-app-odw-${{ variables.environment }}-uks'

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -18,7 +18,7 @@ steps:
 - task: AzureCLI@2
   displayName: 'Deploy to function app'
   inputs:
-    azureSubscription: '$(armServiceConnectionName)'
+    azureSubscription: ${{ parameters.armServiceConnectionName }}
     scriptType: 'bash'
     scriptLocation: 'inlineScript'
     inlineScript: |

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -22,6 +22,13 @@ steps:
     scriptType: 'bash'
     scriptLocation: 'inlineScript'
     inlineScript: |
+
+      echo "Deploying to function app with the following variables:"
+      echo "Environment: $(environment)"
+      echo "Resource Group: $(resourceGroup)"
+      echo "Function App Name: $(functionApp)"
+      echo "Zip File: $(zipFile)"
+
       az functionapp deployment source config-zip \
       --resource-group $(resourceGroup) \
       --name $(functionApp) \

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -1,0 +1,13 @@
+steps:
+- task: AzureCLI@2
+  displayName: 'Deploy to function app'
+  inputs:
+    azureSubscription: '$(armServiceConnectionName)'
+    scriptType: 'bash'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      az functionapp deployment source config-zip \
+      --resource-group $(resourceGroup) \
+      --name $(functionApp) \
+      --src $(zipFile) \
+      --build-remote true

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -2,8 +2,8 @@ parameters:
   - name: environment
     type: string
 
-  - name: armServiceConnectionName
-    type: string
+  # - name: armServiceConnectionName
+  #   type: string
 
   - name: resourceGroup
     type: string
@@ -18,7 +18,7 @@ steps:
 - task: AzureCLI@2
   displayName: 'Deploy to function app'
   inputs:
-    azureSubscription: ${{ parameters.armServiceConnectionName }}
+    azureSubscription: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
     scriptType: 'bash'
     scriptLocation: 'inlineScript'
     inlineScript: |

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -2,8 +2,8 @@ parameters:
   - name: environment
     type: string
 
-  # - name: armServiceConnectionName
-  #   type: string
+  - name: armServiceConnectionName
+    type: string
 
   - name: resourceGroup
     type: string
@@ -18,7 +18,7 @@ steps:
 - task: AzureCLI@2
   displayName: 'Deploy to function app'
   inputs:
-    azureSubscription: "Azure DevOps Pipelines - ODW TEST - Infrastructure"
+    azureSubscription: ${{ parameters.armServiceConnectionName }}
     scriptType: 'bash'
     scriptLocation: 'inlineScript'
     inlineScript: |

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -1,3 +1,19 @@
+parameters:
+  - name: environment
+    type: string
+
+  - name: armServiceConnectionName
+    type: string
+
+  - name: resourceGroup
+    type: string
+
+  - name: functionApp
+    type: string
+
+  - name: zipFile
+    type: string
+
 steps:
 - task: AzureCLI@2
   displayName: 'Deploy to function app'

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -25,6 +25,7 @@ steps:
 
       echo "Deploying to function app with the following variables:"
       echo "Environment: $(environment)"
+      echo "Service Connection": $(armServiceConnectionName)
       echo "Resource Group: $(resourceGroup)"
       echo "Function App Name: $(functionApp)"
       echo "Zip File: $(zipFile)"

--- a/pipelines/steps/download_function_code.yaml
+++ b/pipelines/steps/download_function_code.yaml
@@ -1,0 +1,7 @@
+steps:
+- task: DownloadBuildArtifacts@1
+  displayName: 'Download function code artifact'
+  inputs:
+    buildType: 'current'
+    artifactName: 'FunctionCode'
+    downloadPath: '$(System.ArtifactsDirectory)'


### PR DESCRIPTION
4 stages - build, dev, test, prod
triggered on push to main branch
build runs first, then dev and test in parallel
prod will only run if triggered manually and if run from main branch
build, dev and test can be run manually from any branch when needed