### PR TITLE
Feat/odw 1272 curated table make into spark table to match schema nsip data

### DIFF
--- a/workspace/notebook/py_reload_from_raw_nsip_project.json
+++ b/workspace/notebook/py_reload_from_raw_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c4acb114-f576-4d6f-9e0d-63df4e2ba768"
+				"spark.autotune.trackingId": "21aaf08c-fd9a-4534-958f-b080c8367cb8"
 			}
 		},
 		"metadata": {
@@ -74,6 +74,25 @@
 					}
 				},
 				"source": [
+					"entity_name = \"nsip-project\"\r\n",
+					"table_name = \"odw_standardised_db.sb_nsip_project\""
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
 					"%run service-bus/py_spark_df_ingestion_functions"
 				],
 				"execution_count": null
@@ -93,10 +112,10 @@
 				},
 				"source": [
 					"def create_valid_dataframe() -> DataFrame:\r\n",
-					"    df: DataFrame = collect_all_raw_sb_data(\"nsip-project\")\r\n",
+					"    df: DataFrame = collect_all_raw_sb_data(f\"{entity_name}\")\r\n",
 					"    # drop corrupt records loaded with bad files and any test columns created during testing\r\n",
-					"    valid_df: DataFrame = df.filter(col(\"_corrupt_record\").isNull()).drop(\"_corrupt_record\", \"baddata\", \"interestedpartyids\")\r\n",
-					"    valid_df: DataFrame = valid_df.withColumnRenamed(\"applicantIds\", \"applicantId\")\r\n",
+					"    valid_df: DataFrame = df.filter(col(\"_corrupt_record\").isNull()).drop(\"_corrupt_record\", \"baddata\", \"interestedpartyids\", \"applicantIds\")\r\n",
+					"    # valid_df: DataFrame = valid_df.withColumnRenamed(\"applicantIds\", \"applicantId\")\r\n",
 					"    return valid_df"
 				],
 				"execution_count": null
@@ -115,8 +134,8 @@
 					}
 				},
 				"source": [
-					"def schemas_match(historical_schema: StructType, table_schema: StructType) -> bool:\r\n",
-					"    return historical_schema == table_schema"
+					"def schemas_match(schema1: StructType, schema2: StructType) -> bool:\r\n",
+					"    return schema1 == schema2"
 				],
 				"execution_count": null
 			},
@@ -160,10 +179,10 @@
 					"collapsed": false
 				},
 				"source": [
-					"historical_df: DataFrame = create_valid_dataframe()\r\n",
-					"old_table_df = spark.sql(\"select * from odw_standardised_db.nsip_project\")\r\n",
+					"historical_df: DataFrame = create_valid_dataframe().alias(\"historical\")\r\n",
+					"old_table_df = spark.sql(\"select message_id, ingested_datetime, expected_from, expected_to from odw_standardised_db.nsip_project\").alias(\"old\")\r\n",
 					"historical_schema = historical_df.schema\r\n",
-					"table_schema = spark.table(\"odw_standardised_db.sb_nsip_project\").schema\r\n",
+					"table_schema = spark.table(f\"{table_name}\").schema\r\n",
 					"joined_df = historical_df.join(old_table_df, on=\"message_id\", how=\"left\")\r\n",
 					"joined_df_schema = joined_df.schema"
 				],
@@ -201,7 +220,7 @@
 					}
 				},
 				"source": [
-					"schemas_match(historical_schema, table_schema)"
+					"schemas_match(joined_df_schema, table_schema)"
 				],
 				"execution_count": null
 			},
@@ -237,7 +256,7 @@
 					}
 				},
 				"source": [
-					"print(historical_schema)"
+					"print(joined_df_schema)"
 				],
 				"execution_count": null
 			},
@@ -255,9 +274,210 @@
 					}
 				},
 				"source": [
-					"in_schema1_not_in_schema2, in_schema2_not_in_schema1 = compare_schema_fields_only(joined_df_schema, table_schema)\r\n",
+					"in_schema1_not_in_schema2, in_schema2_not_in_schema1 = compare_schemas(joined_df_schema, table_schema)\r\n",
 					"\r\n",
-					"print(in_schema1_not_in_schema2)"
+					"print(in_schema1_not_in_schema2)\r\n",
+					"print(in_schema2_not_in_schema1)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"display(joined_df.head(5))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"joined_df: DataFrame = joined_df.withColumn(\"expected_from\", current_timestamp())\r\n",
+					"joined_df: DataFrame = joined_df.withColumn(\"expected_to\", expr(\"current_timestamp() + INTERVAL 1 DAY\"))\r\n",
+					"joined_df: DataFrame = joined_df.withColumn(\"ingested_datetime\", to_timestamp(col(\"historical.message_enqueued_time_utc\")))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"display(joined_df.filter(\"ingested_datetime is not null\").head(3))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"display(joined_df.select(\"message_id\", \"ingested_datetime\").filter(\"ingested_datetime is not null\").head(5))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"joined_df.printSchema()"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def cast_columns(df: DataFrame, schema: StructType) -> DataFrame:\r\n",
+					"    for field in schema.fields:\r\n",
+					"        df = df.withColumn(field.name, col(field.name).cast(field.dataType))\r\n",
+					"    return df"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"final_df = cast_columns(joined_df, table_schema)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"final_df.printSchema()"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def create_dataframe_to_load(df: DataFrame, table_name: str) -> DataFrame:\r\n",
+					"    table_df: DataFrame = spark.table(table_name)\r\n",
+					"    df: DataFrame = df.select(table_df.columns)\r\n",
+					"    table_df: DataFrame = table_df.union(df)\r\n",
+					"\r\n",
+					"    # removing duplicates while ignoring the ingestion dates columns\r\n",
+					"    columns_to_ignore: list = ['expected_to', 'expected_from', 'ingested_datetime']\r\n",
+					"    columns_to_consider: list = [c for c in table_df.columns if c not in columns_to_ignore]\r\n",
+					"    table_df: DataFrame = table_df.dropDuplicates(subset=columns_to_consider)\r\n",
+					"\r\n",
+					"    return table_df"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"table_df: DataFrame = create_dataframe_to_load(final_df, table_name)\r\n",
+					"apply_df_to_table(table_df, table_name.split('.')[0], table_name.split('.')[1])"
 				],
 				"execution_count": null
 			}

--- a/workspace/notebook/py_reload_from_raw_nsip_project.json
+++ b/workspace/notebook/py_reload_from_raw_nsip_project.json
@@ -1,0 +1,266 @@
+{
+	"name": "py_reload_from_raw_nsip_project",
+	"properties": {
+		"folder": {
+			"name": "service-bus"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "c4acb114-f576-4d6f-9e0d-63df4e2ba768"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": true,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"source": [
+					"from pyspark.sql import DataFrame\r\n",
+					"from pyspark.sql.functions import *\r\n",
+					"import pprint"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"%run service-bus/py_spark_df_ingestion_functions"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def create_valid_dataframe() -> DataFrame:\r\n",
+					"    df: DataFrame = collect_all_raw_sb_data(\"nsip-project\")\r\n",
+					"    # drop corrupt records loaded with bad files and any test columns created during testing\r\n",
+					"    valid_df: DataFrame = df.filter(col(\"_corrupt_record\").isNull()).drop(\"_corrupt_record\", \"baddata\", \"interestedpartyids\")\r\n",
+					"    valid_df: DataFrame = valid_df.withColumnRenamed(\"applicantIds\", \"applicantId\")\r\n",
+					"    return valid_df"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def schemas_match(historical_schema: StructType, table_schema: StructType) -> bool:\r\n",
+					"    return historical_schema == table_schema"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def compare_schema_fields_only(schema1: StructType, schema2: StructType) -> tuple:\r\n",
+					"    fields1 = set((field.name) for field in schema1.fields)\r\n",
+					"    fields2 = set((field.name) for field in schema2.fields)\r\n",
+					"    \r\n",
+					"    in_schema1_not_in_schema2: set = fields1 - fields2\r\n",
+					"    in_schema2_not_in_schema1: set = fields2 - fields1\r\n",
+					"    \r\n",
+					"    return in_schema1_not_in_schema2, in_schema2_not_in_schema1"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"historical_df: DataFrame = create_valid_dataframe()\r\n",
+					"old_table_df = spark.sql(\"select * from odw_standardised_db.nsip_project\")\r\n",
+					"historical_schema = historical_df.schema\r\n",
+					"table_schema = spark.table(\"odw_standardised_db.sb_nsip_project\").schema\r\n",
+					"joined_df = historical_df.join(old_table_df, on=\"message_id\", how=\"left\")\r\n",
+					"joined_df_schema = joined_df.schema"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"joined_df.printSchema()"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"schemas_match(historical_schema, table_schema)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(table_schema)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(historical_schema)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"in_schema1_not_in_schema2, in_schema2_not_in_schema1 = compare_schema_fields_only(joined_df_schema, table_schema)\r\n",
+					"\r\n",
+					"print(in_schema1_not_in_schema2)"
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/py_reload_from_raw_nsip_project.json
+++ b/workspace/notebook/py_reload_from_raw_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "21aaf08c-fd9a-4534-958f-b080c8367cb8"
+				"spark.autotune.trackingId": "8cd14cff-d3f4-42c4-9be9-92c2f88d51fe"
 			}
 		},
 		"metadata": {
@@ -115,7 +115,6 @@
 					"    df: DataFrame = collect_all_raw_sb_data(f\"{entity_name}\")\r\n",
 					"    # drop corrupt records loaded with bad files and any test columns created during testing\r\n",
 					"    valid_df: DataFrame = df.filter(col(\"_corrupt_record\").isNull()).drop(\"_corrupt_record\", \"baddata\", \"interestedpartyids\", \"applicantIds\")\r\n",
-					"    # valid_df: DataFrame = valid_df.withColumnRenamed(\"applicantIds\", \"applicantId\")\r\n",
 					"    return valid_df"
 				],
 				"execution_count": null
@@ -134,7 +133,7 @@
 					}
 				},
 				"source": [
-					"def schemas_match(schema1: StructType, schema2: StructType) -> bool:\r\n",
+					"def test_schemas_match(schema1: StructType, schema2: StructType) -> bool:\r\n",
 					"    return schema1 == schema2"
 				],
 				"execution_count": null
@@ -220,7 +219,7 @@
 					}
 				},
 				"source": [
-					"schemas_match(joined_df_schema, table_schema)"
+					"test_schemas_match(joined_df_schema, table_schema)"
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "24fe5f3d-129e-49f5-8baa-d8ac34680f4f"
+				"spark.autotune.trackingId": "3826f06e-1457-485c-8d9f-3bc6535378eb"
 			}
 		},
 		"metadata": {
@@ -79,9 +79,10 @@
 				},
 				"source": [
 					"from pyspark.sql import DataFrame\r\n",
-					"from pyspark.sql.types import StructType"
+					"from pyspark.sql.types import StructType\r\n",
+					"from pyspark.sql.functions import *"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -191,6 +192,35 @@
 					"        print('Schemas match.')"
 				],
 				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def collect_all_raw_sb_data(entity_name: str):\r\n",
+					"\r\n",
+					"    storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\r\n",
+					"\r\n",
+					"    folder: str = f\"abfss://odw-raw@{storage_account}ServiceBus/{entity_name}\"\r\n",
+					"\r\n",
+					"    df: DataFrame = (spark.read.format(\"json\") \r\n",
+					"        .option(\"recursiveFileLookup\", \"true\")\r\n",
+					"        .option(\"pathGlobFilter\",\"*.json\")\r\n",
+					"        .load(folder))\r\n",
+					"\r\n",
+					"    return df"
+				],
+				"execution_count": 5
 			}
 		]
 	}


### PR DESCRIPTION
Reload notebook created as a bespoke notebook for nsip-project rebuild work. This can be used as a template for other entities that need rebuilding with data needing to be loaded again from RAW layer.

This covers rebuilding nsip-project standardised table.