### PR TITLE
Fix/raw to std array in schema

### DIFF
--- a/workspace/notebook/py_0_source_to_raw_hr_functions.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "83e393c3-7426-4333-ad9b-1b7949ff3ab8"
+				"spark.autotune.trackingId": "590a6ca8-c854-4727-847b-1ab3196b47dd"
 			}
 		},
 		"metadata": {
@@ -208,7 +208,6 @@
 					"        if field['type'] == 'array':\r\n",
 					"            field['type'] = 'string'\r\n",
 					"    \r\n",
-					"    print(jsonschema)\r\n",
 					"    ### use json to create dataframe\r\n",
 					"    schema = StructType.fromJson(jsonschema)\r\n",
 					"    df = spark.createDataFrame([], schema)\r\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f0f1bb6a-b2ee-4087-89b8-83ab5573cdf0"
+				"spark.autotune.trackingId": "c8c2c5a7-dcee-475f-836f-80dad905c2c6"
 			}
 		},
 		"metadata": {
@@ -386,9 +386,8 @@
 					"    ### change any array field to string\n",
 					"\tschema = json.loads(standardised_table_def_json)\n",
 					"\tfor field in schema['fields']:\n",
-					"\t\tif field['type'] == 'array':\n",
-					"\t\t\tfield['type'] = 'string'\n",
-					"\n",
+					"\t    if field['type'] == 'array':\n",
+					"\t\t    field['type'] = 'string'\n",
 					"    schema = StructType.fromJson(schema)\n",
 					"\n",
 					"    ### remove characters that Delta can't allow in headers and add numbers to repeated column headers\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "52cf7c73-a53f-427c-ac2d-7f1ce9450c2e"
+				"spark.autotune.trackingId": "97eb022a-754d-4ee7-b4bb-8eddc18367ef"
 			}
 		},
 		"metadata": {
@@ -404,7 +404,7 @@
 					"\n",
 					"    ### Cast any column in sparkDF with type mismatch\n",
 					"    for field in sparkDF.schema:\n",
-					"        table_field = next((f for f in schema if f.name == field.name), None)\n",
+					"        table_field = next((f for f in schema if f.name.lower() == field.name.lower()), None)\n",
 					"        if table_field is not None and field.dataType != table_field.dataType:\n",
 					"            sparkDF = sparkDF.withColumn(field.name, col(field.name).cast(table_field.dataType))\n",
 					"\n",
@@ -416,7 +416,7 @@
 					"\n",
 					"    ### test correct number of rows have written\n",
 					"    if rows_raw == rows_new:\n",
-					"        print('All rows have successfully written')\n",
+					"        print('All rows have successfully been written')\n",
 					""
 				],
 				"execution_count": 1

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f23d09d0-32b9-481c-b203-4f998ee56a8d"
+				"spark.autotune.trackingId": "f0f1bb6a-b2ee-4087-89b8-83ab5573cdf0"
 			}
 		},
 		"metadata": {
@@ -344,8 +344,6 @@
 					"    else:\n",
 					"        standardised_table_def_json = mssparkutils.notebook.run('/py_get_schema_from_url', 30, {'db_name': 'odw_standardised_db', 'entity_name': definition['Source_Frequency_Folder']})\n",
 					"\n",
-					"    schema = StructType.fromJson(json.loads(standardised_table_def_json))\n",
-					"\n",
 					"    if not any([table.name == standardised_table_name for table in spark.catalog.listTables('odw_standardised_db')]):\n",
 					"        create_table_from_schema(standardised_table_def_json, \"odw_standardised_db\", standardised_table_name,standardised_container , standardised_path+standardised_table_name)   \n",
 					"                        \n",
@@ -385,6 +383,14 @@
 					"    sparkDF = sparkDF.withColumn(\"expected_from\",lit(expected_from))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_to\",lit(expected_to))\n",
 					"    \n",
+					"    ### change any array field to string\n",
+					"\tschema = json.loads(standardised_table_def_json)\n",
+					"\tfor field in schema['fields']:\n",
+					"\t\tif field['type'] == 'array':\n",
+					"\t\t\tfield['type'] = 'string'\n",
+					"\n",
+					"    schema = StructType.fromJson(schema)\n",
+					"\n",
 					"    ### remove characters that Delta can't allow in headers and add numbers to repeated column headers\n",
 					"    cols_orig = sparkDF.schema.names\n",
 					"    cols=[re.sub('[^0-9a-zA-Z]+', '_', i).lower() for i in cols_orig]\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c8c2c5a7-dcee-475f-836f-80dad905c2c6"
+				"spark.autotune.trackingId": "52cf7c73-a53f-427c-ac2d-7f1ce9450c2e"
 			}
 		},
 		"metadata": {
@@ -384,10 +384,10 @@
 					"    sparkDF = sparkDF.withColumn(\"expected_to\",lit(expected_to))\n",
 					"    \n",
 					"    ### change any array field to string\n",
-					"\tschema = json.loads(standardised_table_def_json)\n",
-					"\tfor field in schema['fields']:\n",
-					"\t    if field['type'] == 'array':\n",
-					"\t\t    field['type'] = 'string'\n",
+					"    schema = json.loads(standardised_table_def_json)\n",
+					"    for field in schema['fields']:\n",
+					"        if field['type'] == 'array':\n",
+					"            field['type'] = 'string'\n",
 					"    schema = StructType.fromJson(schema)\n",
 					"\n",
 					"    ### remove characters that Delta can't allow in headers and add numbers to repeated column headers\n",

--- a/workspace/notebook/py_std_to_hrm.json
+++ b/workspace/notebook/py_std_to_hrm.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "9474a8bd-7ac8-439a-a759-ee2ba60877fa"
+				"spark.autotune.trackingId": "ac5dfb8a-34ca-4889-85dd-b1b05001c501"
 			}
 		},
 		"metadata": {
@@ -313,7 +313,7 @@
 					"\n",
 					"    for source_column, source_dtype in source_df.dtypes.iteritems():\n",
 					"        for target_column, target_dtype in target_df.dtypes.iteritems():\n",
-					"            if source_column == target_column and source_dtype != target_dtype:\n",
+					"            if source_column.lower() == target_column.lower() and source_dtype != target_dtype:\n",
 					"                source_df[source_column] = source_df[source_column].astype(target_dtype)\n",
 					"                \n",
 					"    return pd.concat([target_df, source_df], ignore_index=True)\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
