### PR TITLE
Pd/feat/add column 1208

### DIFF
--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ec34035f-67b1-4540-8973-c0104349ef3c"
+				"spark.autotune.trackingId": "0a59fcf1-c951-4fc1-ad71-68d9b1082985"
 			}
 		},
 		"metadata": {
@@ -83,6 +83,7 @@
 					"SELECT DISTINCT\r\n",
 					"\r\n",
 					"    ET.CaseReference                                            AS caseReference,\r\n",
+					"    ET.Published                                                AS published,\r\n",
 					"    CAST(ET.ID AS integer)                                      AS eventId,\r\n",
 					"    CASE    \r\n",
 					"        WHEN ET.TypeOfExamination  =  'Site Visit (Unaccompanied)'\r\n",
@@ -102,7 +103,7 @@
 					"ORDER BY caseReference,eventTitle DESC\r\n",
 					""
 				],
-				"execution_count": 8
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -150,7 +151,7 @@
 					"    description    \r\n",
 					"FROM odw_curated_db.vw_examination_timetable"
 				],
-				"execution_count": 9
+				"execution_count": 5
 			}
 		]
 	}

--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0a59fcf1-c951-4fc1-ad71-68d9b1082985"
+				"spark.autotune.trackingId": "5b93b7af-e0e3-47c2-9adc-6824d7698ef0"
 			}
 		},
 		"metadata": {
@@ -103,7 +103,7 @@
 					"ORDER BY caseReference,eventTitle DESC\r\n",
 					""
 				],
-				"execution_count": 4
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -151,7 +151,7 @@
 					"    description    \r\n",
 					"FROM odw_curated_db.vw_examination_timetable"
 				],
-				"execution_count": 5
+				"execution_count": 9
 			}
 		]
 	}

--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5b93b7af-e0e3-47c2-9adc-6824d7698ef0"
+				"spark.autotune.trackingId": "d74d2d90-7eae-45b2-b6c3-6eb365bc857d"
 			}
 		},
 		"metadata": {
@@ -103,7 +103,7 @@
 					"ORDER BY caseReference,eventTitle DESC\r\n",
 					""
 				],
-				"execution_count": 8
+				"execution_count": 11
 			},
 			{
 				"cell_type": "markdown",
@@ -130,28 +130,15 @@
 							"deleting": false
 						}
 					},
-					"microsoft": {
-						"language": "sparksql"
-					},
 					"collapsed": false
 				},
 				"source": [
-					"%%sql\r\n",
-					"CREATE OR REPLACE TABLE odw_curated_db.examination_timetable\r\n",
-					"USING delta\r\n",
-					"AS\r\n",
-					"SELECT \r\n",
-					"    caseReference,\r\n",
-					"    eventId,\r\n",
-					"    type,\r\n",
-					"    eventTitle,\r\n",
-					"    eventDeadlineStartDate,\r\n",
-					"    date,\r\n",
-					"    eventLineItems,\r\n",
-					"    description    \r\n",
-					"FROM odw_curated_db.vw_examination_timetable"
+					"from pyspark.sql import SparkSession\r\n",
+					"spark = SparkSession.builder.getOrCreate()\r\n",
+					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_examination_timetable')\r\n",
+					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.examination_timetable')"
 				],
-				"execution_count": 9
+				"execution_count": 12
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
