### PR TITLE
added both entities to conifg file and to function app file

### DIFF
--- a/functions/config.yaml
+++ b/functions/config.yaml
@@ -65,3 +65,11 @@ global:
     appeal-document:
       topic: "appeal-document"
       subscription: "appeal-document-odw-sub"
+
+    appeal:
+      topic: "appeal"
+      subscription: "appeal-odw-sub"
+    
+    appeal-event:
+      topic: "appeal-event"
+      subscription: "appeal-event-odw-sub"

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -530,3 +530,101 @@ def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
             if f"{_VALIDATION_ERROR}" in str(e)
             else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
         )
+
+@_app.function_name("appeal")
+@_app.route(route="appeal", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
+def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
+    """
+    Azure Function endpoint for handling HTTP requests.
+
+    Args:
+        req: An instance of `func.HttpRequest` representing the HTTP request.
+
+    Returns:
+        An instance of `func.HttpResponse` representing the HTTP response.
+    """
+
+    _SCHEMA = _SCHEMAS["appeal.schema.json"]
+    _TOPIC = config["global"]["entities"]["appeal"]["topic"]
+    _SUBSCRIPTION = config["global"]["entities"]["appeal-odw-sub"]["subscription"]
+
+    try:
+        _data = get_messages_and_validate(
+            namespace=_NAMESPACE_APPEALS,
+            credential=_CREDENTIAL,
+            topic=_TOPIC,
+            subscription=_SUBSCRIPTION,
+            max_message_count=_MAX_MESSAGE_COUNT,
+            max_wait_time=_MAX_WAIT_TIME,
+            schema=_SCHEMA,
+        )
+        _message_count = send_to_storage(
+            account_url=_STORAGE,
+            credential=_CREDENTIAL,
+            container=_CONTAINER,
+            entity=_TOPIC,
+            data=_data,
+        )
+        
+        response = json.dumps({"message" : f"{_SUCCESS_RESPONSE} - {_message_count} messages sent to storage", "count": _message_count})
+
+        return func.HttpResponse(
+            response,
+            status_code=200
+        )
+
+    except Exception as e:
+        return (
+            func.HttpResponse(f"Validation error: {str(e)}", status_code=500)
+            if f"{_VALIDATION_ERROR}" in str(e)
+            else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
+        )
+
+@_app.function_name("appealevent")
+@_app.route(route="appealevent", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
+def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
+    """
+    Azure Function endpoint for handling HTTP requests.
+
+    Args:
+        req: An instance of `func.HttpRequest` representing the HTTP request.
+
+    Returns:
+        An instance of `func.HttpResponse` representing the HTTP response.
+    """
+
+    _SCHEMA = _SCHEMAS["appeal-event.schema.json"]
+    _TOPIC = config["global"]["entities"]["appeal-document"]["topic"]
+    _SUBSCRIPTION = config["global"]["entities"]["appeal-event-odw-sub"]["subscription"]
+
+    try:
+        _data = get_messages_and_validate(
+            namespace=_NAMESPACE_APPEALS,
+            credential=_CREDENTIAL,
+            topic=_TOPIC,
+            subscription=_SUBSCRIPTION,
+            max_message_count=_MAX_MESSAGE_COUNT,
+            max_wait_time=_MAX_WAIT_TIME,
+            schema=_SCHEMA,
+        )
+        _message_count = send_to_storage(
+            account_url=_STORAGE,
+            credential=_CREDENTIAL,
+            container=_CONTAINER,
+            entity=_TOPIC,
+            data=_data,
+        )
+        
+        response = json.dumps({"message" : f"{_SUCCESS_RESPONSE} - {_message_count} messages sent to storage", "count": _message_count})
+
+        return func.HttpResponse(
+            response,
+            status_code=200
+        )
+
+    except Exception as e:
+        return (
+            func.HttpResponse(f"Validation error: {str(e)}", status_code=500)
+            if f"{_VALIDATION_ERROR}" in str(e)
+            else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
+        )

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -484,7 +484,7 @@ def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
 
 @_app.function_name("appealdocument")
 @_app.route(route="appealdocument", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
-def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
+def appealdocument(req: func.HttpRequest) -> func.HttpResponse:
     """
     Azure Function endpoint for handling HTTP requests.
 
@@ -533,7 +533,7 @@ def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
 
 @_app.function_name("appeal")
 @_app.route(route="appeal", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
-def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
+def appeal(req: func.HttpRequest) -> func.HttpResponse:
     """
     Azure Function endpoint for handling HTTP requests.
 
@@ -546,7 +546,7 @@ def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
 
     _SCHEMA = _SCHEMAS["appeal.schema.json"]
     _TOPIC = config["global"]["entities"]["appeal"]["topic"]
-    _SUBSCRIPTION = config["global"]["entities"]["appeal-odw-sub"]["subscription"]
+    _SUBSCRIPTION = config["global"]["entities"]["appeal"]["subscription"]
 
     try:
         _data = get_messages_and_validate(
@@ -582,7 +582,7 @@ def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
 
 @_app.function_name("appealevent")
 @_app.route(route="appealevent", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
-def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
+def appealevent(req: func.HttpRequest) -> func.HttpResponse:
     """
     Azure Function endpoint for handling HTTP requests.
 
@@ -594,8 +594,8 @@ def serviceuser(req: func.HttpRequest) -> func.HttpResponse:
     """
 
     _SCHEMA = _SCHEMAS["appeal-event.schema.json"]
-    _TOPIC = config["global"]["entities"]["appeal-document"]["topic"]
-    _SUBSCRIPTION = config["global"]["entities"]["appeal-event-odw-sub"]["subscription"]
+    _TOPIC = config["global"]["entities"]["appeal-event"]["topic"]
+    _SUBSCRIPTION = config["global"]["entities"]["appeal-event"]["subscription"]
 
     try:
         _data = get_messages_and_validate(


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
