### PR TITLE
Adding pipeline: pln_appeals_master

### DIFF
--- a/workspace/pipeline/pln_appeals_master.json
+++ b/workspace/pipeline/pln_appeals_master.json
@@ -65,6 +65,54 @@
 					},
 					"waitOnCompletion": true
 				}
+			},
+			{
+				"name": "pln_service_bus_appeals_has",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_service_bus_appeals_has",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_horizon_Appeals_Event",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_horizon_Appeals_Event",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_service_bus_appeals_event",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_service_bus_appeals_event",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
 			}
 		],
 		"folder": {

--- a/workspace/pipeline/pln_appeals_master.json
+++ b/workspace/pipeline/pln_appeals_master.json
@@ -1,0 +1,75 @@
+{
+	"name": "pln_appeals_master",
+	"properties": {
+		"activities": [
+			{
+				"name": "pln_horizon_appeals_folder",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_horizon_appeals_folder",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_service_bus_appeals_document",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_service_bus_appeals_document",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_horizon_appeals_document_metadata",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_horizon_appeals_document_metadata",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			},
+			{
+				"name": "pln_appeals_document_main",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_appeals_document_main",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			}
+		],
+		"folder": {
+			"name": "utils"
+		},
+		"annotations": []
+	}
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
