### PR TITLE
Pd/fix/schemas data types

### DIFF
--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "84bae88f-5dd0-4fa1-8eef-d25a4157866a"
+				"spark.autotune.trackingId": "0b2fbee1-0492-497f-9b07-9e1eb38e9594"
 			}
 		},
 		"metadata": {
@@ -103,10 +103,15 @@
 					"\r\n",
 					"    ET.CaseReference                                            AS caseReference,\r\n",
 					"    CAST(ET.ID AS integer)                                                        AS eventId,\r\n",
-					"    ET.TypeOfExamination                                        AS type,\r\n",
+					"    CASE    \r\n",
+					"        WHEN ET.TypeOfExamination  =  'Site Visit (Unaccompanied)'\r\n",
+					"        THEN 'Accompanied Site Inspection'       \r\n",
+					"        WHEN ET.TypeOfExamination  =   'Site Visit (Accompanied)'\r\n",
+					"        THEN 'Accompanied Site Inspection'  \r\n",
+					"    END                                                         AS type,\r\n",
 					"    ET.Name                                                     AS eventTitle,\r\n",
-					"    CAST(ET.DeadlineStartDateTime AS string)                  AS eventDeadlineStartDate,\r\n",
-					"    CAST(ET.Date AS string)                                   AS date,\r\n",
+					"    CAST(ET.DeadlineStartDateTime AS string)                    AS eventDeadlineStartDate,\r\n",
+					"    CAST(ET.Date AS string)                                     AS date,\r\n",
 					"    ET.EventLineItems                                           AS eventLineItems,\r\n",
 					"    ET.Description                                              AS description \r\n",
 					"    \r\n",

--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "80f8a74d-6411-4800-a807-2b1f40654261"
+				"spark.autotune.trackingId": "84bae88f-5dd0-4fa1-8eef-d25a4157866a"
 			}
 		},
 		"metadata": {
@@ -102,11 +102,11 @@
 					"SELECT DISTINCT\r\n",
 					"\r\n",
 					"    ET.CaseReference                                            AS caseReference,\r\n",
-					"    ET.ID                                                       AS eventId,\r\n",
+					"    CAST(ET.ID AS integer)                                                        AS eventId,\r\n",
 					"    ET.TypeOfExamination                                        AS type,\r\n",
 					"    ET.Name                                                     AS eventTitle,\r\n",
-					"    CAST(ET.DeadlineStartDateTime AS timestamp)                  AS eventDeadlineStartDate,\r\n",
-					"    CAST(ET.Date AS timestamp)                                   AS date,\r\n",
+					"    CAST(ET.DeadlineStartDateTime AS string)                  AS eventDeadlineStartDate,\r\n",
+					"    CAST(ET.Date AS string)                                   AS date,\r\n",
 					"    ET.EventLineItems                                           AS eventLineItems,\r\n",
 					"    ET.Description                                              AS description \r\n",
 					"    \r\n",

--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0b2fbee1-0492-497f-9b07-9e1eb38e9594"
+				"spark.autotune.trackingId": "0696348b-ab2b-4881-adf8-f38106ef72b8"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"from notebookutils import mssparkutils\n",
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 4
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -120,7 +120,7 @@
 					"ORDER BY caseReference,eventTitle DESC\r\n",
 					""
 				],
-				"execution_count": 5
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -168,7 +168,7 @@
 					"    description    \r\n",
 					"FROM odw_curated_db.vw_examination_timetable"
 				],
-				"execution_count": 6
+				"execution_count": 9
 			}
 		]
 	}

--- a/workspace/notebook/nsip_subscription.json
+++ b/workspace/notebook/nsip_subscription.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bc590159-b952-4aac-a616-20acd1029a2c"
+				"spark.autotune.trackingId": "c3563acd-4385-4465-b223-a65f9ffd36b3"
 			}
 		},
 		"metadata": {
@@ -92,13 +92,20 @@
 					"\n",
 					"SELECT DISTINCT\n",
 					"\n",
-					"    *\n",
+					"    CAST(subscriptionId\tAS integer),\n",
+					"    caseReference\t,\n",
+					"    emailAddress\t,\n",
+					"    subscriptionType\t,\n",
+					"    startDate\t,\n",
+					"    endDate\t,\n",
+					"    language\t\n",
+					"\n",
 					"\n",
 					"FROM odw_harmonised_db.nsip_subscription\n",
 					"\n",
 					"WHERE IsActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -132,7 +139,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_subscription')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_subscription')"
 				],
-				"execution_count": 2
+				"execution_count": 4
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
