### PR TITLE
Fix/ingestion fixes

### DIFF
--- a/workspace/notebook/py_sb_std_to_hrm.json
+++ b/workspace/notebook/py_sb_std_to_hrm.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7c9b5546-bcb3-49ad-8907-21b4a4a4297a"
+				"spark.autotune.trackingId": "6dc49327-8d66-4970-bd08-5f9131d187ab"
 			}
 		},
 		"metadata": {
@@ -530,7 +530,7 @@
 				},
 				"source": [
 					"if create_df.count() > 0:\r\n",
-					"    create_df = update_df.dropDuplicates().orderBy(\"IngestionDate\")\r\n",
+					"    create_df = create_df.dropDuplicates().orderBy(\"IngestionDate\")\r\n",
 					"\r\n",
 					"if update_df.count() > 0:\r\n",
 					"    update_df = update_df.dropDuplicates().orderBy(\"IngestionDate\")\r\n",
@@ -759,24 +759,6 @@
 					"apply_df_to_table(target_df, hrm_db, hrm_table)"
 				],
 				"execution_count": 96
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					""
-				],
-				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0db3f65c-7bcb-4bfb-9baa-628d837a33c9"
+				"spark.autotune.trackingId": "06ea3cef-5c78-4bd9-9f2f-c855afdaeb25"
 			}
 		},
 		"metadata": {
@@ -212,6 +212,20 @@
 				},
 				"source": [
 					"def collect_all_raw_sb_data(folder_name: str, schema: StructType) -> DataFrame:\r\n",
+					"\r\n",
+					"    \"\"\"\r\n",
+					"    Function to loop through all sub-folders in a given folder path and collect all\r\n",
+					"    json data into a single DataFrame. To be used for a reload of an entity from all\r\n",
+					"    data in the RAW layer.\r\n",
+					"\r\n",
+					"    Args:\r\n",
+					"        folder_name: the name of the folder in the storage account. May be different from the\r\n",
+					"        entity name.\r\n",
+					"        schema: a spark schema of type StructType to apply to the RAW data.\r\n",
+					"\r\n",
+					"    Returns:\r\n",
+					"        A spark DataFrame of all json data from the RAW layer for a given root folder\r\n",
+					"    \"\"\"\r\n",
 					"\r\n",
 					"    storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\r\n",
 					"\r\n",

--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ae404f30-af0b-4804-a313-c487eb039c2d"
+				"spark.autotune.trackingId": "0db3f65c-7bcb-4bfb-9baa-628d837a33c9"
 			}
 		},
 		"metadata": {
@@ -118,8 +118,9 @@
 				},
 				"source": [
 					"def compare_schemas(schema1: StructType, schema2: StructType) -> tuple:\n",
-					"    fields1 = set((field.name, field.dataType, field.nullable) for field in schema1.fields)\n",
-					"    fields2 = set((field.name, field.dataType, field.nullable) for field in schema2.fields)\n",
+					"    \n",
+					"    fields1 = set((field.name, field.dataType) for field in schema1.fields)\n",
+					"    fields2 = set((field.name, field.dataType) for field in schema2.fields)\n",
 					"\n",
 					"    in_schema1_not_in_schema2 = fields1 - fields2\n",
 					"    in_schema2_not_in_schema1 = fields2 - fields1\n",
@@ -210,13 +211,14 @@
 					}
 				},
 				"source": [
-					"def collect_all_raw_sb_data(folder_name: str):\r\n",
+					"def collect_all_raw_sb_data(folder_name: str, schema: StructType) -> DataFrame:\r\n",
 					"\r\n",
 					"    storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\r\n",
 					"\r\n",
 					"    folder: str = f\"abfss://odw-raw@{storage_account}ServiceBus/{folder_name}\"\r\n",
 					"\r\n",
-					"    df: DataFrame = (spark.read.format(\"json\") \r\n",
+					"    df: DataFrame = (spark.read.format(\"json\")\r\n",
+					"        .schema(schema) \r\n",
 					"        .option(\"recursiveFileLookup\", \"true\")\r\n",
 					"        .option(\"pathGlobFilter\",\"*.json\")\r\n",
 					"        .load(folder))\r\n",


### PR DESCRIPTION
Removed check for nullable in compare schemas function. 
Corrected de-dupe for created records.
Added a schema parameter to the collect raw data function. This will help to avoid any need to cast data types. When reloading the data, use the schema of the new table and apply that to the raw data by passing it into this function. That way the schema will be controlled in advance and not inferred by pyspark.