### PR TITLE
Pd/fix/schemas fixes

### DIFF
--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a8c216d5-f00c-4e36-a5a4-6a963ccb3af0"
+				"spark.autotune.trackingId": "a0bbd369-9258-4b52-b183-012edc247623"
 			}
 		},
 		"metadata": {
@@ -99,12 +99,12 @@
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
 					"    AD.Enquirer                                             AS from,\n",
 					"    CASE\n",
-					"        WHEN AD.EnquirerOrganisation = 'None'\n",
+					"        WHEN LOWER(AD.EnquirerOrganisation) = 'none'\n",
 					"        THEN NULL\n",
 					"        ELSE AD.EnquirerOrganisation\n",
 					"    END                                                     AS agent,\n",
 					"    CASE \n",
-					"        WHEN AD.EnquiryMethod = 'None'\n",
+					"        WHEN LOWER(AD.EnquiryMethod) = 'none'\n",
 					"        THEN NULL\n",
 					"        ELSE LOWER(AD.EnquiryMethod)\n",
 					"        END                                                 AS method,\n",
@@ -122,7 +122,7 @@
 					"    END                                                     AS status,\n",
 					"    \"unredacted\"                                            AS redactionStatus,\n",
 					"    CASE\n",
-					"        WHEN AD.AttachmentID = 'None'\n",
+					"        WHEN LOWER(AD.AttachmentID) = 'none'\n",
 					"        THEN NULL\n",
 					"        ELSE AD.AttachmentID\n",
 					"    END                                                     AS attachmentIds\n",

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f5b26225-bef7-4ff8-b6ac-44e270c29a00"
+				"spark.autotune.trackingId": "004d76ba-47a6-492b-a09a-7034259cc19a"
 			}
 		},
 		"metadata": {
@@ -126,7 +126,7 @@
 					"FROM odw_harmonised_db.casework_nsip_advice_dim \t        AS AD\n",
 					"WHERE AD.IsActive = 'Y'"
 				],
-				"execution_count": 11
+				"execution_count": 1
 			},
 			{
 				"cell_type": "markdown",
@@ -160,7 +160,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
-				"execution_count": 9
+				"execution_count": 2
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "10c03f40-6a96-49cc-bb3e-fb9dffd75317"
+				"spark.autotune.trackingId": "f5b26225-bef7-4ff8-b6ac-44e270c29a00"
 			}
 		},
 		"metadata": {
@@ -99,7 +99,7 @@
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
 					"    AD.Enquirer                                             AS from,\n",
 					"    CASE\n",
-					"        WHEN AD.EnquirerOrganisation = 'None'\n",
+					"        WHEN AD.EnquirerOrganisation = NULL\n",
 					"        THEN NULL\n",
 					"        ELSE AD.EnquirerOrganisation\n",
 					"    END                                                     AS agent,\n",
@@ -118,7 +118,7 @@
 					"    END                                                     AS status,\n",
 					"    \"unredacted\"                                            AS redactionStatus,\n",
 					"    CASE\n",
-					"        WHEN AD.AttachmentID = 'None'\n",
+					"        WHEN AD.AttachmentID = NULL\n",
 					"        THEN NULL\n",
 					"        ELSE AD.AttachmentID\n",
 					"    END                                                     AS attachmentIds\n",

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "004d76ba-47a6-492b-a09a-7034259cc19a"
+				"spark.autotune.trackingId": "a472639f-4fec-441f-a373-7bb3bc362786"
 			}
 		},
 		"metadata": {
@@ -99,11 +99,15 @@
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
 					"    AD.Enquirer                                             AS from,\n",
 					"    CASE\n",
-					"        WHEN AD.EnquirerOrganisation = NULL\n",
+					"        WHEN AD.EnquirerOrganisation = 'None'\n",
 					"        THEN NULL\n",
 					"        ELSE AD.EnquirerOrganisation\n",
 					"    END                                                     AS agent,\n",
-					"    LOWER(AD.EnquiryMethod)                                 AS method,\n",
+					"    CASE \n",
+					"        WHEN AD.EnquiryMethod = 'None'\n",
+					"        THEN NULL\n",
+					"        ELSE LOWER(AD.EnquiryMethod)\n",
+					"        END                                                 AS method,\n",
 					"    AD.EnquiryDate                                          AS enquiryDate,\n",
 					"    AD.Enquiry                                              AS enquiryDetails,\n",
 					"    AD.AdviceFrom                                           AS adviceGivenBy,\n",
@@ -118,7 +122,7 @@
 					"    END                                                     AS status,\n",
 					"    \"unredacted\"                                            AS redactionStatus,\n",
 					"    CASE\n",
-					"        WHEN AD.AttachmentID = NULL\n",
+					"        WHEN AD.AttachmentID = 'None'\n",
 					"        THEN NULL\n",
 					"        ELSE AD.AttachmentID\n",
 					"    END                                                     AS attachmentIds\n",

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a472639f-4fec-441f-a373-7bb3bc362786"
+				"spark.autotune.trackingId": "a8c216d5-f00c-4e36-a5a4-6a963ccb3af0"
 			}
 		},
 		"metadata": {
@@ -131,6 +131,29 @@
 					"WHERE AD.IsActive = 'Y'"
 				],
 				"execution_count": 1
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"Select * from odw_curated_db.nsip_s51_advice where adviceId = 32842535"
+				],
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_utils_curated_validate_functions.json
+++ b/workspace/notebook/py_utils_curated_validate_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0c4db2e8-45d8-450a-bf1a-bb45c86cc131"
+				"spark.autotune.trackingId": "3d55b710-e2cd-4438-a531-093b58ae3602"
 			}
 		},
 		"metadata": {
@@ -292,7 +292,7 @@
 					"\r\n",
 					"        array_to_populate = data_dict[primary_key_field][array]\r\n",
 					"        new_item = row[array_field]\r\n",
-					"        if new_item not in array_to_populate:\r\n",
+					"        if new_item not in array_to_populate and new_item is not None:\r\n",
 					"            array_to_populate.append(new_item)\r\n",
 					"\r\n",
 					"    final_dict = {key: dict(value) for key, value in data_dict.items()}\r\n",

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4e54e35c-f3c0-4714-b274-e99271d34109"
+				"spark.autotune.trackingId": "2ffda87c-89e5-4f6c-8bef-4fe7b14aca6e"
 			}
 		},
 		"metadata": {
@@ -133,7 +133,7 @@
 					"    THEN 'ORGANISATION'\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'Myself'\r\n",
 					"    THEN 'PERSON'\r\n",
-					"    ELSE NULL\r\n",
+					"    ELSE 'UNKNOWN'\r\n",
 					"END                                                                    AS registerFor,\r\n",
 					"CASE\r\n",
 					"    WHEN RR.RelRepOrganisation = 'Other Statutory Consultees'\r\n",
@@ -205,7 +205,7 @@
 				},
 				"source": [
 					"%%sql\r\n",
-					"SELECT * FROM odw_curated_db.relevant_representation where caseRef = WS010003"
+					"SELECT * FROM odw_curated_db.relevant_representation where caseRef = 'WS010003'"
 				],
 				"execution_count": 3
 			}

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "77f956cb-fdbc-443e-bb9c-e29adffe602f"
+				"spark.autotune.trackingId": "e44c6b93-a76f-4237-854b-3fa6154b2e9a"
 			}
 		},
 		"metadata": {
@@ -127,10 +127,6 @@
 					"CASE\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'An Organisation'                                                   \r\n",
 					"    THEN 'ORGANISATION'\r\n",
-					"    WHEN RR.RelRepOnBehalfOf = 'Members of the Public/Businesses'\r\n",
-					"    THEN RR.RelRepOnBehalfOf\r\n",
-					"    WHEN RR.RelRepOnBehalfOf = 'Another Individual or Organisation'\r\n",
-					"    THEN RR.RelRepOnBehalfOf\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'Myself'\r\n",
 					"    THEN 'PERSON'\r\n",
 					"    ELSE 'UNKNOWN'\r\n",

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e44c6b93-a76f-4237-854b-3fa6154b2e9a"
+				"spark.autotune.trackingId": "28ba7bd1-a157-4644-83bd-61a913a710a1"
 			}
 		},
 		"metadata": {
@@ -127,9 +127,13 @@
 					"CASE\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'An Organisation'                                                   \r\n",
 					"    THEN 'ORGANISATION'\r\n",
+					"    WHEN RR.RelRepOnBehalfOf = 'Members of the Public/Businesses'\r\n",
+					"    THEN 'ORGANISATION'\r\n",
+					"    WHEN RR.RelRepOnBehalfOf = 'Another Individual or Organisation'\r\n",
+					"    THEN 'ORGANISATION'\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'Myself'\r\n",
 					"    THEN 'PERSON'\r\n",
-					"    ELSE 'UNKNOWN'\r\n",
+					"    ELSE NULL\r\n",
 					"END                                                                    AS registerFor,\r\n",
 					"CASE\r\n",
 					"    WHEN RR.RelRepOrganisation = 'Other Statutory Consultees'\r\n",
@@ -181,7 +185,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_relevant_representation')\r\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.relevant_representation')"
 				],
-				"execution_count": 14
+				"execution_count": 2
 			}
 		]
 	}

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2ffda87c-89e5-4f6c-8bef-4fe7b14aca6e"
+				"spark.autotune.trackingId": "39c6564a-7eee-44cf-98a8-f65bd987b9c7"
 			}
 		},
 		"metadata": {
@@ -107,12 +107,12 @@
 					"    WHEN RR.RelRepOnBehalfOf = 'An Organisation'                                                   \r\n",
 					"    THEN 'ORGANISATION'\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'Members of the Public/Businesses'\r\n",
-					"    THEN RR.RelRepOnBehalfOf\r\n",
+					"    THEN 'ORGANISATION'\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'Another Individual or Organisation'\r\n",
 					"    THEN 'AGENT'\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'Myself'\r\n",
 					"    THEN 'PERSON'\r\n",
-					"    ELSE 'UNKNOWN'\r\n",
+					"    ELSE RR.RelRepOnBehalfOf\r\n",
 					"END                                                                    AS representationFrom,\r\n",
 					"CASE \r\n",
 					"    WHEN SU.serviceUserType = 'RepresentationContact'\r\n",
@@ -133,7 +133,7 @@
 					"    THEN 'ORGANISATION'\r\n",
 					"    WHEN RR.RelRepOnBehalfOf = 'Myself'\r\n",
 					"    THEN 'PERSON'\r\n",
-					"    ELSE 'UNKNOWN'\r\n",
+					"    ELSE RR.RelRepOnBehalfOf\r\n",
 					"END                                                                    AS registerFor,\r\n",
 					"CASE\r\n",
 					"    WHEN RR.RelRepOrganisation = 'Other Statutory Consultees'\r\n",

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0570fe4c-05f7-49a2-9fde-d9ada7b096f6"
+				"spark.autotune.trackingId": "4e54e35c-f3c0-4714-b274-e99271d34109"
 			}
 		},
 		"metadata": {
@@ -186,6 +186,28 @@
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.relevant_representation')"
 				],
 				"execution_count": 6
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					}
+				},
+				"source": [
+					"%%sql\r\n",
+					"SELECT * FROM odw_curated_db.relevant_representation where caseRef = WS010003"
+				],
+				"execution_count": 3
 			}
 		]
 	}

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "64cd4708-59d4-4ae2-abc4-f489ae643f63"
+				"spark.autotune.trackingId": "0570fe4c-05f7-49a2-9fde-d9ada7b096f6"
 			}
 		},
 		"metadata": {
@@ -151,7 +151,7 @@
 					"    ON SU2.ID = RR.AgentContactID\r\n",
 					"WHERE RR.ISActive = 'Y'"
 				],
-				"execution_count": 3
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -185,7 +185,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_relevant_representation')\r\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.relevant_representation')"
 				],
-				"execution_count": 4
+				"execution_count": 6
 			}
 		]
 	}

--- a/workspace/notebook/relevant_representation.json
+++ b/workspace/notebook/relevant_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "28ba7bd1-a157-4644-83bd-61a913a710a1"
+				"spark.autotune.trackingId": "64cd4708-59d4-4ae2-abc4-f489ae643f63"
 			}
 		},
 		"metadata": {
@@ -151,7 +151,7 @@
 					"    ON SU2.ID = RR.AgentContactID\r\n",
 					"WHERE RR.ISActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -185,7 +185,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_relevant_representation')\r\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.relevant_representation')"
 				],
-				"execution_count": 2
+				"execution_count": 4
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
