### PR TITLE
Updating notebook: casework_nsip_examination_timetable_dim_legacy

### DIFF
--- a/workspace/notebook/casework_nsip_examination_timetable_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_examination_timetable_dim_legacy.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7811cb26-af38-4602-baa3-e6b010575ab9"
+				"spark.autotune.trackingId": "5dc9c2c2-2a51-4ee3-887c-01eb5e500a57"
 			}
 		},
 		"metadata": {
@@ -107,6 +107,7 @@
 					"    T1.location                     AS Location,\r\n",
 					"    null                            AS EventLineItems,\r\n",
 					"    \"0\"                             AS Migrated,\r\n",
+					"    NULL                            AS Published,\r\n",
 					"    \"Horizon\"                       AS ODTSourceSystem,\r\n",
 					"    T2.SourceSystemID               AS SourceSystemID,\r\n",
 					"    to_timestamp(T1.expected_from)  AS IngestionDate,\r\n",
@@ -151,7 +152,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_examination_timetable)\r\n",
 					";"
 				],
-				"execution_count": 5
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -207,6 +208,7 @@
 					"    Location,\r\n",
 					"    EventLineItems,\r\n",
 					"    Migrated,\r\n",
+					"    Published,\r\n",
 					"    ODTSourceSystem,\r\n",
 					"    SourceSystemID,\r\n",
 					"    IngestionDate,\r\n",
@@ -231,6 +233,7 @@
 					"    Location,\r\n",
 					"    EventLineItems,\r\n",
 					"    Migrated,\r\n",
+					"    Published,\r\n",
 					"    ODTSourceSystem,\r\n",
 					"    SourceSystemID,\r\n",
 					"    IngestionDate,\r\n",
@@ -241,7 +244,7 @@
 					"FROM odw_harmonised_db.casework_nsip_examination_timetable_dim\r\n",
 					"WHERE CaseReference IN (SELECT CaseReference FROM casework_nsip_examination_timetable_dim_new WHERE NSIPExaminationTimetableID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": 6
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -290,6 +293,7 @@
 					"    Location,\n",
 					"    EventLineItems,\n",
 					"    Migrated,\n",
+					"    Published,\n",
 					"    ODTSourceSystem,\n",
 					"    T1.SourceSystemID,\n",
 					"    T1.IngestionDate,\n",
@@ -300,7 +304,7 @@
 					"FROM casework_nsip_examination_timetable_dim_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 7
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -367,6 +371,7 @@
 					"        Location,\r\n",
 					"        EventLineItems,\r\n",
 					"        Migrated,\r\n",
+					"        Published,\r\n",
 					"        ODTSourceSystem,\r\n",
 					"        SourceSystemID,\r\n",
 					"        IngestionDate,\r\n",
@@ -385,6 +390,7 @@
 					"        Source.Location,\r\n",
 					"        Source.EventLineItems,\r\n",
 					"        Source.Migrated,\r\n",
+					"        Source.Published,\r\n",
 					"        Source.ODTSourceSystem,\r\n",
 					"        Source.SourceSystemID,\r\n",
 					"        Source.IngestionDate,\r\n",
@@ -446,6 +452,7 @@
 					"    Location,\r\n",
 					"    EventLineItems,\r\n",
 					"    Migrated,\r\n",
+					"    Published,\r\n",
 					"    ODTSourceSystem,\r\n",
 					"    SourceSystemID,\r\n",
 					"    IngestionDate,\r\n",

--- a/workspace/notebook/casework_nsip_examination_timetable_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_examination_timetable_dim_legacy.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5dc9c2c2-2a51-4ee3-887c-01eb5e500a57"
+				"spark.autotune.trackingId": "f6416c98-d8e9-43ae-9619-c6e0140a8ccc"
 			}
 		},
 		"metadata": {
@@ -107,7 +107,7 @@
 					"    T1.location                     AS Location,\r\n",
 					"    null                            AS EventLineItems,\r\n",
 					"    \"0\"                             AS Migrated,\r\n",
-					"    NULL                            AS Published,\r\n",
+					"    T3.Published                    AS Published,\r\n",
 					"    \"Horizon\"                       AS ODTSourceSystem,\r\n",
 					"    T2.SourceSystemID               AS SourceSystemID,\r\n",
 					"    to_timestamp(T1.expected_from)  AS IngestionDate,\r\n",
@@ -152,7 +152,7 @@
 					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_examination_timetable)\r\n",
 					";"
 				],
-				"execution_count": 4
+				"execution_count": 11
 			},
 			{
 				"cell_type": "markdown",
@@ -244,7 +244,7 @@
 					"FROM odw_harmonised_db.casework_nsip_examination_timetable_dim\r\n",
 					"WHERE CaseReference IN (SELECT CaseReference FROM casework_nsip_examination_timetable_dim_new WHERE NSIPExaminationTimetableID IS NULL) AND IsActive = 'Y'; "
 				],
-				"execution_count": 5
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -304,7 +304,7 @@
 					"FROM casework_nsip_examination_timetable_dim_changed_rows T1\n",
 					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
 				],
-				"execution_count": 6
+				"execution_count": 13
 			},
 			{
 				"cell_type": "markdown",
@@ -399,7 +399,7 @@
 					"        Source.IsActive)\r\n",
 					"     ;   "
 				],
-				"execution_count": 8
+				"execution_count": 14
 			},
 			{
 				"cell_type": "markdown",
@@ -463,7 +463,7 @@
 					"FROM odw_harmonised_db.casework_nsip_examination_timetable_dim;\r\n",
 					""
 				],
-				"execution_count": 9
+				"execution_count": 15
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
