### PR TITLE
Mvg/fix/odw 1165 folder

### DIFF
--- a/workspace/notebook/legacy_folder_data.json
+++ b/workspace/notebook/legacy_folder_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a8a8cfa8-ada3-4042-81a2-1eb4f9a6d48e"
+				"spark.autotune.trackingId": "0084e887-3bcb-420d-ac01-fffe70e902e8"
 			}
 		},
 		"metadata": {
@@ -124,6 +124,8 @@
 					"        END                            AS caseStage\n",
 					"\n",
 					"FROM odw_harmonised_db.horizon_folder   AS LFD\n",
+					"\n",
+					"WHERE LEFT(LFD.CaseReference,3) IN (\"TR0\",\"WW0\",\"BC0\",\"WA0\",\"WS0\",\"EN0\");\n",
 					""
 				],
 				"execution_count": 2
@@ -182,9 +184,10 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"SELECT * FROM odw_curated_db.legacy_folder_data"
+					"SELECT * FROM odw_curated_db.legacy_folder_data;\n",
+					"SELECT count(*) FROM odw_curated_db.legacy_folder_data;"
 				],
-				"execution_count": 4
+				"execution_count": 2
 			}
 		]
 	}

--- a/workspace/notebook/legacy_folder_data.json
+++ b/workspace/notebook/legacy_folder_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "294a7d86-5595-44e8-8c4d-8ed2c2b988fc"
+				"spark.autotune.trackingId": "5368e8d4-0ad8-446c-9b38-4bdb4617cc4f"
 			}
 		},
 		"metadata": {
@@ -125,7 +125,7 @@
 					"\n",
 					"FROM odw_harmonised_db.horizon_folder   AS LFD\n",
 					"\n",
-					"WHERE LEFT(LFD.CaseReference,3) IN (\"TR0\",\"WW0\",\"BC0\",\"WA0\",\"WS0\",\"EN0\");\n",
+					"-- WHERE LEFT(LFD.CaseReference,3) IN (\"TR0\",\"WW0\",\"BC0\",\"WA0\",\"WS0\",\"EN0\");\n",
 					""
 				],
 				"execution_count": 2

--- a/workspace/notebook/legacy_folder_data.json
+++ b/workspace/notebook/legacy_folder_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0084e887-3bcb-420d-ac01-fffe70e902e8"
+				"spark.autotune.trackingId": "294a7d86-5595-44e8-8c4d-8ed2c2b988fc"
 			}
 		},
 		"metadata": {
@@ -184,10 +184,10 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"SELECT * FROM odw_curated_db.legacy_folder_data;\n",
+					"SELECT * FROM odw_curated_db.legacy_folder_data WHERE id = '31001250';\n",
 					"SELECT count(*) FROM odw_curated_db.legacy_folder_data;"
 				],
-				"execution_count": 2
+				"execution_count": 3
 			}
 		]
 	}

--- a/workspace/notebook/py_utils_curated_validate_legacy_folder_data.json
+++ b/workspace/notebook/py_utils_curated_validate_legacy_folder_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "true",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "4",
-				"spark.autotune.trackingId": "c3352dd5-8a44-4118-9b65-02a93565f981"
+				"spark.autotune.trackingId": "4754d120-937f-4c2d-adad-74d0226343d3"
 			}
 		},
 		"metadata": {
@@ -357,7 +357,7 @@
 				"source": [
 					"write_file_to_storage(path, OUTPUT_FILE, result)"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -391,7 +391,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(validate)"
 				],
-				"execution_count": null
+				"execution_count": 10
 			}
 		]
 	}

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7e3d3a04-478a-4559-a5cd-7e4285f5c5e9"
+				"spark.autotune.trackingId": "a948e6eb-cac6-41d6-8400-255872f9dbe4"
 			}
 		},
 		"metadata": {
@@ -139,6 +139,31 @@
 					"LEFT JOIN odw_curated_db.nsip_service_user                             AS SU2\r\n",
 					"    ON SU2.ID = RR.AgentContactID\r\n",
 					"WHERE RR.ISActive = 'Y'"
+				],
+				"execution_count": 1
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_harmonised_db.casework_nsip_relevant_representation_dim;\n",
+					"SELECT * FROM odw_curated_db.nsip_service_user;"
 				],
 				"execution_count": 2
 			},

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a948e6eb-cac6-41d6-8400-255872f9dbe4"
+				"spark.autotune.trackingId": "77f956cb-fdbc-443e-bb9c-e29adffe602f"
 			}
 		},
 		"metadata": {
@@ -141,31 +141,6 @@
 					"WHERE RR.ISActive = 'Y'"
 				],
 				"execution_count": 1
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM odw_harmonised_db.casework_nsip_relevant_representation_dim;\n",
-					"SELECT * FROM odw_curated_db.nsip_service_user;"
-				],
-				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
