### PR TITLE
feat(infrastructure): appeals back office service bus subscriptions

### DIFF
--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/azure/azapi" {
   hashes = [
     "h1:SMZ/x4nM54vVlqqtH7gk+ZM44jTZ4s35fuOHFvZGlXM=",
     "h1:SmO4p9BoN8MWPDDycOysh4WxHv5v8c9cTbF9+efg/K8=",
+    "h1:hyHiXqegENqTo4e1ooCkay1mHhBRooHH/nGIF8PuS1w=",
     "zh:39713f9aa01824a6db818dffcb2fff9175cf888c70c6805e1dced17d42dd0d24",
     "zh:4bb38a1861491ea380d5fe65062b73299aab49ec5baf58ad55edd9c99b2f5072",
     "zh:4d572e30973b8dd1936ee60a2fd3dab201ec55ea16521905b06ac7e8e41ecc57",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/azure/azapi" {
 provider "registry.terraform.io/hashicorp/azuread" {
   version = "2.46.0"
   hashes = [
+    "h1:8cUf14zX4TJTPQAhE9c1oW0k4v+pdx3QLlsNLXivorw=",
     "h1:juynwVlu6iNqqPDSQIIt2gN7/uFpo6E3uqdwhyauSHo=",
     "h1:t21VvB6Mdsebwld7dJpd8H9Q/37SzknYUxtJVRHFn4s=",
     "zh:1b9bfe88b02684dca86591ed595d2d9e2ca4fdd146812cbf2baea4260aa1cf45",
@@ -47,6 +49,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 3.74.0"
   hashes = [
     "h1:4b15khHtc5OkIVEFg0W5QRwf/ov1WVQkXVdSiAcTCS8=",
+    "h1:ETVZfmulZQ435+lgFCkZRpfVOLyAxfDOwbPXFg3aLLQ=",
     "h1:OtJKZcMwrRNR84ylT1GgMwGR8KTxVOCkNifbjABlGj0=",
     "zh:0424c70152f949da1ec52ba96d20e5fd32fd22d9bd9203ce045d5f6aab3d20fc",
     "zh:16dbf581d10f8e7937185bcdcceb4f91d08c919e452fb8da7580071288c8c397",
@@ -67,6 +70,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
     "h1:0ULxM8/DscMzfiDWg1yclBf/39U44wQmlx745BfYZ80=",
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
@@ -87,6 +91,7 @@ provider "registry.terraform.io/hashicorp/time" {
   version = "0.9.1"
   hashes = [
     "h1:NDBCUogi8SVEFGCmoVP7VOU2KbnV7z2mUQF3pRyndoo=",
+    "h1:NUv/YtEytDQncBQ2mTxnUZEy/rmDlPYmE9h2iokR0vk=",
     "h1:UHcDnIYFZ00uoou0TwPGMwOrE8gTkoRephIvdwDAK70=",
     "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
     "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -117,6 +117,13 @@ odt_backoffice_sb_topic_subscriptions = [
   }
 ]
 
+## Appeals Back Office
+odt_appeals_back_office = {
+  resource_group_name = "pins-rg-appeals-bo-dev"
+  service_bus_enabled = true
+  service_bus_name    = "pins-sb-appeals-bo-dev"
+}
+
 service_bus_failover_enabled = false
 service_bus_role_assignments = {
   "Azure Service Bus Data Owner" = {

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -118,6 +118,13 @@ odt_backoffice_sb_topic_subscriptions = [
   }
 ]
 
+## Appeals Back Office
+odt_appeals_back_office = {
+  resource_group_name = "pins-rg-appeals-bo-prod"
+  service_bus_enabled = true
+  service_bus_name    = "pins-sb-appeals-bo-prod"
+}
+
 service_bus_failover_enabled = false
 service_bus_role_assignments = {
   "Azure Service Bus Data Owner" = {

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -118,6 +118,12 @@ odt_backoffice_sb_topic_subscriptions = [
   }
 ]
 
+## Appeals Back Office
+odt_appeals_back_office = {
+  resource_group_name = "pins-rg-appeals-bo-test"
+  service_bus_enabled = true
+  service_bus_name    = "pins-sb-appeals-bo-test"
+}
 
 service_bus_failover_enabled = false
 service_bus_role_assignments = {

--- a/infrastructure/terraform.tfvars
+++ b/infrastructure/terraform.tfvars
@@ -1,0 +1,21 @@
+# common variables loaded by default
+# see https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files
+
+odt_appeals_back_office_sb_topic_subscriptions = [
+  {
+    subscription_name = "appeal-odw-sub"
+    topic_name        = "appeal"
+  },
+  {
+    subscription_name = "appeal-document-odw-sub"
+    topic_name        = "appeal-document"
+  },
+  {
+    subscription_name = "appeal-event-odw-sub"
+    topic_name        = "appeal-event"
+  },
+  {
+    subscription_name = "appeal-service-user-odw-sub"
+    topic_name        = "appeal-service-user"
+  }
+]

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -231,6 +231,43 @@ variable "odt_backoffice_sb_topic_subscriptions" {
   EOT
 }
 
+variable "odt_appeals_back_office" {
+  description = "Appeals Back Office configuration"
+  type = object({
+    resource_group_name = string
+    service_bus_enabled = bool
+    service_bus_name    = string
+  })
+}
+
+variable "odt_appeals_back_office_sb_topic_subscriptions" {
+  default     = {}
+  type        = any
+  description = <<-EOT
+    "A map containing the configuration for Service Bus Subscriptions to be created in the Appeals Back Office Service Bus Namespace.
+    {
+    subscription_name                         = "subscription_name"
+    topic_name                                = "topic_name"
+    status                                    = "Active"
+    max_delivery_count                        = 1
+    auto_delete_on_idle                       = "PT5M"
+    default_message_ttl                       = "P14D"
+    lock_duration                             = "P0DT0H1M0S"
+    dead_lettering_on_message_expiration      = false
+    dead_lettering_on_filter_evaluation_error = true
+    enable_batched_operations                 = false
+    requires_session                          = false
+    forward_to                                = ""
+    role_assignments                          = {
+      "role_name" = {
+        users = []
+        groups = []
+        service_principals = []
+      }
+    }"
+  EOT
+}
+
 variable "odt_subscription_id" {
   description = "The subscription ID of the ODT subscription"
   type        = string

--- a/infrastructure/workload-function-app.tf
+++ b/infrastructure/workload-function-app.tf
@@ -144,6 +144,16 @@ resource "azurerm_role_assignment" "odt_servicebus_namespace" {
   principal_id         = module.function_app[each.key].identity[0].principal_id
 }
 
+resource "azurerm_role_assignment" "odt_appeals_servicebus_namespace" {
+  for_each = {
+    for function_app in var.function_app : function_app.name => function_app if var.function_app_enabled == true
+  }
+
+  scope                = module.odt_appeals_back_office_sb[0].namespace_id
+  role_definition_name = "Azure Service Bus Data receiver"
+  principal_id         = module.function_app[each.key].identity[0].principal_id
+}
+
 resource "azurerm_application_insights" "function_app_insights" {
   for_each = {
     for function_app in var.function_app : function_app.name => function_app if var.function_app_enabled == true

--- a/infrastructure/workload-odt-backoffice-sb.tf
+++ b/infrastructure/workload-odt-backoffice-sb.tf
@@ -93,3 +93,28 @@ module "odt_backoffice_sb_failover" {
     azurerm.odt = azurerm.odt
   }
 }
+
+
+module "odt_appeals_back_office_sb" {
+  count = var.odt_appeals_back_office.service_bus_enabled ? 1 : 0
+
+  source = "./modules/odt-backoffice-sb"
+
+  environment                                     = var.environment
+  resource_group_name                             = azurerm_resource_group.odt_backoffice_sb[0].name
+  location                                        = module.azure_region.location_cli
+  service_name                                    = local.service_name
+  odt_backoffice_sb_topic_subscriptions           = var.odt_appeals_back_office_sb_topic_subscriptions
+  odt_back_office_service_bus_name                = var.odt_appeals_back_office.service_bus_name
+  odt_back_office_service_bus_resource_group_name = var.odt_appeals_back_office.resource_group_name
+  odt_back_office_private_endpoint_dns_zone_id    = (var.environment != "dev" ? azurerm_private_dns_zone.back_office_private_dns_zone[0].id : null)
+  synapse_private_endpoint_subnet_name            = local.synapse_subnet_name
+  synapse_private_endpoint_vnet_subnets           = module.synapse_network.vnet_subnets
+
+  tags = local.tags
+
+  providers = {
+    azurerm     = azurerm,
+    azurerm.odt = azurerm.odt
+  }
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [x] No

 2. Have any new tables been created in Standardised?

  	- [x] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [x] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [x] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [x] No - No scripts have run 
	
 
