### PR TITLE
Mvg/fix/s51 advice

### DIFF
--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a51bae4f-6085-4272-b125-d0179c64b470"
+				"spark.autotune.trackingId": "205e389c-4b9e-4e23-83f4-2e937e924b99"
 			}
 		},
 		"metadata": {
@@ -151,30 +151,6 @@
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
 				"execution_count": 7
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.nsip_s51_advice"
-				],
-				"execution_count": 8
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fc70d752-ef18-46be-8628-7434b2540e28"
+				"spark.autotune.trackingId": "ef0bab63-4c83-4423-aa55-09d68d819b11"
 			}
 		},
 		"metadata": {
@@ -92,8 +92,8 @@
 					"\n",
 					"SELECT DISTINCT\n",
 					"\n",
-					"    CAST(AD.NSIPAdviceID as INT)\t\t\t\t\t\t    AS adviceId,\n",
-					"    CAST(AD.AdviceNodeID as INT)                            AS caseId,\n",
+					"    CAST(AD.AdviceNodeID as INT)\t\t\t\t\t\t    AS adviceId,\n",
+					"    NULL                                                    AS caseId,\n",
 					"    AD.AdviceReference\t\t\t\t\t\t\t\t\t    AS adviceReference,\n",
 					"    AD.CaseReference\t\t\t\t\t\t\t\t\t    AS caseReference,\n",
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5c67d56d-bc60-45f6-9bbf-79bb84c63ae0"
+				"spark.autotune.trackingId": "8989356f-d6ec-4975-8266-8ebb48264b0d"
 			}
 		},
 		"metadata": {
@@ -93,7 +93,7 @@
 					"SELECT DISTINCT\n",
 					"\n",
 					"    CAST(AD.AdviceNodeID as INT)\t\t\t\t\t\t    AS adviceId,\n",
-					"    NULL                                                    AS caseId,\n",
+					"    AD.CaseReference                                        AS caseId,\n",
 					"    AD.AdviceReference\t\t\t\t\t\t\t\t\t    AS adviceReference,\n",
 					"    AD.CaseReference\t\t\t\t\t\t\t\t\t    AS caseReference,\n",
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
@@ -116,7 +116,7 @@
 					"FROM odw_harmonised_db.casework_nsip_advice_dim \t        AS AD\n",
 					"WHERE AD.IsActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -150,7 +150,31 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
-				"execution_count": null
+				"execution_count": 4
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_curated_db.nsip_s51_advice"
+				],
+				"execution_count": 5
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8989356f-d6ec-4975-8266-8ebb48264b0d"
+				"spark.autotune.trackingId": "a51bae4f-6085-4272-b125-d0179c64b470"
 			}
 		},
 		"metadata": {
@@ -93,7 +93,7 @@
 					"SELECT DISTINCT\n",
 					"\n",
 					"    CAST(AD.AdviceNodeID as INT)\t\t\t\t\t\t    AS adviceId,\n",
-					"    AD.CaseReference                                        AS caseId,\n",
+					"    CAST(\"-1\" as INT)                                       AS caseId,\n",
 					"    AD.AdviceReference\t\t\t\t\t\t\t\t\t    AS adviceReference,\n",
 					"    AD.CaseReference\t\t\t\t\t\t\t\t\t    AS caseReference,\n",
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
@@ -116,7 +116,7 @@
 					"FROM odw_harmonised_db.casework_nsip_advice_dim \t        AS AD\n",
 					"WHERE AD.IsActive = 'Y'"
 				],
-				"execution_count": 3
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -150,7 +150,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
-				"execution_count": 4
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -174,7 +174,7 @@
 					"\n",
 					"SELECT * FROM odw_curated_db.nsip_s51_advice"
 				],
-				"execution_count": 5
+				"execution_count": 8
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bb97546f-7f3c-420f-a25a-dcf9b38fca08"
+				"spark.autotune.trackingId": "fc70d752-ef18-46be-8628-7434b2540e28"
 			}
 		},
 		"metadata": {
@@ -62,7 +62,7 @@
 					}
 				},
 				"source": [
-					"## View odw_curated_db.vw_nsip_data is created"
+					"## View odw_curated_db.vw_nsip_s51_advice is created"
 				]
 			},
 			{

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ef0bab63-4c83-4423-aa55-09d68d819b11"
+				"spark.autotune.trackingId": "5c67d56d-bc60-45f6-9bbf-79bb84c63ae0"
 			}
 		},
 		"metadata": {
@@ -150,7 +150,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
-				"execution_count": 2
+				"execution_count": null
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
