### PR TITLE
Mvg/fix/s51 advice

### DIFF
--- a/workspace/notebook/nsip_data.json
+++ b/workspace/notebook/nsip_data.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4a3063e8-113f-4b76-970e-4a6946b87652"
+				"spark.autotune.trackingId": "c2ec0abd-4605-47bb-ae6d-66dfd33231ea"
 			}
 		},
 		"metadata": {
@@ -90,7 +90,7 @@
 					"\n",
 					"# spark.sql(f\"SET MAX_LIMIT = {max_limit}\")"
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "markdown",
@@ -471,7 +471,7 @@
 					"\n",
 					"-- LIMIT ${MAX_LIMIT}"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -587,7 +587,7 @@
 					"\n",
 					"WHERE caseId IS NOT NULL;"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -609,9 +609,10 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"SELECT distinct projectType FROM odw_curated_db.nsip_data order by 1;"
+					"-- SELECT distinct projectType FROM odw_curated_db.nsip_data order by 1;\n",
+					"SELECT distinct caseReference FROM odw_curated_db.nsip_data ORDER BY caseReference;"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -643,7 +644,7 @@
 					"# %%pyspark\n",
 					"# pip install Faker"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -696,7 +697,7 @@
 					"#         table_loc = \"abfss://odw-curated@\"+storage_account+'nsip_data'\n",
 					"#         df.write.format(\"delta\").mode(\"overwrite\").save(table_loc)  "
 				],
-				"execution_count": null
+				"execution_count": 6
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a0bbd369-9258-4b52-b183-012edc247623"
+				"spark.autotune.trackingId": "44062576-62fd-41ea-87e0-f0152b49860e"
 			}
 		},
 		"metadata": {
@@ -94,7 +94,11 @@
 					"\n",
 					"    CAST(AD.AdviceNodeID as INT)\t\t\t\t\t\t    AS adviceId,\n",
 					"    AD.AdviceReference\t\t\t\t\t\t\t\t\t    AS adviceReference,\n",
-					"    CAST(\"-1\" as INT)                                       AS caseId,\n",
+					"    CASE\n",
+					"        WHEN AD.CaseNodeID = 'None'\n",
+					"        THEN CAST(\"-1\" as INT)\n",
+					"        ELSE AD.CaseNodeID\n",
+					"    END                                                     AS caseId,\n",
 					"    AD.CaseReference\t\t\t\t\t\t\t\t\t    AS caseReference,\n",
 					"    AD.AdviceTitle\t\t\t\t\t\t\t\t\t        AS title,\n",
 					"    AD.Enquirer                                             AS from,\n",
@@ -130,7 +134,7 @@
 					"FROM odw_harmonised_db.casework_nsip_advice_dim \t        AS AD\n",
 					"WHERE AD.IsActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -187,7 +191,32 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
-				"execution_count": 2
+				"execution_count": 6
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_harmonised_db.casework_nsip_advice_dim;\n",
+					"SELECT * FROM odw_curated_db.nsip_s51_advice;"
+				],
+				"execution_count": 7
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "44062576-62fd-41ea-87e0-f0152b49860e"
+				"spark.autotune.trackingId": "9ee5535f-e4ac-435a-80e2-6a0ba7c205cf"
 			}
 		},
 		"metadata": {
@@ -213,10 +213,11 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"SELECT * FROM odw_harmonised_db.casework_nsip_advice_dim;\n",
-					"SELECT * FROM odw_curated_db.nsip_s51_advice;"
+					"SELECT * FROM odw_harmonised_db.casework_nsip_advice_dim WHERE caseReference = 'EN010049' AND AdviceReference = 'EN010049-Advice-00005';\n",
+					"-- SELECT * FROM odw_curated_db.nsip_s51_advice;\n",
+					"SELECT * FROM odw_curated_db.nsip_s51_advice WHERE caseReference = 'EN010049' ORDER BY adviceReference;"
 				],
-				"execution_count": 7
+				"execution_count": 6
 			}
 		]
 	}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "9ee5535f-e4ac-435a-80e2-6a0ba7c205cf"
+				"spark.autotune.trackingId": "aa093164-74d9-41cb-b874-e0a096c40ef8"
 			}
 		},
 		"metadata": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
