### PR TITLE
Updating notebook: py_odw_harmonised_table_creation

### DIFF
--- a/workspace/notebook/horizon_appeals_folder.json
+++ b/workspace/notebook/horizon_appeals_folder.json
@@ -1,0 +1,453 @@
+{
+	"name": "horizon_appeals_folder",
+	"properties": {
+		"folder": {
+			"name": "odw-harmonised/DocumentTree"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"runAsWorkspaceSystemIdentity": false,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "5f25f071-f285-4aa7-80ed-f8628e54e82d"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Check for new, updated or deleted data\n",
+					"- This script checks for new, updated or deleted data by checking the source data (horizon tables) against the target (odw_harmonised_db.casework tables)\n",
+					"- **New Data:** where an main Reference in the source does not exist in the target, then NewData flag is set to 'Y'\n",
+					"- **Updated data:** Comparison occurs on Reference Fields in source and in target where the row hash is different i.e. there is a change in one of the columns. NewData flag is set to 'Y'\n",
+					"- **Deleted data:** where an Reference info in the target exists but the same identifyers don't exist in the source. DeletedData flag is set to 'Y'\n",
+					"\n",
+					"## View horizon_appeals_folder is created"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Build horizon_appeals_folder table\r\n",
+					"-- Gets modified or deleted from source rows\r\n",
+					"\r\n",
+					"CREATE OR REPLACE TEMPORARY VIEW horizon_appeals_folder_new\r\n",
+					"\r\n",
+					"     AS\r\n",
+					"\r\n",
+					"-- gets data that matches of SourceID and flags that it is modified based on a row (md5) hash. Flags as \"NewData\"\r\n",
+					"-- gets data that is in the target but not in source. Flags as \"DeletedData\"\r\n",
+					"\r\n",
+					"SELECT DISTINCT\r\n",
+					"    CASE\r\n",
+					"        WHEN T1.id IS NULL\r\n",
+					"        THEN T3.HorizonAppealFolderId\r\n",
+					"        ELSE NULL\r\n",
+					"    END                             AS HorizonAppealFolderId,\r\n",
+					"    T1.id                           AS ID,\r\n",
+					"    T1.casereference\t            AS CaseReference,\r\n",
+					"    T1.displaynameenglish\t        AS DisplayNameEnglish,\r\n",
+					"    T1.displaynamewelsh\t            AS DisplayNameWelsh,\r\n",
+					"    T1.parentfolderid\t            AS ParentFolderID,\r\n",
+					"    T1.casenodeid\t                AS CaseNodeId,\r\n",
+					"    T1.casestage\t                AS CaseStage,\r\n",
+					"    T2.SourceSystemID               AS SourceSystemID,\r\n",
+					"    to_timestamp(T1.expected_from)  AS IngestionDate,\r\n",
+					"    NULL                            AS ValidTo,\r\n",
+					"    md5(\r\n",
+					"        concat(\r\n",
+					"            IFNULL(T1.id,'.'),\r\n",
+					"            IFNULL(T1.casereference,'.'),\r\n",
+					"            IFNULL(T1.displaynameenglish,'.'),\r\n",
+					"            IFNULL(T1.displaynamewelsh,'.'),\r\n",
+					"            IFNULL(T1.parentfolderid,'.'),\r\n",
+					"            IFNULL(T1.casenodeid,'.'),\r\n",
+					"            IFNULL(T1.casestage,'.')\r\n",
+					"        ))                          AS RowID, -- this hash should contain all the defining fields\r\n",
+					"    'Y'                             AS IsActive,\r\n",
+					"    T3.IsActive                     AS HistoricIsActive\r\n",
+					"\r\n",
+					"FROM odw_standardised_db.horizon_appeals_folder T1\r\n",
+					"LEFT JOIN odw_harmonised_db.main_sourcesystem_fact T2 \r\n",
+					"    ON \"DocumentTree\" = T2.Description AND \r\n",
+					"        T2.IsActive = 'Y'\r\n",
+					"FULL JOIN odw_harmonised_db.horizon_appeals_folder T3 \r\n",
+					"    ON T1.id = T3.ID AND \r\n",
+					"        T3.IsActive = 'Y'\r\n",
+					"WHERE\r\n",
+					"    -- flags new data        \r\n",
+					"    (CASE\r\n",
+					"        WHEN T1.casereference = T3.CaseReference AND md5(\r\n",
+					"            concat(\r\n",
+					"                IFNULL(T1.id,'.'),\r\n",
+					"                IFNULL(T1.casereference,'.'),\r\n",
+					"                IFNULL(T1.displaynameenglish,'.'),\r\n",
+					"                IFNULL(T1.displaynamewelsh,'.'),\r\n",
+					"                IFNULL(T1.parentfolderid,'.'),\r\n",
+					"                IFNULL(T1.casenodeid,'.'),\r\n",
+					"                IFNULL(T1.casestage,'.')\r\n",
+					"            )) <> T3.RowID  -- same record, changed data\r\n",
+					"        THEN 'Y'\r\n",
+					"        WHEN T3.ID IS NULL -- new record\r\n",
+					"        THEN 'Y'\r\n",
+					"    ELSE 'N'\r\n",
+					"    END  = 'Y' )\r\n",
+					"    AND T1.id IS NOT NULL\r\n",
+					"    AND NOT(T1.id = '29309932' AND T1.casestage = 'Initial Documents') --- Hardcoded exception as per Gareth request for data consistency\r\n",
+					"    AND T1.expected_from = (SELECT MAX(expected_from) FROM odw_standardised_db.horizon_appeals_folder)\r\n",
+					";"
+				],
+				"execution_count": 14
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Dataset is created that contains changed data and corresponding target data\n",
+					"- This script combines data that has been updated, Deleted or is new, with corresponding target data\n",
+					"- View **casework_all_appeals_new** is unioned to the target data filter to only those rows where changes have been detected\n",
+					"## View horizon_appeals_folder_changed_rows is created"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Create new and updated dataset\r\n",
+					"\r\n",
+					"CREATE OR REPLACE TEMPORARY VIEW horizon_appeals_folder_changed_rows\r\n",
+					"\r\n",
+					"    AS\r\n",
+					"\r\n",
+					"-- gets updated, deleted and new rows \r\n",
+					"SELECT \r\n",
+					"    HorizonAppealFolderId,\r\n",
+					"    ID,\r\n",
+					"    CaseReference,\r\n",
+					"    DisplayNameEnglish,\r\n",
+					"    DisplayNameWelsh,\r\n",
+					"    ParentFolderID,\r\n",
+					"    CaseNodeId,\r\n",
+					"    CaseStage,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"    \r\n",
+					"\r\n",
+					"From horizon_appeals_folder_new WHERE HistoricIsActive = 'Y' or HistoricIsActive IS NULL\r\n",
+					"\r\n",
+					"    UNION ALL\r\n",
+					"\r\n",
+					"-- gets original versions of updated rows so we can update EndDate and set IsActive flag to 'N'\r\n",
+					"SELECT\r\n",
+					"    \r\n",
+					"    HorizonAppealFolderId,\r\n",
+					"    ID,\r\n",
+					"    CaseReference,\r\n",
+					"    DisplayNameEnglish,\r\n",
+					"    DisplayNameWelsh,\r\n",
+					"    ParentFolderID,\r\n",
+					"    CaseNodeId,\r\n",
+					"    CaseStage,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"    \r\n",
+					"FROM odw_harmonised_db.horizon_appeals_folder\r\n",
+					"WHERE ID IN (SELECT ID FROM horizon_appeals_folder_new WHERE HorizonAppealFolderId IS NULL) AND IsActive = 'Y'; "
+				],
+				"execution_count": 15
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"CREATE OR REPLACE TEMPORARY VIEW Loading_month\n",
+					"\n",
+					"    AS\n",
+					"\n",
+					"SELECT DISTINCT\n",
+					"    IngestionDate AS IngestionDate,\n",
+					"    to_timestamp(date_sub(IngestionDate,1)) AS ClosingDate,\n",
+					"    'Y' AS IsActive\n",
+					"\n",
+					"FROM horizon_appeals_folder_new;\n",
+					"\n",
+					"CREATE OR REPLACE TEMPORARY VIEW horizon_appeals_folder_changed_rows_final\n",
+					"\n",
+					"    AS\n",
+					"\n",
+					"SELECT \n",
+					"    HorizonAppealFolderId,\n",
+					"    ID,\n",
+					"    CaseReference,\n",
+					"    DisplayNameEnglish,\n",
+					"    DisplayNameWelsh,\n",
+					"    ParentFolderID,\n",
+					"    CaseNodeId,\n",
+					"    CaseStage,\n",
+					"    T1.SourceSystemID,\n",
+					"    T1.IngestionDate,\n",
+					"    T1.ValidTo,\n",
+					"    T1.RowID,\n",
+					"    T1.IsActive,\n",
+					"    T2.ClosingDate\n",
+					"FROM horizon_appeals_folder_changed_rows T1\n",
+					"FULL JOIN Loading_month T2 ON T1.IsActive = T2.IsActive"
+				],
+				"execution_count": 16
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					""
+				]
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# View horizon_appeals_folder_changed_rows is used in a merge (Upsert) statement into the target table\n",
+					"- **WHEN MATCHED** ON the surrogate Key (i.e. AllAppealsID), EndDate is set to today -1 day and the IsActive flag is set to 'N'\n",
+					"- **WHEN NOT MATCHED** ON the surrogate Key, insert rows\n",
+					"## Table odw_harmonised_db.horizon_appeals_folder is updated"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- merge into dim table\r\n",
+					"\r\n",
+					"MERGE INTO odw_harmonised_db.horizon_appeals_folder AS Target\r\n",
+					"USING horizon_appeals_folder_changed_rows_final AS Source\r\n",
+					"\r\n",
+					"ON Source.HorizonAppealFolderId = Target.HorizonAppealFolderId AND Target.IsActive = 'Y'\r\n",
+					"\r\n",
+					"-- For Updates existing rows\r\n",
+					"\r\n",
+					"WHEN MATCHED\r\n",
+					"    THEN \r\n",
+					"    UPDATE SET\r\n",
+					"    Target.ValidTo = to_timestamp(ClosingDate),\r\n",
+					"    Target.IsActive = 'N'\r\n",
+					"\r\n",
+					"-- Insert completely new rows\r\n",
+					"\r\n",
+					"WHEN NOT MATCHED \r\n",
+					"    THEN INSERT (\r\n",
+					"        HorizonAppealFolderId,\r\n",
+					"        ID,\r\n",
+					"        CaseReference,\r\n",
+					"        DisplayNameEnglish,\r\n",
+					"        DisplayNameWelsh,\r\n",
+					"        ParentFolderID,\r\n",
+					"        CaseNodeId,\r\n",
+					"        CaseStage,\r\n",
+					"        SourceSystemID,\r\n",
+					"        IngestionDate,\r\n",
+					"        ValidTo,\r\n",
+					"        RowID,\r\n",
+					"        IsActive    \r\n",
+					"        )\r\n",
+					"    VALUES (\r\n",
+					"        Source.HorizonAppealFolderId,\r\n",
+					"        Source.ID,\r\n",
+					"        Source.CaseReference,\r\n",
+					"        Source.DisplayNameEnglish,\r\n",
+					"        Source.DisplayNameWelsh,\r\n",
+					"        Source.ParentFolderID,\r\n",
+					"        Source.CaseNodeId,\r\n",
+					"        Source.CaseStage,\r\n",
+					"        Source.SourceSystemID,\r\n",
+					"        Source.IngestionDate,\r\n",
+					"        Source.ValidTo,\r\n",
+					"        Source.RowID,\r\n",
+					"        Source.IsActive)\r\n",
+					"     ;   "
+				],
+				"execution_count": 17
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Fix the IDs\n",
+					"- No auto-increment feature is available in delta tables, therefore we need to create new IDs for the inserted rows\n",
+					"- This is done by select the target data and using INSERT OVERWRITE to re-insert the data is a new Row Number\n",
+					"## Table odw_harmonised_db.horizon_appeals_folder is updated"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\r\n",
+					"-- Insert new horizon_appeals_folder\r\n",
+					"\r\n",
+					"INSERT OVERWRITE odw_harmonised_db.horizon_appeals_folder\r\n",
+					"\r\n",
+					"SELECT \r\n",
+					"    ROW_NUMBER() OVER (ORDER BY CaseReference NULLS LAST) AS  HorizonAppealFolderId\t,\r\n",
+					"    ID,\r\n",
+					"    CaseReference,\r\n",
+					"    DisplayNameEnglish,\r\n",
+					"    DisplayNameWelsh,\r\n",
+					"    ParentFolderID,\r\n",
+					"    CaseNodeId,\r\n",
+					"    CaseStage,\r\n",
+					"    SourceSystemID,\r\n",
+					"    IngestionDate,\r\n",
+					"    ValidTo,\r\n",
+					"    RowID,\r\n",
+					"    IsActive\r\n",
+					"FROM odw_harmonised_db.horizon_appeals_folder;\r\n",
+					""
+				],
+				"execution_count": 18
+			}
+		]
+	}
+}

--- a/workspace/notebook/py_odw_harmonised_table_creation.json
+++ b/workspace/notebook/py_odw_harmonised_table_creation.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "9acc4ed9-85eb-4b36-bf26-895ddf401eac"
+				"spark.autotune.trackingId": "3dff3c41-05f7-45f3-bbf2-e7b262337f6b"
 			}
 		},
 		"metadata": {
@@ -88,7 +88,7 @@
 					]
 				},
 				"source": [
-					"specific_table = \"horizon_appeals_folder\""
+					"specific_table = \"\""
 				],
 				"execution_count": 9
 			},

--- a/workspace/notebook/py_odw_harmonised_table_creation.json
+++ b/workspace/notebook/py_odw_harmonised_table_creation.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "20e1e6c2-cf7e-4be4-8008-302b472ec323"
+				"spark.autotune.trackingId": "9acc4ed9-85eb-4b36-bf26-895ddf401eac"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 				"source": [
 					"%run  /0-odw-source-to-raw/Fileshare/SAP_HR/py_0_source_to_raw_hr_functions"
 				],
-				"execution_count": 39
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -88,9 +88,9 @@
 					]
 				},
 				"source": [
-					"specific_table = \"\""
+					"specific_table = \"horizon_appeals_folder\""
 				],
-				"execution_count": 40
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -164,7 +164,7 @@
 					"automation_table_creation()\r\n",
 					"   "
 				],
-				"execution_count": 41
+				"execution_count": 10
 			}
 		]
 	}

--- a/workspace/pipeline/pln_horizon_appeals_folder.json
+++ b/workspace/pipeline/pln_horizon_appeals_folder.json
@@ -61,6 +61,33 @@
 					},
 					"numExecutors": null
 				}
+			},
+			{
+				"name": "Std to Harmonized",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Raw to Std",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "horizon_appeals_folder",
+						"type": "NotebookReference"
+					},
+					"snapshot": true
+				}
 			}
 		],
 		"folder": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
