### PR TITLE
Mvg/fic/applications document

### DIFF
--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6b26e9dc-9c73-432a-95c5-d6c0e8517a1c"
+				"spark.autotune.trackingId": "fc713ed0-83b6-4d7e-b7e2-04fbd08f263b"
 			}
 		},
 		"metadata": {
@@ -129,7 +129,9 @@
 					"\n",
 					"FROM odw_harmonised_db.document_meta_data   AS MD\n",
 					"FULL JOIN odw_harmonised_db.aie_document_data    AS AMD\n",
-					"    ON MD.DataID = AMD.DocumentID AND left(AMD.Path,8) = MD.caseReference\n",
+					"    ON MD.DataID = AMD.DocumentID \n",
+					"        AND AMD.Version = MD.Version\n",
+					"        AND AMD.Size = MD.DataSize\n",
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'\n",
 					";\n",
@@ -139,7 +141,7 @@
 					"SELECT * FROM odw_curated_db.vw_document_metadata WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
 					""
 				],
-				"execution_count": 33
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -157,7 +159,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")"
 				],
-				"execution_count": 29
+				"execution_count": 16
 			},
 			{
 				"cell_type": "markdown",
@@ -194,7 +196,7 @@
 					"view_df2.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.document_meta_data\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": 30
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -236,7 +238,8 @@
 					"-- -- Returns 1057 in dev (off by one)\n",
 					"\n",
 					"-- -- Test #3: Check doc metadata in Curated -\n",
-					"-- SELECT COUNT(*) FROM odw_curated_db.dbo.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
+					"SELECT COUNT(*) FROM odw_curated_db.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
+					"SELECT * FROM odw_curated_db.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
 					"\n",
 					"-- Returns 1222 in test\n",
 					"\n",
@@ -245,11 +248,13 @@
 					"-- Should be 1058, so there is some duplication occurring.\n",
 					"\n",
 					"\n",
-					"SELECT * FROM odw_curated_db.document_meta_data WHERE documentId = '15259212' AND sourceSystem = 'horizon';\n",
-					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15259212';\n",
-					"SELECT * FROM odw_harmonised_db.document_meta_data WHERE DataID = '15259212';"
+					"SELECT * FROM odw_curated_db.document_meta_data WHERE documentId = '15259223' AND sourceSystem = 'horizon';\n",
+					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15259223';\n",
+					"SELECT * FROM odw_harmonised_db.document_meta_data WHERE DataID = '15259223';\n",
+					"\n",
+					""
 				],
-				"execution_count": 2
+				"execution_count": 19
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fc713ed0-83b6-4d7e-b7e2-04fbd08f263b"
+				"spark.autotune.trackingId": "e3befcad-ae8e-4808-ad48-4a95225c58a6"
 			}
 		},
 		"metadata": {
@@ -130,15 +130,12 @@
 					"FROM odw_harmonised_db.document_meta_data   AS MD\n",
 					"FULL JOIN odw_harmonised_db.aie_document_data    AS AMD\n",
 					"    ON MD.DataID = AMD.DocumentID \n",
-					"        AND AMD.Version = MD.Version\n",
+					"        AND AMD.Version = MD.Version \n",
 					"        AND AMD.Size = MD.DataSize\n",
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'\n",
 					";\n",
 					"\n",
-					"SELECT count(*) FROM odw_curated_db.vw_document_metadata WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.vw_document_metadata WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
 					""
 				],
 				"execution_count": 15

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a4038a4a-96c7-45cd-861e-aaa1f5642c38"
+				"spark.autotune.trackingId": "6bd721b2-954c-4fb2-97f6-1f39d5d36e92"
 			}
 		},
 		"metadata": {
@@ -128,12 +128,18 @@
 					"NULL\t                                AS transcriptId\t\n",
 					"\n",
 					"FROM odw_harmonised_db.document_meta_data   AS MD\n",
-					"JOIN odw_harmonised_db.aie_document_data    AS AMD\n",
-					"    ON MD.DataID = AMD.DocumentID\n",
+					"FULL JOIN odw_harmonised_db.aie_document_data    AS AMD\n",
+					"    ON MD.DataID = AMD.DocumentID AND left(AMD.Path,8) = MD.caseReference\n",
 					"WHERE AMD.IsActive = 'Y' \n",
-					"    AND MD.IsActive = 'Y'"
+					"    AND MD.IsActive = 'Y'\n",
+					";\n",
+					"\n",
+					"SELECT count(*) FROM odw_curated_db.vw_document_metadata WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
+					"\n",
+					"SELECT * FROM odw_curated_db.vw_document_metadata WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
+					""
 				],
-				"execution_count": 1
+				"execution_count": 33
 			},
 			{
 				"cell_type": "code",
@@ -151,7 +157,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")"
 				],
-				"execution_count": 2
+				"execution_count": 29
 			},
 			{
 				"cell_type": "markdown",
@@ -188,7 +194,7 @@
 					"view_df2.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.document_meta_data\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": 3
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -209,27 +215,27 @@
 				},
 				"source": [
 					"%%sql \n",
-					"-- Test #1: Check aie_document_data - \n",
+					"-- -- Test #1: Check aie_document_data - \n",
 					"\n",
-					"SELECT COUNT(*) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
-					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
-					"SELECT DISTINCT DocumentID FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
-					"SELECT COUNT(DISTINCT (DocumentID)) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
+					"-- SELECT COUNT(*) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
+					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%' AND DocumentID = '33820255';\n",
+					"-- SELECT DISTINCT DocumentID FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
+					"-- SELECT COUNT(DISTINCT (DocumentID)) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
 					"\n",
-					"-- Returns 1058 in both dev & test, as expected.\n",
+					"-- -- Returns 1058 in both dev & test, as expected.\n",
 					"\n",
-					"-- Test #2: Check doc metadata in Harmonized - \n",
+					"-- -- Test #2: Check doc metadata in Harmonized - \n",
 					"\n",
-					"SELECT COUNT(*) FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
+					"-- SELECT COUNT(*) FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
 					"\n",
-					"SELECT DISTINCT DataID FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
-					"SELECT COUNT(DISTINCT (DataID))  FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
+					"-- SELECT DISTINCT DataID FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
+					"-- SELECT COUNT(DISTINCT (DataID))  FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
 					"\n",
-					"-- Returns 4196 in test (big discrepancy)\n",
+					"-- -- Returns 4196 in test (big discrepancy)\n",
 					"\n",
-					"-- Returns 1057 in dev (off by one)\n",
+					"-- -- Returns 1057 in dev (off by one)\n",
 					"\n",
-					"-- Test #3: Check doc metadata in Curated -\n",
+					"-- -- Test #3: Check doc metadata in Curated -\n",
 					"\n",
 					"SELECT COUNT(*) FROM odw_curated_db.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
 					"\n",
@@ -239,7 +245,7 @@
 					"\n",
 					"-- Should be 1058, so there is some duplication occurring."
 				],
-				"execution_count": 15
+				"execution_count": 31
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1b4ba333-5565-486e-9ae1-1d2777c69233"
+				"spark.autotune.trackingId": "a4038a4a-96c7-45cd-861e-aaa1f5642c38"
 			}
 		},
 		"metadata": {
@@ -133,7 +133,7 @@
 					"WHERE AMD.IsActive = 'Y' \n",
 					"    AND MD.IsActive = 'Y'"
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -151,7 +151,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -188,7 +188,58 @@
 					"view_df2.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.document_meta_data\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": null
+				"execution_count": 3
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql \n",
+					"-- Test #1: Check aie_document_data - \n",
+					"\n",
+					"SELECT COUNT(*) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
+					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
+					"SELECT DISTINCT DocumentID FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
+					"SELECT COUNT(DISTINCT (DocumentID)) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
+					"\n",
+					"-- Returns 1058 in both dev & test, as expected.\n",
+					"\n",
+					"-- Test #2: Check doc metadata in Harmonized - \n",
+					"\n",
+					"SELECT COUNT(*) FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
+					"\n",
+					"SELECT DISTINCT DataID FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
+					"SELECT COUNT(DISTINCT (DataID))  FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
+					"\n",
+					"-- Returns 4196 in test (big discrepancy)\n",
+					"\n",
+					"-- Returns 1057 in dev (off by one)\n",
+					"\n",
+					"-- Test #3: Check doc metadata in Curated -\n",
+					"\n",
+					"SELECT COUNT(*) FROM odw_curated_db.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
+					"\n",
+					"-- Returns 1222 in test\n",
+					"\n",
+					"-- returns 1221 in dev\n",
+					"\n",
+					"-- Should be 1058, so there is some duplication occurring."
+				],
+				"execution_count": 15
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e3befcad-ae8e-4808-ad48-4a95225c58a6"
+				"spark.autotune.trackingId": "b225b92d-69ac-44c9-b871-cbea80b64227"
 			}
 		},
 		"metadata": {
@@ -138,7 +138,7 @@
 					"\n",
 					""
 				],
-				"execution_count": 15
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -156,7 +156,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.document_meta_data;\")"
 				],
-				"execution_count": 16
+				"execution_count": 27
 			},
 			{
 				"cell_type": "markdown",
@@ -193,65 +193,7 @@
 					"view_df2.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.document_meta_data\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": 17
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql \n",
-					"-- -- Test #1: Check aie_document_data - \n",
-					"\n",
-					"-- SELECT COUNT(*) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
-					"-- SELECT * FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%' AND DocumentID = '33820255';\n",
-					"-- SELECT DISTINCT DocumentID FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
-					"-- SELECT COUNT(DISTINCT (DocumentID)) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
-					"\n",
-					"-- -- Returns 1058 in both dev & test, as expected.\n",
-					"\n",
-					"-- -- Test #2: Check doc metadata in Harmonized - \n",
-					"\n",
-					"-- SELECT COUNT(*) FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
-					"\n",
-					"-- SELECT DISTINCT DataID FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
-					"-- SELECT COUNT(DISTINCT (DataID))  FROM odw_harmonised_db.document_meta_data WHERE CaseReference = 'TR010010' AND SourceSystem = 'horizon';\n",
-					"\n",
-					"-- -- Returns 4196 in test (big discrepancy)\n",
-					"\n",
-					"-- -- Returns 1057 in dev (off by one)\n",
-					"\n",
-					"-- -- Test #3: Check doc metadata in Curated -\n",
-					"SELECT COUNT(*) FROM odw_curated_db.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
-					"SELECT * FROM odw_curated_db.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
-					"\n",
-					"-- Returns 1222 in test\n",
-					"\n",
-					"-- returns 1221 in dev\n",
-					"\n",
-					"-- Should be 1058, so there is some duplication occurring.\n",
-					"\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.document_meta_data WHERE documentId = '15259223' AND sourceSystem = 'horizon';\n",
-					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15259223';\n",
-					"SELECT * FROM odw_harmonised_db.document_meta_data WHERE DataID = '15259223';\n",
-					"\n",
-					""
-				],
-				"execution_count": 19
+				"execution_count": 28
 			}
 		]
 	}

--- a/workspace/notebook/document_metadata.json
+++ b/workspace/notebook/document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6bd721b2-954c-4fb2-97f6-1f39d5d36e92"
+				"spark.autotune.trackingId": "6b26e9dc-9c73-432a-95c5-d6c0e8517a1c"
 			}
 		},
 		"metadata": {
@@ -218,7 +218,7 @@
 					"-- -- Test #1: Check aie_document_data - \n",
 					"\n",
 					"-- SELECT COUNT(*) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
-					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%' AND DocumentID = '33820255';\n",
+					"-- SELECT * FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%' AND DocumentID = '33820255';\n",
 					"-- SELECT DISTINCT DocumentID FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
 					"-- SELECT COUNT(DISTINCT (DocumentID)) FROM odw_harmonised_db.aie_document_data WHERE Path LIKE '%TR010010%';\n",
 					"\n",
@@ -236,16 +236,20 @@
 					"-- -- Returns 1057 in dev (off by one)\n",
 					"\n",
 					"-- -- Test #3: Check doc metadata in Curated -\n",
-					"\n",
-					"SELECT COUNT(*) FROM odw_curated_db.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
+					"-- SELECT COUNT(*) FROM odw_curated_db.dbo.document_meta_data WHERE caseRef = 'TR010010' AND sourceSystem = 'horizon';\n",
 					"\n",
 					"-- Returns 1222 in test\n",
 					"\n",
 					"-- returns 1221 in dev\n",
 					"\n",
-					"-- Should be 1058, so there is some duplication occurring."
+					"-- Should be 1058, so there is some duplication occurring.\n",
+					"\n",
+					"\n",
+					"SELECT * FROM odw_curated_db.document_meta_data WHERE documentId = '15259212' AND sourceSystem = 'horizon';\n",
+					"SELECT * FROM odw_harmonised_db.aie_document_data WHERE DocumentID = '15259212';\n",
+					"SELECT * FROM odw_harmonised_db.document_meta_data WHERE DataID = '15259212';"
 				],
-				"execution_count": 31
+				"execution_count": 2
 			}
 		]
 	}

--- a/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
+++ b/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
@@ -27,7 +27,7 @@
 				"typeProperties": {
 					"source": {
 						"type": "AzureSqlSource",
-						"sqlReaderQuery": "SELECT * FROM Horizon_ODW_vw_DocumentMetadata\nWHERE DATEDIFF(Day, ModifyDate, GETDATE()) < 4",
+						"sqlReaderQuery": "SELECT * FROM Horizon_ODW_vw_DocumentMetadata\nWHERE DATEDIFF(Day, ModifyDate, GETDATE()) < 4\n",
 						"queryTimeout": "02:00:00",
 						"isolationLevel": "ReadCommitted",
 						"partitionOption": "None"

--- a/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
+++ b/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
@@ -75,7 +75,7 @@
 								"source": {
 									"name": "caseReference",
 									"type": "String",
-									"physicalType": "nvarchar"
+									"physicalType": "varchar"
 								},
 								"sink": {
 									"name": "caseReference",
@@ -109,12 +109,12 @@
 							},
 							{
 								"source": {
-									"name": "Name",
+									"name": "name",
 									"type": "String",
 									"physicalType": "nvarchar"
 								},
 								"sink": {
-									"name": "Name",
+									"name": "name",
 									"type": "String",
 									"physicalType": "String"
 								}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
