### PR TITLE
Pd/fead/1316

### DIFF
--- a/workspace/notebook/py_deployment_manage_main_config.json
+++ b/workspace/notebook/py_deployment_manage_main_config.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a0fea1f7-4c34-4500-bb8d-a13ffad08949"
+				"spark.autotune.trackingId": "8b82efed-fbfa-4de6-8af5-68faf1688e9b"
 			}
 		},
 		"metadata": {
@@ -219,6 +219,13 @@
 					"    ,'Service bus' AS System_name\r\n",
 					"    ,'Appeals Has' AS Object\r\n",
 					"    ,'appeal-has' AS entity_name\r\n",
+					"    ,TRUE AS is_enabled\r\n",
+					"    UNION ALL\r\n",
+					"SELECT\r\n",
+					"    20 AS System_key\r\n",
+					"    ,'Horizon' AS System_name\r\n",
+					"    ,'Entraid' AS Object\r\n",
+					"    ,CAST(NULL AS VARCHAR(500)) AS entity_name\r\n",
 					"    ,TRUE AS is_enabled"
 				],
 				"execution_count": 1

--- a/workspace/notebook/py_deployment_manage_main_config.json
+++ b/workspace/notebook/py_deployment_manage_main_config.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8b82efed-fbfa-4de6-8af5-68faf1688e9b"
+				"spark.autotune.trackingId": "103ccda4-2e6f-4f47-97a6-5fa8c0ca1e22"
 			}
 		},
 		"metadata": {
@@ -223,7 +223,7 @@
 					"    UNION ALL\r\n",
 					"SELECT\r\n",
 					"    20 AS System_key\r\n",
-					"    ,'Horizon' AS System_name\r\n",
+					"    ,'HR' AS System_name\r\n",
 					"    ,'Entraid' AS Object\r\n",
 					"    ,CAST(NULL AS VARCHAR(500)) AS entity_name\r\n",
 					"    ,TRUE AS is_enabled"

--- a/workspace/pipeline/pln_horizon_2.json
+++ b/workspace/pipeline/pln_horizon_2.json
@@ -1,0 +1,621 @@
+{
+	"name": "pln_horizon_2",
+	"properties": {
+		"activities": [
+			{
+				"name": "Get Entraid config",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Random wait to allow parallelism",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_utils_get_pipeline_config",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"system_name": {
+							"value": "Horizon",
+							"type": "string"
+						},
+						"Object": {
+							"value": "Relevant Reps",
+							"type": "string"
+						}
+					},
+					"snapshot": true,
+					"sparkPool": {
+						"referenceName": "pinssynspodw",
+						"type": "BigDataPoolReference"
+					},
+					"conf": {
+						"spark.dynamicAllocation.enabled": true
+					}
+				}
+			},
+			{
+				"name": "Relevant Reps",
+				"type": "IfCondition",
+				"dependsOn": [
+					{
+						"activity": "Get Entraid config",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"expression": {
+						"value": "@equals(activity('Get Relevant Reps config').output.status.Output.result.exitValue, '[True]')",
+						"type": "Expression"
+					},
+					"ifFalseActivities": [
+						{
+							"name": "Record relevant reps warning",
+							"type": "SynapseNotebook",
+							"dependsOn": [
+								{
+									"activity": "Send relevant reps disabled warning",
+									"dependencyConditions": [
+										"Succeeded"
+									]
+								}
+							],
+							"policy": {
+								"timeout": "0.12:00:00",
+								"retry": 0,
+								"retryIntervalInSeconds": 30,
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"notebook": {
+									"referenceName": "py_utils_log_stage",
+									"type": "NotebookReference"
+								},
+								"parameters": {
+									"Stage": {
+										"value": "Warning",
+										"type": "string"
+									},
+									"PipelineName": {
+										"value": {
+											"value": "@pipeline().Pipeline",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineRunID": {
+										"value": {
+											"value": "@pipeline().RunId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"Inserts": {
+										"value": "0",
+										"type": "int"
+									},
+									"Updates": {
+										"value": "0",
+										"type": "int"
+									},
+									"Deletes": {
+										"value": "0",
+										"type": "int"
+									},
+									"ErrorMessage": {
+										"value": "Horizon - Relevant Reps disabled",
+										"type": "string"
+									},
+									"StatusMessage": {
+										"value": "Warning",
+										"type": "string"
+									},
+									"PipelineTriggerID": {
+										"value": {
+											"value": "@pipeline().TriggerId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggerName": {
+										"value": {
+											"value": "@pipeline().TriggerName",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggerType": {
+										"value": {
+											"value": "@pipeline().TriggerType",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggeredbyPipelineName": {
+										"value": {
+											"value": "@pipeline()?.TriggeredByPipelineName",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggeredbyPipelineRunID": {
+										"value": {
+											"value": "@pipeline()?.TriggeredByPipelineRunId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"ActivityType": {
+										"value": "Pipeline",
+										"type": "string"
+									}
+								},
+								"snapshot": true,
+								"sparkPool": {
+									"referenceName": "pinssynspodw",
+									"type": "BigDataPoolReference"
+								},
+								"conf": {
+									"spark.dynamicAllocation.enabled": true,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
+							}
+						},
+						{
+							"name": "Send relevant reps disabled warning",
+							"type": "ExecutePipeline",
+							"dependsOn": [],
+							"policy": {
+								"secureInput": true
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "pln_utl_Send_Teams_Message",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"dataFactorySubscription": {
+										"value": "@pipeline().parameters.subscription_id",
+										"type": "Expression"
+									},
+									"dataFactoryResourceGroup": {
+										"value": "@pipeline().parameters.resource_group",
+										"type": "Expression"
+									},
+									"pipelineRunId": {
+										"value": "@pipeline().RunId",
+										"type": "Expression"
+									},
+									"teamsWebhookUrl": {
+										"value": "@pipeline().parameters.webhook_url",
+										"type": "Expression"
+									},
+									"activityName": {
+										"value": "@pipeline().Pipeline",
+										"type": "Expression"
+									},
+									"activityMessage": "Loading Horizon data",
+									"activityDuration": {
+										"value": "@concat(string(div(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(pipeline().parameters.start_time,'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'H:', \nstring(mod(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(pipeline().parameters.start_time,'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'M:00s')",
+										"type": "Expression"
+									},
+									"activityStatus": "On Progress",
+									"Colour": {
+										"value": "@pipeline().parameters.warning_colour",
+										"type": "Expression"
+									},
+									"Image": {
+										"value": "@pipeline().parameters.warning_image",
+										"type": "Expression"
+									},
+									"Message_title": "ODW - Master pipeline warning",
+									"Message_subtitle": "Horizon relevant reps data load disabled"
+								}
+							}
+						}
+					],
+					"ifTrueActivities": [
+						{
+							"name": "Record loading relevant reps data",
+							"type": "SynapseNotebook",
+							"dependsOn": [],
+							"policy": {
+								"timeout": "0.12:00:00",
+								"retry": 0,
+								"retryIntervalInSeconds": 30,
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"notebook": {
+									"referenceName": "py_utils_log_stage",
+									"type": "NotebookReference"
+								},
+								"parameters": {
+									"Stage": {
+										"value": "OnProgress",
+										"type": "string"
+									},
+									"PipelineName": {
+										"value": {
+											"value": "@pipeline().Pipeline",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineRunID": {
+										"value": {
+											"value": "@pipeline().RunId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"Inserts": {
+										"value": "0",
+										"type": "int"
+									},
+									"Updates": {
+										"value": "0",
+										"type": "int"
+									},
+									"Deletes": {
+										"value": "0",
+										"type": "int"
+									},
+									"ErrorMessage": {
+										"value": "",
+										"type": "string"
+									},
+									"StatusMessage": {
+										"value": "Loading relevant reps",
+										"type": "string"
+									},
+									"PipelineTriggerID": {
+										"value": {
+											"value": "@pipeline().TriggerId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggerName": {
+										"value": {
+											"value": "@pipeline().TriggerName",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggerType": {
+										"value": {
+											"value": "@pipeline().TriggerType",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggeredbyPipelineName": {
+										"value": {
+											"value": "@pipeline()?.TriggeredByPipelineName",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggeredbyPipelineRunID": {
+										"value": {
+											"value": "@pipeline()?.TriggeredByPipelineRunId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"ActivityType": {
+										"value": "Pipeline",
+										"type": "string"
+									}
+								},
+								"snapshot": true,
+								"sparkPool": {
+									"referenceName": "pinssynspodw",
+									"type": "BigDataPoolReference"
+								},
+								"conf": {
+									"spark.dynamicAllocation.enabled": true,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
+							}
+						},
+						{
+							"name": "Horizon Relevant reps",
+							"type": "ExecutePipeline",
+							"dependsOn": [
+								{
+									"activity": "Record loading relevant reps data",
+									"dependencyConditions": [
+										"Succeeded"
+									]
+								}
+							],
+							"policy": {
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "pln_horizon_nsip_representation_main",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true
+							}
+						},
+						{
+							"name": "Record completed relevant reps data",
+							"type": "SynapseNotebook",
+							"dependsOn": [
+								{
+									"activity": "Horizon Relevant reps",
+									"dependencyConditions": [
+										"Succeeded"
+									]
+								}
+							],
+							"policy": {
+								"timeout": "0.12:00:00",
+								"retry": 0,
+								"retryIntervalInSeconds": 30,
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"notebook": {
+									"referenceName": "py_utils_log_stage",
+									"type": "NotebookReference"
+								},
+								"parameters": {
+									"Stage": {
+										"value": "Completion",
+										"type": "string"
+									},
+									"PipelineName": {
+										"value": {
+											"value": "@pipeline().Pipeline",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineRunID": {
+										"value": {
+											"value": "@pipeline().RunId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"Inserts": {
+										"value": "0",
+										"type": "int"
+									},
+									"Updates": {
+										"value": "0",
+										"type": "int"
+									},
+									"Deletes": {
+										"value": "0",
+										"type": "int"
+									},
+									"ErrorMessage": {
+										"value": "",
+										"type": "string"
+									},
+									"StatusMessage": {
+										"value": "Loading relevant reps",
+										"type": "string"
+									},
+									"PipelineTriggerID": {
+										"value": {
+											"value": "@pipeline().TriggerId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggerName": {
+										"value": {
+											"value": "@pipeline().TriggerName",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggerType": {
+										"value": {
+											"value": "@pipeline().TriggerType",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggeredbyPipelineName": {
+										"value": {
+											"value": "@pipeline()?.TriggeredByPipelineName",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"PipelineTriggeredbyPipelineRunID": {
+										"value": {
+											"value": "@pipeline()?.TriggeredByPipelineRunId",
+											"type": "Expression"
+										},
+										"type": "string"
+									},
+									"ActivityType": {
+										"value": "Pipeline",
+										"type": "string"
+									}
+								},
+								"snapshot": true,
+								"sparkPool": {
+									"referenceName": "pinssynspodw",
+									"type": "BigDataPoolReference"
+								},
+								"conf": {
+									"spark.dynamicAllocation.enabled": true,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
+							}
+						},
+						{
+							"name": "Send Horizon failed",
+							"type": "ExecutePipeline",
+							"dependsOn": [
+								{
+									"activity": "Horizon Relevant reps",
+									"dependencyConditions": [
+										"Failed"
+									]
+								}
+							],
+							"policy": {
+								"secureInput": true
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "pln_utl_Send_Teams_Message",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"dataFactorySubscription": {
+										"value": "@pipeline().parameters.subscription_id",
+										"type": "Expression"
+									},
+									"dataFactoryResourceGroup": {
+										"value": "@pipeline().parameters.resource_group",
+										"type": "Expression"
+									},
+									"pipelineRunId": {
+										"value": "@pipeline().RunId",
+										"type": "Expression"
+									},
+									"teamsWebhookUrl": {
+										"value": "@pipeline().parameters.webhook_url",
+										"type": "Expression"
+									},
+									"activityName": {
+										"value": "@pipeline().Pipeline",
+										"type": "Expression"
+									},
+									"activityMessage": "Horizon data failed",
+									"activityDuration": {
+										"value": "@concat(string(div(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(pipeline().parameters.start_time,'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'H:', \nstring(mod(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(pipeline().parameters.start_time,'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'M:00s')",
+										"type": "Expression"
+									},
+									"activityStatus": "Failed",
+									"Colour": {
+										"value": "@pipeline().parameters.failed_colour",
+										"type": "Expression"
+									},
+									"Image": {
+										"value": "@pipeline().parameters.failed_image",
+										"type": "Expression"
+									},
+									"Message_title": "ODW - Horizon data failed",
+									"Message_subtitle": "Relevant representation feed failed"
+								}
+							}
+						}
+					]
+				}
+			},
+			{
+				"name": "Random wait to allow parallelism",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_utils_random_sleep",
+						"type": "NotebookReference"
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			}
+		],
+		"parameters": {
+			"webhook_url": {
+				"type": "string"
+			},
+			"subscription_id": {
+				"type": "string"
+			},
+			"resource_group": {
+				"type": "string"
+			},
+			"starting_colour": {
+				"type": "string"
+			},
+			"on_progress_colour": {
+				"type": "string"
+			},
+			"failed_colour": {
+				"type": "string"
+			},
+			"start_time": {
+				"type": "string"
+			},
+			"starting_image": {
+				"type": "string"
+			},
+			"progress_image": {
+				"type": "string"
+			},
+			"warning_image": {
+				"type": "string"
+			},
+			"failed_image": {
+				"type": "string"
+			},
+			"warning_colour": {
+				"type": "string"
+			}
+		},
+		"folder": {
+			"name": "utils/Master"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_horizon_2.json
+++ b/workspace/pipeline/pln_horizon_2.json
@@ -28,11 +28,11 @@
 					},
 					"parameters": {
 						"system_name": {
-							"value": "Horizon",
+							"value": "HR",
 							"type": "string"
 						},
 						"Object": {
-							"value": "Relevant Reps",
+							"value": "Entraid",
 							"type": "string"
 						}
 					},

--- a/workspace/pipeline/pln_horizon_2.json
+++ b/workspace/pipeline/pln_horizon_2.json
@@ -47,7 +47,7 @@
 				}
 			},
 			{
-				"name": "Relevant Reps",
+				"name": "entraid",
 				"type": "IfCondition",
 				"dependsOn": [
 					{
@@ -60,7 +60,7 @@
 				"userProperties": [],
 				"typeProperties": {
 					"expression": {
-						"value": "@equals(activity('Get Relevant Reps config').output.status.Output.result.exitValue, '[True]')",
+						"value": "@equals(activity('Get Entraid config').output.status.Output.result.exitValue, '[True]')",
 						"type": "Expression"
 					},
 					"ifFalseActivities": [
@@ -237,7 +237,7 @@
 					],
 					"ifTrueActivities": [
 						{
-							"name": "Record loading relevant reps data",
+							"name": "Record loading entraid data",
 							"type": "SynapseNotebook",
 							"dependsOn": [],
 							"policy": {
@@ -350,7 +350,7 @@
 							"type": "ExecutePipeline",
 							"dependsOn": [
 								{
-									"activity": "Record loading relevant reps data",
+									"activity": "Record loading entraid data",
 									"dependencyConditions": [
 										"Succeeded"
 									]
@@ -362,7 +362,7 @@
 							"userProperties": [],
 							"typeProperties": {
 								"pipeline": {
-									"referenceName": "pln_horizon_nsip_representation_main",
+									"referenceName": "EntraID",
 									"type": "PipelineReference"
 								},
 								"waitOnCompletion": true

--- a/workspace/pipeline/pln_horizon_2.json
+++ b/workspace/pipeline/pln_horizon_2.json
@@ -369,7 +369,7 @@
 							}
 						},
 						{
-							"name": "Record completed relevant reps data",
+							"name": "Record completed entraid data",
 							"type": "SynapseNotebook",
 							"dependsOn": [
 								{
@@ -485,7 +485,7 @@
 							}
 						},
 						{
-							"name": "Send Horizon failed",
+							"name": "Send HR failed",
 							"type": "ExecutePipeline",
 							"dependsOn": [
 								{

--- a/workspace/pipeline/pln_master.json
+++ b/workspace/pipeline/pln_master.json
@@ -315,6 +315,12 @@
 						"dependencyConditions": [
 							"Succeeded"
 						]
+					},
+					{
+						"activity": "pln_horizon_2",
+						"dependencyConditions": [
+							"Succeeded"
+						]
 					}
 				],
 				"policy": {
@@ -881,6 +887,12 @@
 				"dependsOn": [
 					{
 						"activity": "Load Horizon data",
+						"dependencyConditions": [
+							"Failed"
+						]
+					},
+					{
+						"activity": "pln_horizon_2",
 						"dependencyConditions": [
 							"Failed"
 						]
@@ -1656,6 +1668,12 @@
 						"dependencyConditions": [
 							"Failed"
 						]
+					},
+					{
+						"activity": "pln_horizon_2",
+						"dependencyConditions": [
+							"Failed"
+						]
 					}
 				],
 				"policy": {
@@ -1714,6 +1732,12 @@
 				"dependsOn": [
 					{
 						"activity": "Load Horizon data",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					},
+					{
+						"activity": "pln_horizon_2",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -2188,6 +2212,35 @@
 						"type": "MSI",
 						"resource": "https://vault.azure.net"
 					}
+				}
+			},
+			{
+				"name": "pln_horizon_2",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "Send progressing to Horizon data",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					},
+					{
+						"activity": "Record moving on to loading Horizon data",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_horizon_2",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
 				}
 			}
 		],


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
