### PR TITLE
Feat/create curated table

### DIFF
--- a/workspace/notebook/py_create_curated_table.json
+++ b/workspace/notebook/py_create_curated_table.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a4f16b48-6ed0-4fca-93ba-758483f54132"
+				"spark.autotune.trackingId": "deb52b01-17e2-4c50-a783-e719ba3d1bbb"
 			}
 		},
 		"metadata": {
@@ -61,7 +61,7 @@
 					}
 				},
 				"source": [
-					"##### Define parameters"
+					"##### Define parameters for the database and table name that you want to create"
 				]
 			},
 			{
@@ -115,33 +115,6 @@
 					}
 				},
 				"source": [
-					"##### Define a schema if you want - optional"
-				]
-			},
-			{
-				"cell_type": "code",
-				"source": [
-					"# schema: StructType = StructType([\r\n",
-					"#     StructField(\"ingested_datetime\", TimestampType(), False),\r\n",
-					"#     StructField(\"expected_from\", TimestampType(), False),\r\n",
-					"#     StructField(\"expected_to\", TimestampType(), False),\r\n",
-					"#     StructField(\"message_id\", StringType(), False),\r\n",
-					"#     StructField(\"message_type\", StringType(), False),\r\n",
-					"#     StructField(\"message_enqueued_time_utc\", StringType(), False)\r\n",
-					"# ])"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"##### Define the query to fetch the data you want to load to the table"
 				]
 			},
@@ -159,7 +132,7 @@
 					}
 				},
 				"source": [
-					"query: str = \"select * from odw_harmonised_db.appeals_folder\""
+					"query: str = \"select * table\""
 				],
 				"execution_count": null
 			},
@@ -236,9 +209,7 @@
 					}
 				},
 				"source": [
-					"##### Show the schema of the DataFrame - optional visual check\r\n",
-					"\r\n",
-					"If you don't define a schema above then it will be inferred and might not be how you want it. Make sure you're happy with it."
+					"##### Show the schema of the DataFrame - optional visual check"
 				]
 			},
 			{

--- a/workspace/notebook/py_create_curated_table.json
+++ b/workspace/notebook/py_create_curated_table.json
@@ -1,0 +1,315 @@
+{
+	"name": "py_create_curated_table",
+	"properties": {
+		"folder": {
+			"name": "utils"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "a4f16b48-6ed0-4fca-93ba-758483f54132"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": true,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Define parameters"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"tags": [
+						"parameters"
+					]
+				},
+				"source": [
+					"db_name: str = \"odw_curated_db\"\r\n",
+					"table_name: str = \"rams_table\""
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"from pyspark.sql.types import *\r\n",
+					"from pyspark.sql import DataFrame"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Define a schema if you want - optional"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"# schema: StructType = StructType([\r\n",
+					"#     StructField(\"ingested_datetime\", TimestampType(), False),\r\n",
+					"#     StructField(\"expected_from\", TimestampType(), False),\r\n",
+					"#     StructField(\"expected_to\", TimestampType(), False),\r\n",
+					"#     StructField(\"message_id\", StringType(), False),\r\n",
+					"#     StructField(\"message_type\", StringType(), False),\r\n",
+					"#     StructField(\"message_enqueued_time_utc\", StringType(), False)\r\n",
+					"# ])"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Define the query to fetch the data you want to load to the table"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"query: str = \"select * from odw_harmonised_db.appeals_folder\""
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Put query results into a spark DataFrame"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"spark_dataframe: DataFrame = spark.sql(query)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Display a sample of the DataFrame for a visual check - optional"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"display(spark_dataframe.head(5))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Show the schema of the DataFrame - optional visual check\r\n",
+					"\r\n",
+					"If you don't define a schema above then it will be inferred and might not be how you want it. Make sure you're happy with it."
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"spark_dataframe.printSchema()"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Create a table from the DataFrame"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def create_spark_table(db_name: str, table_name: str, spark_dataframe: DataFrame) -> None:\r\n",
+					"    spark_dataframe.write.format(\"delta\").saveAsTable(f\"{db_name}.{table_name}\")\r\n",
+					"    print(\"Table created\")"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"create_spark_table(db_name, table_name, spark_dataframe)"
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/py_create_curated_table.json
+++ b/workspace/notebook/py_create_curated_table.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "deb52b01-17e2-4c50-a783-e719ba3d1bbb"
+				"spark.autotune.trackingId": "e4ac4565-2218-4311-b5bb-f7380853243b"
 			}
 		},
 		"metadata": {
@@ -61,7 +61,7 @@
 					}
 				},
 				"source": [
-					"##### Define parameters for the database and table name that you want to create"
+					"##### Define parameters for the database and table name that you want to create and the query to fetch the data"
 				]
 			},
 			{
@@ -82,7 +82,8 @@
 				},
 				"source": [
 					"db_name: str = \"odw_curated_db\"\r\n",
-					"table_name: str = \"rams_table\""
+					"table_name: str = \"rams_table\"\r\n",
+					"query: str = \"select * table\""
 				],
 				"execution_count": null
 			},
@@ -102,37 +103,6 @@
 				"source": [
 					"from pyspark.sql.types import *\r\n",
 					"from pyspark.sql import DataFrame"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"##### Define the query to fetch the data you want to load to the table"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"query: str = \"select * table\""
 				],
 				"execution_count": null
 			},


### PR DESCRIPTION
Added notebook to create a curated table without a defined schema, rather just from a SQL query. To meet Rams' request to be able to easily create curated tables without defining a schema in advance in the data model.