### PR TITLE
Pd/fix/nsip document

### DIFF
--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8dd7b67a-bbc2-4740-abc4-cf8b2e4be233"
+				"spark.autotune.trackingId": "d057b774-db80-4485-b793-5e2d0919aa2a"
 			}
 		},
 		"metadata": {
@@ -125,7 +125,7 @@
 					"MD.Filter1\t                            AS filter1,\n",
 					"MD.Filter2\t                            AS filter2,\n",
 					"MD.ParentID\t                            AS horizonFolderId,\n",
-					"'NULL'\t                                AS transcriptId\t\n",
+					"''\t                                AS transcriptId\t\n",
 					"\n",
 					"FROM odw_harmonised_db.document_meta_data   AS MD\n",
 					"JOIN odw_harmonised_db.aie_document_data    AS AMD\n",

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d057b774-db80-4485-b793-5e2d0919aa2a"
+				"spark.autotune.trackingId": "97099c73-e1ac-4fb8-a71f-eb881ef6b813"
 			}
 		},
 		"metadata": {
@@ -125,7 +125,7 @@
 					"MD.Filter1\t                            AS filter1,\n",
 					"MD.Filter2\t                            AS filter2,\n",
 					"MD.ParentID\t                            AS horizonFolderId,\n",
-					"''\t                                AS transcriptId\t\n",
+					"NULL\t                                    AS transcriptId\t\n",
 					"\n",
 					"FROM odw_harmonised_db.document_meta_data   AS MD\n",
 					"JOIN odw_harmonised_db.aie_document_data    AS AMD\n",
@@ -133,7 +133,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": 26
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -152,7 +152,7 @@
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")\n",
 					""
 				],
-				"execution_count": 27
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -184,7 +184,7 @@
 					"* \r\n",
 					"FROM odw_curated_db.vw_document_metadata"
 				],
-				"execution_count": 28
+				"execution_count": 6
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
