### PR TITLE
Feat/deployment odw 1072 new

### DIFF
--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,157 +3,132 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "pln_trigger_function_app",
+				"name": "pln_service_bus_nsip_project_update",
 				"type": "ExecutePipeline",
-				"dependsOn": [],
+				"dependsOn": [
+					{
+						"activity": "pln_nsip_project_update_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
+						"referenceName": "pln_service_bus_nsip_project_update",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "service-user"
-					}
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_trigger_function_app_copy1",
+				"name": "pln_nsip_project_update_clean_slate",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
+						"referenceName": "pln_nsip_project_update_clean_slate",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "nsip-project"
-					}
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_trigger_function_app_copy1_copy1",
+				"name": "pln_nisp_relevant_reps_clean_slate",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
+						"referenceName": "pln_nisp_relevant_reps_clean_slate",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "nsip-exam-timetable"
-					}
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_trigger_function_app_copy1_copy1_copy1",
+				"name": "pln_horizon_nsip_representation_main",
 				"type": "ExecutePipeline",
-				"dependsOn": [],
+				"dependsOn": [
+					{
+						"activity": "pln_nisp_relevant_reps_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
+						"referenceName": "pln_horizon_nsip_representation_main",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "folder"
-					}
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_trigger_function_app_copy1_copy1_copy1_copy1",
+				"name": "pln_nsip_exam_timetable_clean_slate",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
+						"referenceName": "pln_nsip_exam_timetable_clean_slate",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "nsip-document"
-					}
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_trigger_function_app_copy1_copy1_copy1_copy1_copy1",
+				"name": "pln_nsip_exam_timetable_main",
 				"type": "ExecutePipeline",
-				"dependsOn": [],
+				"dependsOn": [
+					{
+						"activity": "pln_nsip_exam_timetable_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
+						"referenceName": "pln_nsip_exam_timetable_main",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "nsip-s51-advice"
-					}
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_trigger_function_app_2",
+				"name": "pln_nsip_project_clean_slate",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
+						"referenceName": "pln_nsip_project_clean_slate",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "nsip-representation"
-					}
+					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "pln_trigger_function_app_2_copy1",
+				"name": "pln_nsip_project_main",
 				"type": "ExecutePipeline",
-				"dependsOn": [],
-				"userProperties": [],
-				"typeProperties": {
-					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
-						"type": "PipelineReference"
-					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "nsip-project-update"
+				"dependsOn": [
+					{
+						"activity": "pln_nsip_project_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
 					}
-				}
-			},
-			{
-				"name": "pln_trigger_function_app_2_copy1_copy1",
-				"type": "ExecutePipeline",
-				"dependsOn": [],
+				],
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "pln_trigger_function_app",
-						"type": "PipelineReference"
-					},
-					"waitOnCompletion": true,
-					"parameters": {
-						"function_name": "nsip-subscription"
-					}
-				}
-			},
-			{
-				"name": "pln_horizon_nsip_s51_advice",
-				"type": "ExecutePipeline",
-				"dependsOn": [],
-				"userProperties": [],
-				"typeProperties": {
-					"pipeline": {
-						"referenceName": "pln_horizon_nsip_s51_advice",
+						"referenceName": "pln_nsip_project_main",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -179,6 +179,72 @@
 					},
 					"waitOnCompletion": true
 				}
+			},
+			{
+				"name": "pln_service_bus_nsip_subscription",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "pln_nsip_subscription_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_service_bus_nsip_subscription",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_nsip_subscription_clean_slate",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_nsip_subscription_clean_slate",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_nsip_s51_advice_clean_slate",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_nsip_s51_advice_clean_slate",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_nsip_s51_advice_main",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "pln_nsip_s51_advice_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_nsip_s51_advice_main",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
 			}
 		],
 		"folder": {

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -133,6 +133,52 @@
 					},
 					"waitOnCompletion": true
 				}
+			},
+			{
+				"name": "pln_service_user_clean_slate",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "pln_nsip_project_main",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					},
+					{
+						"activity": "pln_horizon_nsip_representation_main",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_service_user_clean_slate",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_service_user_main",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "pln_service_user_clean_slate",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_service_user_main",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
 			}
 		],
 		"folder": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
