### PR TITLE
Feat/odw 1174 create orchestration and config for each layer

### DIFF
--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a86ac1c3-1b07-4a0e-947b-923dc3a9e0f6"
+				"spark.autotune.trackingId": "81816e3a-dcc6-4d05-8878-d8712f78b216"
 			}
 		},
 		"metadata": {
@@ -263,10 +263,45 @@
 					"    --AND RR.CaseReference = 'TR020002'--TEST RECORD\r\n",
 					"        AND RR.AgentContactID IS NOT NULL --THIS MEANS THEY ARE AN AGENT\r\n",
 					"\r\n",
-					"ORDER BY ingestionDate DESC\r\n",
+					"\r\n",
+					"--------------------- Appeals data -----------------------------------\r\n",
+					"UNION ALL\r\n",
+					"SELECT \r\n",
+					"    service_user.ServiceUserID AS id    \r\n",
+					"    ,service_user.salutation\r\n",
+					"    ,service_user.firstName\r\n",
+					"    ,service_user.lastName\r\n",
+					"    ,service_user.addressLine1\r\n",
+					"    ,service_user.addressLine2\r\n",
+					"    ,service_user.addressTown\r\n",
+					"    ,service_user.addressCounty\r\n",
+					"    ,service_user.postcode\r\n",
+					"    ,service_user.addressCountry\r\n",
+					"    ,service_user.organisation\r\n",
+					"    ,service_user.organisationType\r\n",
+					"    ,service_user.role\r\n",
+					"    ,service_user.telephoneNumber\r\n",
+					"    ,service_user.otherPhoneNumber\r\n",
+					"    ,service_user.faxNumber\r\n",
+					"    ,service_user.emailAddress\r\n",
+					"    ,service_user.webAddress\r\n",
+					"    ,'Appellant' AS serviceUserType\r\n",
+					"    ,service_user.caseReference\r\n",
+					"    ,service_user.ingestionDate\r\n",
+					"    ,Source_system.SourceSystemID\r\n",
+					"    ,Source_system.Description\r\n",
+					"FROM \r\n",
+					"    odw_harmonised_db.service_user AS service_user\r\n",
+					"    INNER JOIN odw_harmonised_db.main_sourcesystem_fact AS source_system\r\n",
+					"        ON service_user.SourceSystemID = source_system.SourceSystemID\r\n",
+					"WHERE \r\n",
+					"    service_user.sourceSystem = 'back-office-appeals'\r\n",
+					"    AND service_user.IsActive = 'Y'\r\n",
+					"\r\n",
+					"\r\n",
 					""
 				],
-				"execution_count": 2
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -329,7 +364,7 @@
 					"    \r\n",
 					"FROM odw_curated_db.vw_nsip_service_user"
 				],
-				"execution_count": 3
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -364,7 +399,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": 4
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -415,7 +450,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 5
+				"execution_count": 10
 			}
 		]
 	}

--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bc0024dc-d7ef-4422-8488-32240f27ba62"
+				"spark.autotune.trackingId": "772c59cc-fe33-4b6f-84b4-4adebdb4bd4a"
 			}
 		},
 		"metadata": {
@@ -91,7 +91,7 @@
 					"\n",
 					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 31
+				"execution_count": 36
 			},
 			{
 				"cell_type": "markdown",
@@ -267,7 +267,7 @@
 					"--------------------- Appeals data -----------------------------------\r\n",
 					"UNION\r\n",
 					"SELECT \r\n",
-					"    service_user.ServiceUserID AS id    \r\n",
+					"    service_user.id    \r\n",
 					"    ,service_user.salutation\r\n",
 					"    ,service_user.firstName\r\n",
 					"    ,service_user.lastName\r\n",
@@ -285,11 +285,11 @@
 					"    ,service_user.faxNumber\r\n",
 					"    ,service_user.emailAddress\r\n",
 					"    ,service_user.webAddress\r\n",
-					"    ,'Appellant' AS serviceUserType\r\n",
+					"    ,service_user.serviceUserType\r\n",
 					"    ,service_user.caseReference\r\n",
 					"    ,service_user.ingestionDate\r\n",
-					"    ,'back-office-appeals' AS sourceSuid\r\n",
-					"    ,'Appeals' As Description\r\n",
+					"    ,service_user.sourceSuid\r\n",
+					"    ,service_user.SourceSystem As Description\r\n",
 					"FROM \r\n",
 					"    odw_harmonised_db.service_user AS service_user\r\n",
 					"WHERE \r\n",
@@ -299,7 +299,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 32
+				"execution_count": 37
 			},
 			{
 				"cell_type": "markdown",
@@ -362,7 +362,7 @@
 					"    \r\n",
 					"FROM odw_curated_db.vw_nsip_service_user"
 				],
-				"execution_count": 33
+				"execution_count": 38
 			},
 			{
 				"cell_type": "markdown",
@@ -397,7 +397,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": 34
+				"execution_count": 39
 			},
 			{
 				"cell_type": "markdown",
@@ -448,7 +448,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 35
+				"execution_count": 40
 			}
 		]
 	}

--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a9545d6f-b364-4f8f-90e2-cb77006ffe5c"
+				"spark.autotune.trackingId": "bc0024dc-d7ef-4422-8488-32240f27ba62"
 			}
 		},
 		"metadata": {
@@ -91,7 +91,7 @@
 					"\n",
 					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 23
+				"execution_count": 31
 			},
 			{
 				"cell_type": "markdown",
@@ -251,7 +251,7 @@
 					"    RR.EmailAddress                                     AS emailAddress,\r\n",
 					"    NULL                                                AS webAddress,\r\n",
 					"    'Agent'                                             AS serviceUserType,\r\n",
-					"    RR.CaseReference                                    AS caseReference,\r\n",
+					"    RR.CaseReference                                    AS caseReference,   \r\n",
 					"    RR.IngestionDate                                    AS ingestionDate,\r\n",
 					"    'Horizon'                                           AS sourceSuid,\r\n",
 					"    SS.Description                                      AS sourceSystem\r\n",
@@ -288,12 +288,10 @@
 					"    ,'Appellant' AS serviceUserType\r\n",
 					"    ,service_user.caseReference\r\n",
 					"    ,service_user.ingestionDate\r\n",
-					"    ,'back-office-appeals'\r\n",
-					"    ,Source_system.Description\r\n",
+					"    ,'back-office-appeals' AS sourceSuid\r\n",
+					"    ,'Appeals' As Description\r\n",
 					"FROM \r\n",
 					"    odw_harmonised_db.service_user AS service_user\r\n",
-					"    INNER JOIN odw_harmonised_db.main_sourcesystem_fact AS source_system\r\n",
-					"        ON service_user.SourceSystemID = source_system.SourceSystemID\r\n",
 					"WHERE \r\n",
 					"    service_user.sourceSystem = 'back-office-appeals'\r\n",
 					"    AND service_user.IsActive = 'Y'\r\n",
@@ -301,7 +299,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 24
+				"execution_count": 32
 			},
 			{
 				"cell_type": "markdown",
@@ -364,7 +362,7 @@
 					"    \r\n",
 					"FROM odw_curated_db.vw_nsip_service_user"
 				],
-				"execution_count": 25
+				"execution_count": 33
 			},
 			{
 				"cell_type": "markdown",
@@ -399,7 +397,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": 26
+				"execution_count": 34
 			},
 			{
 				"cell_type": "markdown",
@@ -450,7 +448,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 27
+				"execution_count": 35
 			}
 		]
 	}

--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "81816e3a-dcc6-4d05-8878-d8712f78b216"
+				"spark.autotune.trackingId": "a9545d6f-b364-4f8f-90e2-cb77006ffe5c"
 			}
 		},
 		"metadata": {
@@ -91,7 +91,7 @@
 					"\n",
 					"spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": 1
+				"execution_count": 23
 			},
 			{
 				"cell_type": "markdown",
@@ -125,7 +125,7 @@
 					"\r\n",
 					"-----------------------REPRESENTATION CONTACTS DATA-----------------\r\n",
 					"\r\n",
-					"SELECT DISTINCT\r\n",
+					"SELECT\r\n",
 					"\r\n",
 					"    REPLACE(RR.ContactID, 'P_', '')                     AS id,\r\n",
 					"    NULL                                                AS salutation,\r\n",
@@ -175,9 +175,9 @@
 					"\r\n",
 					"---------------------------------APPLICANTS DATA-----------------------------\r\n",
 					"\r\n",
-					"UNION ALL\r\n",
+					"UNION\r\n",
 					"\r\n",
-					"SELECT DISTINCT\r\n",
+					"SELECT\r\n",
 					"CASE\r\n",
 					"    WHEN NSIP.CaseNodeID IS NOT NULL\r\n",
 					"    THEN NSIP.CaseNodeID\r\n",
@@ -214,9 +214,9 @@
 					"\r\n",
 					"----------------------------------AGENTS DATA-----------------------------\r\n",
 					"\r\n",
-					"UNION ALL\r\n",
+					"UNION\r\n",
 					"\r\n",
-					"SELECT DISTINCT\r\n",
+					"SELECT\r\n",
 					"\r\n",
 					"    REPLACE(RR.AgentContactID, 'P_', '')                AS id,\r\n",
 					"    ''                                                  AS salutation,\r\n",
@@ -265,7 +265,7 @@
 					"\r\n",
 					"\r\n",
 					"--------------------- Appeals data -----------------------------------\r\n",
-					"UNION ALL\r\n",
+					"UNION\r\n",
 					"SELECT \r\n",
 					"    service_user.ServiceUserID AS id    \r\n",
 					"    ,service_user.salutation\r\n",
@@ -288,7 +288,7 @@
 					"    ,'Appellant' AS serviceUserType\r\n",
 					"    ,service_user.caseReference\r\n",
 					"    ,service_user.ingestionDate\r\n",
-					"    ,Source_system.SourceSystemID\r\n",
+					"    ,'back-office-appeals'\r\n",
 					"    ,Source_system.Description\r\n",
 					"FROM \r\n",
 					"    odw_harmonised_db.service_user AS service_user\r\n",
@@ -301,7 +301,7 @@
 					"\r\n",
 					""
 				],
-				"execution_count": 7
+				"execution_count": 24
 			},
 			{
 				"cell_type": "markdown",
@@ -364,7 +364,7 @@
 					"    \r\n",
 					"FROM odw_curated_db.vw_nsip_service_user"
 				],
-				"execution_count": 8
+				"execution_count": 25
 			},
 			{
 				"cell_type": "markdown",
@@ -399,7 +399,7 @@
 					"%%pyspark\n",
 					"pip install Faker"
 				],
-				"execution_count": 9
+				"execution_count": 26
 			},
 			{
 				"cell_type": "markdown",
@@ -450,7 +450,7 @@
 					"        table_loc = \"abfss://odw-curated@\"+storage_account+'service_user'\n",
 					"        df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": 10
+				"execution_count": 27
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [x ] No

 2. Have any new tables been created in Standardised?

  	- [ x] No
 3. Have any new tables been created in Harmonised or Curated?

   	 - [x] No
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ x] No


Adding appeals service user required adding union in view within to std -> harmonised notebook. Additional cleanup to improve performance - use of select distinct with union all results in the same data set as using union given non-overlapping select statements.
 
