### PR TITLE
Pd/feat/1257

### DIFF
--- a/workspace/notebook/appeals_event.json
+++ b/workspace/notebook/appeals_event.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "17bd439f-7ec4-45cd-a96d-8c743e00b0fc"
+				"spark.autotune.trackingId": "fbf497ce-4b9c-486c-82b3-213aaaf24676"
 			}
 		},
 		"metadata": {
@@ -80,7 +80,7 @@
 					"    ,eventName\r\n",
 					"    ,eventStatus\r\n",
 					"    ,isUrgent\r\n",
-					"    ,eventPublished\r\n",
+					"    ,CAST(eventPublished AS boolean) AS eventPublished\r\n",
 					"    ,eventStartDateTime\r\n",
 					"    ,eventEndDateTime\r\n",
 					"    ,notificationOfSiteVisit\r\n",

--- a/workspace/pipeline/pln_service_bus_appeals_event.json
+++ b/workspace/pipeline/pln_service_bus_appeals_event.json
@@ -45,62 +45,7 @@
 					},
 					"ifTrueActivities": [
 						{
-							"name": "Raw to Std",
-							"description": "Ingests raw data into the standardised table",
-							"type": "SynapseNotebook",
-							"dependsOn": [
-								{
-									"activity": "JSON to CSV",
-									"dependencyConditions": [
-										"Succeeded"
-									]
-								}
-							],
-							"policy": {
-								"timeout": "0.12:00:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"notebook": {
-									"referenceName": "py_raw_to_std",
-									"type": "NotebookReference"
-								},
-								"parameters": {
-									"source_folder": {
-										"value": "ServiceBus",
-										"type": "string"
-									},
-									"source_frequency_folder": {
-										"value": {
-											"value": "@variables('entity_name')",
-											"type": "Expression"
-										},
-										"type": "string"
-									},
-									"specific_file": {
-										"value": {
-											"value": "@variables('entity_name')",
-											"type": "Expression"
-										},
-										"type": "string"
-									}
-								},
-								"snapshot": true,
-								"conf": {
-									"spark.dynamicAllocation.enabled": null,
-									"spark.dynamicAllocation.minExecutors": null,
-									"spark.dynamicAllocation.maxExecutors": null
-								},
-								"numExecutors": null
-							}
-						},
-						{
-							"name": "JSON to CSV",
-							"description": "Converts the messages stored in json format to csv format",
+							"name": "py_sb_raw_to_std",
 							"type": "SynapseNotebook",
 							"dependsOn": [],
 							"policy": {
@@ -113,38 +58,18 @@
 							"userProperties": [],
 							"typeProperties": {
 								"notebook": {
-									"referenceName": "py_service_bus_json_to_csv",
+									"referenceName": "py_sb_raw_to_std",
 									"type": "NotebookReference"
 								},
-								"parameters": {
-									"source_folder": {
-										"value": "ServiceBus",
-										"type": "string"
-									},
-									"source_frequency_folder": {
-										"value": {
-											"value": "@variables('entity_name')",
-											"type": "Expression"
-										},
-										"type": "string"
-									}
-								},
-								"snapshot": true,
-								"conf": {
-									"spark.dynamicAllocation.enabled": null,
-									"spark.dynamicAllocation.minExecutors": null,
-									"spark.dynamicAllocation.maxExecutors": null
-								},
-								"numExecutors": null
+								"snapshot": true
 							}
 						},
 						{
-							"name": "Std to Hrm",
-							"description": "Ingests standardised data into the harmonised table",
+							"name": "py_sb_std_to_hrm",
 							"type": "SynapseNotebook",
 							"dependsOn": [
 								{
-									"activity": "Raw to Std",
+									"activity": "py_sb_raw_to_std",
 									"dependencyConditions": [
 										"Succeeded"
 									]
@@ -160,25 +85,37 @@
 							"userProperties": [],
 							"typeProperties": {
 								"notebook": {
-									"referenceName": "py_std_to_hrm",
+									"referenceName": "py_sb_std_to_hrm",
 									"type": "NotebookReference"
 								},
-								"parameters": {
-									"entity_name": {
-										"value": {
-											"value": "@variables('entity_name')",
-											"type": "Expression"
-										},
-										"type": "string"
-									}
+								"snapshot": true
+							}
+						},
+						{
+							"name": "appeals_event",
+							"type": "SynapseNotebook",
+							"dependsOn": [
+								{
+									"activity": "py_sb_std_to_hrm",
+									"dependencyConditions": [
+										"Succeeded"
+									]
+								}
+							],
+							"policy": {
+								"timeout": "0.12:00:00",
+								"retry": 0,
+								"retryIntervalInSeconds": 30,
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"notebook": {
+									"referenceName": "appeals_event",
+									"type": "NotebookReference"
 								},
-								"snapshot": true,
-								"conf": {
-									"spark.dynamicAllocation.enabled": null,
-									"spark.dynamicAllocation.minExecutors": null,
-									"spark.dynamicAllocation.maxExecutors": null
-								},
-								"numExecutors": null
+								"snapshot": true
 							}
 						}
 					]

--- a/workspace/pipeline/pln_service_bus_appeals_has.json
+++ b/workspace/pipeline/pln_service_bus_appeals_has.json
@@ -45,36 +45,9 @@
 					},
 					"ifTrueActivities": [
 						{
-							"name": "create_table_from_schema",
-							"type": "SynapseNotebook",
-							"dependsOn": [],
-							"policy": {
-								"timeout": "0.12:00:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"notebook": {
-									"referenceName": "create_table_from_schema",
-									"type": "NotebookReference"
-								},
-								"snapshot": true
-							}
-						},
-						{
 							"name": "py_sb_raw_to_std",
 							"type": "SynapseNotebook",
-							"dependsOn": [
-								{
-									"activity": "create_table_from_schema",
-									"dependencyConditions": [
-										"Succeeded"
-									]
-								}
-							],
+							"dependsOn": [],
 							"policy": {
 								"timeout": "0.12:00:00",
 								"retry": 0,
@@ -88,7 +61,13 @@
 									"referenceName": "py_sb_raw_to_std",
 									"type": "NotebookReference"
 								},
-								"snapshot": true
+								"snapshot": true,
+								"conf": {
+									"spark.dynamicAllocation.enabled": null,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
 							}
 						},
 						{
@@ -115,7 +94,13 @@
 									"referenceName": "py_sb_std_to_hrm",
 									"type": "NotebookReference"
 								},
-								"snapshot": true
+								"snapshot": true,
+								"conf": {
+									"spark.dynamicAllocation.enabled": null,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
 							}
 						},
 						{
@@ -142,7 +127,13 @@
 									"referenceName": "appeal_has",
 									"type": "NotebookReference"
 								},
-								"snapshot": true
+								"snapshot": true,
+								"conf": {
+									"spark.dynamicAllocation.enabled": null,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
 							}
 						}
 					]


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
