### PR TITLE
fix(infrastructure): use a unique name for appeals back office private endpoint

### DIFF
--- a/infrastructure/modules/odt-backoffice-sb/odt-backofifce-private-endpoint.tf
+++ b/infrastructure/modules/odt-backoffice-sb/odt-backofifce-private-endpoint.tf
@@ -1,18 +1,18 @@
 resource "azurerm_private_endpoint" "odt_backoffice_servicebus_private_endpoint" {
   count = var.environment != "dev" ? 1 : 0
 
-  name                = "pins-pe-backoffice-sb-${local.resource_suffix}"
+  name                = "pins-pe-${var.back_office_name}-sb-${local.resource_suffix}"
   location            = var.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.synapse_private_endpoint_vnet_subnets[var.synapse_private_endpoint_subnet_name]
   private_service_connection {
-    name                           = "pins-psc-backoffice-sb-${local.resource_suffix}"
+    name                           = "pins-psc-${var.back_office_name}-sb-${local.resource_suffix}"
     is_manual_connection           = false
     private_connection_resource_id = data.azurerm_resources.odt_pe_backoffice_sb.resources[0].id
     subresource_names              = ["namespace"]
   }
   private_dns_zone_group {
-    name                 = "pins-pdns-backoffice-sb-${local.resource_suffix}"
+    name                 = "pins-pdns-${var.back_office_name}-sb-${local.resource_suffix}"
     private_dns_zone_ids = [var.odt_back_office_private_endpoint_dns_zone_id]
   }
 

--- a/infrastructure/modules/odt-backoffice-sb/variables.tf
+++ b/infrastructure/modules/odt-backoffice-sb/variables.tf
@@ -1,4 +1,10 @@
 
+variable "back_office_name" {
+  description = "The name of the back office service being connected to"
+  type        = string
+  default     = "backoffice"
+}
+
 variable "environment" {
   description = "The name of the environment in which resources will be deployed"
   type        = string

--- a/infrastructure/workload-odt-backoffice-sb.tf
+++ b/infrastructure/workload-odt-backoffice-sb.tf
@@ -100,6 +100,7 @@ module "odt_appeals_back_office_sb" {
 
   source = "./modules/odt-backoffice-sb"
 
+  back_office_name                                = "appeals-backoffice"
   environment                                     = var.environment
   resource_group_name                             = azurerm_resource_group.odt_backoffice_sb[0].name
   location                                        = module.azure_region.location_cli


### PR DESCRIPTION

**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
