### PR TITLE
changes over the naming of the subscription and topic of the appeal t…

### DIFF
--- a/functions/config.yaml
+++ b/functions/config.yaml
@@ -66,9 +66,9 @@ global:
       topic: "appeal-document"
       subscription: "appeal-document-odw-sub"
 
-    appeal:
-      topic: "appeal"
-      subscription: "appeal-odw-sub"
+    appeal-has:
+      topic: "appeal-has"
+      subscription: "bo-appeals-case-subscription"
     
     appeal-event:
       topic: "appeal-event"

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -531,8 +531,8 @@ def appealdocument(req: func.HttpRequest) -> func.HttpResponse:
             else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
         )
 
-@_app.function_name("appeal")
-@_app.route(route="appeal", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
+@_app.function_name("appealhas")
+@_app.route(route="appealhas", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
 def appeal(req: func.HttpRequest) -> func.HttpResponse:
     """
     Azure Function endpoint for handling HTTP requests.
@@ -544,9 +544,9 @@ def appeal(req: func.HttpRequest) -> func.HttpResponse:
         An instance of `func.HttpResponse` representing the HTTP response.
     """
 
-    _SCHEMA = _SCHEMAS["appeal.schema.json"]
-    _TOPIC = config["global"]["entities"]["appeal"]["topic"]
-    _SUBSCRIPTION = config["global"]["entities"]["appeal"]["subscription"]
+    _SCHEMA = _SCHEMAS["appeal-has.schema.json"]
+    _TOPIC = config["global"]["entities"]["appeal-has"]["topic"]
+    _SUBSCRIPTION = config["global"]["entities"]["appeal-has"]["subscription"]
 
     try:
         _data = get_messages_and_validate(


### PR DESCRIPTION
…o appeal has

**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
