### PR TITLE
Feat/odw/mcp 8

### DIFF
--- a/workspace/notebook/appeal_has.json
+++ b/workspace/notebook/appeal_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "11698e10-7ccd-47bb-83cb-c902a1dd538b"
+				"spark.autotune.trackingId": "fa6973de-1268-4217-8d6a-1e27b7e7e069"
 			}
 		},
 		"metadata": {
@@ -163,7 +163,7 @@
 					"from pyspark.sql import SparkSession\r\n",
 					"spark = SparkSession.builder.getOrCreate()\r\n",
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has\")\r\n",
-					"view_df.write.mode(\"overwrite\").option(\"overwriteSchema\", \"true\").format(\"delta\").saveAsTable(\"odw_curated_db.appeal_has\")"
+					"view_df.write.mode(\"overwrite\").format(\"delta\").saveAsTable(\"odw_curated_db.appeal_has\")"
 				],
 				"execution_count": 25
 			}

--- a/workspace/notebook/appeal_has.json
+++ b/workspace/notebook/appeal_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "69b86225-24c1-4658-9a8f-66e8c2c88d79"
+				"spark.autotune.trackingId": "29bd41f0-2c90-4334-96d9-9e8be9b31c19"
 			}
 		},
 		"metadata": {
@@ -102,7 +102,7 @@
 					"AH.lpaStatement                             AS lpaStatement,\n",
 					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
 					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
-					"AH.caseClosedDate                           AS caseClosedDate,\n",
+					"AH.transferredCaseClosedDate                AS transferredCaseClosedDate,\n",
 					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
 					"AH.caseDecisionPublishedDate                AS caseDecisionPublishedDate,\n",
 					"AH.caseDecisionOutcome                      AS caseDecisionOutcome,\n",

--- a/workspace/notebook/appeal_has.json
+++ b/workspace/notebook/appeal_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "16d15606-d877-4153-adb0-3fdfeefbdb79"
+				"spark.autotune.trackingId": "69b86225-24c1-4658-9a8f-66e8c2c88d79"
 			}
 		},
 		"metadata": {
@@ -65,6 +65,7 @@
 					"CREATE OR REPLACE VIEW odw_curated_db.vw_sb_appeal_has\n",
 					"\n",
 					"AS\n",
+					"\n",
 					"\n",
 					"SELECT DISTINCT \n",
 					"CAST(AH.caseId AS INT)                      AS caseId,\n",

--- a/workspace/notebook/appeal_has.json
+++ b/workspace/notebook/appeal_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "29bd41f0-2c90-4334-96d9-9e8be9b31c19"
+				"spark.autotune.trackingId": "11698e10-7ccd-47bb-83cb-c902a1dd538b"
 			}
 		},
 		"metadata": {
@@ -44,8 +44,8 @@
 				},
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
-				"cores": 4,
-				"memory": 28,
+				"cores": 16,
+				"memory": 112,
 				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
@@ -62,7 +62,7 @@
 				"source": [
 					"%%sql\n",
 					"\n",
-					"CREATE OR REPLACE VIEW odw_curated_db.vw_sb_appeal_has\n",
+					"CREATE OR REPLACE VIEW odw_curated_db.vw_appeal_has\n",
 					"\n",
 					"AS\n",
 					"\n",
@@ -160,43 +160,10 @@
 					}
 				},
 				"source": [
-					"spark.sql(f\"drop table if exists odw_curated_db.sb_appeal_has;\")"
-				],
-				"execution_count": 1
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"This table has a column \"transcriptId\" which is set to NULL. The column is in the json schema but is not in any of the source data sets (yet). The spark data type is set to \"void\" as there is no data in the column and this prevents the table being created using SQL create table as delta command. Setting this column to StringType and creating the table using spark instead avoids this issue."
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"from pyspark.sql import SparkSession\r\n",
-					"from pyspark.sql.types import StringType\r\n",
 					"spark = SparkSession.builder.getOrCreate()\r\n",
-					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_sb_appeal_has\")\r\n",
-					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has\")\r\n",
-					"print(\"Table created\")"
+					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has\")\r\n",
+					"view_df.write.mode(\"overwrite\").option(\"overwriteSchema\", \"true\").format(\"delta\").saveAsTable(\"odw_curated_db.appeal_has\")"
 				],
 				"execution_count": 25
 			}

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3092a67c-8f6b-474e-95ef-52bc91c61f0b"
+				"spark.autotune.trackingId": "cf264b50-6614-46b5-b860-8514508208e5"
 			}
 		},
 		"metadata": {
@@ -102,7 +102,7 @@
 					"AH.lpaStatement                             AS lpaStatement,\n",
 					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
 					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
-					"AH.caseClosedDate                           AS caseClosedDate,\n",
+					"AH.transferredCaseClosedDate                AS transferredCaseClosedDate,\n",
 					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
 					"AH.caseDecisionPublishedDate                AS caseDecisionPublishedDate,\n",
 					"AH.caseDecisionOutcome                      AS caseDecisionOutcome,\n",
@@ -147,7 +147,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"--WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 23
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -167,7 +167,7 @@
 					"\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\"\n",
 					")"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -203,7 +203,7 @@
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has_POwerBI\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": 25
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6edfb670-80be-4663-91a1-30d6ff3f2a41"
+				"spark.autotune.trackingId": "b970932c-774e-49ae-a94c-636000db637f"
 			}
 		},
 		"metadata": {
@@ -86,7 +86,7 @@
 					"AH.caseValidationDate                       AS caseValidationDate,\n",
 					"AH.caseValidationOutcome                    AS caseValidationOutcome,\n",
 					"AH.caseValidationInvalidDetails             AS caseValidationInvalidDetails,\n",
-					"AH.caseValidationIncompleteDetails          AS caseValidationIncompleteDetails,\n",
+					"CAST(AH.caseValidationIncompleteDetails AS STRING)         AS caseValidationIncompleteDetails,\n",
 					"AH.caseExtensionDate                        AS caseExtensionDate,\n",
 					"AH.caseStartedDate                          AS caseStartedDate,\n",
 					"AH.casePublishedDate                        AS casePublishedDate,\n",
@@ -98,7 +98,7 @@
 					"AH.lpaQuestionnairePublishedDate            AS lpaQuestionnairePublishedDate,\n",
 					"AH.lpaQuestionnaireValidationOutcome        AS lpaQuestionnaireValidationOutcome,\n",
 					"AH.lpaQuestionnaireValidationOutcomeDate    AS lpaQuestionnaireValidationOutcomeDate,\n",
-					"AH.lpaQuestionnaireValidationDetails        AS lpaQuestionnaireValidationDetails,\n",
+					"CAST(AH.lpaQuestionnaireValidationDetails AS STRING)        AS lpaQuestionnaireValidationDetails,\n",
 					"AH.lpaStatement                             AS lpaStatement,\n",
 					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
 					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
@@ -118,7 +118,7 @@
 					"AH.siteAddressTown                          AS siteAddressTown,\n",
 					"AH.siteAddressCounty                        AS siteAddressCounty,\n",
 					"AH.siteAddressPostcode                      AS siteAddressPostcode,\n",
-					"AH.siteAccessDetails                        AS siteAccessDetails,\n",
+					"CAST(AH.siteAccessDetails AS STRING)                        AS siteAccessDetails,\n",
 					"AH.siteSafetyDetails                        AS siteSafetyDetails,\n",
 					"CAST(AH.siteAreaSquareMetres AS BOOLEAN)    AS siteAreaSquareMetres,\n",
 					"CAST(AH.floorSpaceSquareMetres AS NUMERIC)  AS floorSpaceSquareMetres,\n",
@@ -130,7 +130,7 @@
 					"AH.knowsOtherOwners                         AS knowsOtherOwners,\n",
 					"AH.knowsAllOwners                           AS knowsAllOwners,\n",
 					"CAST(AH.advertisedAppeal AS BOOLEAN)        AS advertisedAppeal,\n",
-					"AH.notificationMethod                       AS notificationMethod,\n",
+					"CAST(AH.notificationMethod AS STRING)                      AS notificationMethod,\n",
 					"CAST(AH.ownersInformed AS BOOLEAN)          AS ownersInformed,\n",
 					"AH.originalDevelopmentDescription           AS originalDevelopmentDescription,\n",
 					"CAST(AH.changedDevelopmentDescription       AS BOOLEAN) AS changedDevelopmentDescription,\n",

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0d047df9-6d45-4b4b-a26a-2ea96bd70ad2"
+				"spark.autotune.trackingId": "d280d15e-193f-43f1-870e-97e5c4104408"
 			}
 		},
 		"metadata": {
@@ -147,7 +147,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"--WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 2
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -163,11 +163,9 @@
 					}
 				},
 				"source": [
-					"spark.sql(f\n",
-					"\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\"\n",
-					")"
+					"spark.sql(f\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\")"
 				],
-				"execution_count": 3
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -203,7 +201,7 @@
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has_POwerBI\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": null
+				"execution_count": 6
 			}
 		]
 	}

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b1f3bc4c-0d71-42c4-8524-9ee108b5e25b"
+				"spark.autotune.trackingId": "3092a67c-8f6b-474e-95ef-52bc91c61f0b"
 			}
 		},
 		"metadata": {
@@ -61,13 +61,13 @@
 				},
 				"source": [
 					"%%sql\n",
-					"\n",
-					"CREATE OR REPLACE VIEW odw_curated_db.vw_sb_appeal_has\n",
-					"\n",
+					" \n",
+					"CREATE OR REPLACE VIEW odw_curated_db.vw_sb_appeal_has_POwerBI\n",
+					" \n",
 					"AS\n",
-					"\n",
-					"\n",
-					"SELECT DISTINCT \n",
+					" \n",
+					" \n",
+					"SELECT DISTINCT\n",
 					"CAST(AH.caseId AS INT)                      AS caseId,\n",
 					"AH.caseReference                            AS caseReference,\n",
 					"AH.caseStatus                               AS caseStatus,\n",
@@ -139,10 +139,13 @@
 					"AH.neighbouringSiteAddresses                AS neighbouringSiteAddresses,\n",
 					"AH.affectedListedBuildingNumbers            AS affectedListedBuildingNumbers,\n",
 					"CAST(AH.appellantCostsAppliedFor AS BOOLEAN) AS appellantCostsAppliedFor,\n",
-					"CAST(AH.lpaCostsAppliedFor AS BOOLEAN)       AS lpaCostsAppliedFor\n",
-					"\n",
+					"CAST(AH.lpaCostsAppliedFor AS BOOLEAN)       AS lpaCostsAppliedFor,\n",
+					"AH.IngestionDate                             AS IngestionDate,\n",
+					"AH.ValidTo                                   AS ValidTo,\n",
+					"AH.IsActive                                  AS IsActive\n",
+					" \n",
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
-					"WHERE AH.IsActive = 'Y'"
+					"--WHERE AH.IsActive = 'Y'"
 				],
 				"execution_count": 23
 			},
@@ -160,7 +163,9 @@
 					}
 				},
 				"source": [
-					"spark.sql(f\"drop table if exists odw_curated_db.sb_appeal_has;\")"
+					"spark.sql(f\n",
+					"\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\"\n",
+					")"
 				],
 				"execution_count": 1
 			},
@@ -194,8 +199,8 @@
 					"from pyspark.sql import SparkSession\r\n",
 					"from pyspark.sql.types import StringType\r\n",
 					"spark = SparkSession.builder.getOrCreate()\r\n",
-					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_sb_appeal_has\")\r\n",
-					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has\")\r\n",
+					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_sb_appeal_has_POwerBI\")\r\n",
+					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has_POwerBI\")\r\n",
 					"print(\"Table created\")"
 				],
 				"execution_count": 25

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d280d15e-193f-43f1-870e-97e5c4104408"
+				"spark.autotune.trackingId": "6edfb670-80be-4663-91a1-30d6ff3f2a41"
 			}
 		},
 		"metadata": {
@@ -136,7 +136,7 @@
 					"CAST(AH.changedDevelopmentDescription       AS BOOLEAN) AS changedDevelopmentDescription,\n",
 					"AH.newConditionDetails                      AS newConditionDetails,\n",
 					"AH.nearbyCaseReferences                     AS nearbyCaseReferences,\n",
-					"AH.neighbouringSiteAddresses                AS neighbouringSiteAddresses,\n",
+					"CAST(AH.neighbouringSiteAddresses AS STRING)               AS neighbouringSiteAddresses,\n",
 					"AH.affectedListedBuildingNumbers            AS affectedListedBuildingNumbers,\n",
 					"CAST(AH.appellantCostsAppliedFor AS BOOLEAN) AS appellantCostsAppliedFor,\n",
 					"CAST(AH.lpaCostsAppliedFor AS BOOLEAN)       AS lpaCostsAppliedFor,\n",
@@ -147,7 +147,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"--WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 4
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -165,7 +165,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\")"
 				],
-				"execution_count": 5
+				"execution_count": 10
 			},
 			{
 				"cell_type": "markdown",
@@ -201,7 +201,31 @@
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has_POwerBI\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": 6
+				"execution_count": 11
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"SELECT * FROM odw_curated_db.sb_appeal_has_POwerBI;"
+				],
+				"execution_count": 12
 			}
 		]
 	}

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b970932c-774e-49ae-a94c-636000db637f"
+				"spark.autotune.trackingId": "1163f98f-9e29-46be-b53f-340a905490f0"
 			}
 		},
 		"metadata": {
@@ -86,7 +86,7 @@
 					"AH.caseValidationDate                       AS caseValidationDate,\n",
 					"AH.caseValidationOutcome                    AS caseValidationOutcome,\n",
 					"AH.caseValidationInvalidDetails             AS caseValidationInvalidDetails,\n",
-					"CAST(AH.caseValidationIncompleteDetails AS STRING)         AS caseValidationIncompleteDetails,\n",
+					"CAST(AH.caseValidationIncompleteDetails AS STRING) AS caseValidationIncompleteDetails,\n",
 					"AH.caseExtensionDate                        AS caseExtensionDate,\n",
 					"AH.caseStartedDate                          AS caseStartedDate,\n",
 					"AH.casePublishedDate                        AS casePublishedDate,\n",
@@ -97,10 +97,10 @@
 					"AH.lpaQuestionnaireCreatedDate              AS lpaQuestionnaireCreatedDate,\n",
 					"AH.lpaQuestionnairePublishedDate            AS lpaQuestionnairePublishedDate,\n",
 					"AH.lpaQuestionnaireValidationOutcome        AS lpaQuestionnaireValidationOutcome,\n",
-					"AH.lpaQuestionnaireValidationOutcomeDate    AS lpaQuestionnaireValidationOutcomeDate,\n",
-					"CAST(AH.lpaQuestionnaireValidationDetails AS STRING)        AS lpaQuestionnaireValidationDetails,\n",
-					"AH.lpaStatement                             AS lpaStatement,\n",
-					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
+					"AH.lpaQuestionnaireValidationOutcomeDate                AS lpaQuestionnaireValidationOutcomeDate,\n",
+					"CAST(AH.lpaQuestionnaireValidationDetails AS STRING)    AS lpaQuestionnaireValidationDetails,\n",
+					"AH.lpaStatement                                         AS lpaStatement,\n",
+					"AH.caseWithdrawnDate                                    AS caseWithdrawnDate,\n",
 					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
 					"AH.transferredCaseClosedDate                AS transferredCaseClosedDate,\n",
 					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
@@ -147,7 +147,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"--WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 9
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -165,7 +165,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\")"
 				],
-				"execution_count": 10
+				"execution_count": 14
 			},
 			{
 				"cell_type": "markdown",
@@ -201,7 +201,7 @@
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has_POwerBI\")\r\n",
 					"print(\"Table created\")"
 				],
-				"execution_count": 11
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -225,7 +225,7 @@
 					"\n",
 					"SELECT * FROM odw_curated_db.sb_appeal_has_POwerBI;"
 				],
-				"execution_count": 12
+				"execution_count": 16
 			}
 		]
 	}

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -1,0 +1,205 @@
+{
+	"name": "appeal_has_PowerBi",
+	"properties": {
+		"folder": {
+			"name": "odw-curated"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "b1f3bc4c-0d71-42c4-8524-9ee108b5e25b"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"CREATE OR REPLACE VIEW odw_curated_db.vw_sb_appeal_has\n",
+					"\n",
+					"AS\n",
+					"\n",
+					"\n",
+					"SELECT DISTINCT \n",
+					"CAST(AH.caseId AS INT)                      AS caseId,\n",
+					"AH.caseReference                            AS caseReference,\n",
+					"AH.caseStatus                               AS caseStatus,\n",
+					"AH.caseType                                 AS caseType,\n",
+					"AH.caseProcedure                            AS caseProcedure,\n",
+					"AH.lpaCode                                  AS lpaCode,\n",
+					"AH.caseOfficerId                            AS caseOfficerId,\n",
+					"AH.inspectorId                              AS inspectorId,\n",
+					"AH.allocationLevel                          AS allocationLevel,\n",
+					"CAST(AH.allocationBand AS NUMERIC)          AS allocationBand,\n",
+					"AH.caseSpecialisms                          AS caseSpecialisms,\n",
+					"AH.caseSubmittedDate                        AS caseSubmittedDate,\n",
+					"AH.caseCreatedDate                          AS caseCreatedDate,\n",
+					"AH.caseUpdatedDate                          AS caseUpdatedDate,\n",
+					"AH.caseValidDate                            AS caseValidDate,\n",
+					"AH.caseValidationDate                       AS caseValidationDate,\n",
+					"AH.caseValidationOutcome                    AS caseValidationOutcome,\n",
+					"AH.caseValidationInvalidDetails             AS caseValidationInvalidDetails,\n",
+					"AH.caseValidationIncompleteDetails          AS caseValidationIncompleteDetails,\n",
+					"AH.caseExtensionDate                        AS caseExtensionDate,\n",
+					"AH.caseStartedDate                          AS caseStartedDate,\n",
+					"AH.casePublishedDate                        AS casePublishedDate,\n",
+					"AH.linkedCaseStatus                         AS linkedCaseStatus,\n",
+					"AH.leadCaseReference                        AS leadCaseReference,\n",
+					"AH.lpaQuestionnaireDueDate                  AS lpaQuestionnaireDueDate,\n",
+					"AH.lpaQuestionnaireSubmittedDate            AS lpaQuestionnaireSubmittedDate,\n",
+					"AH.lpaQuestionnaireCreatedDate              AS lpaQuestionnaireCreatedDate,\n",
+					"AH.lpaQuestionnairePublishedDate            AS lpaQuestionnairePublishedDate,\n",
+					"AH.lpaQuestionnaireValidationOutcome        AS lpaQuestionnaireValidationOutcome,\n",
+					"AH.lpaQuestionnaireValidationOutcomeDate    AS lpaQuestionnaireValidationOutcomeDate,\n",
+					"AH.lpaQuestionnaireValidationDetails        AS lpaQuestionnaireValidationDetails,\n",
+					"AH.lpaStatement                             AS lpaStatement,\n",
+					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
+					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
+					"AH.caseClosedDate                           AS caseClosedDate,\n",
+					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
+					"AH.caseDecisionPublishedDate                AS caseDecisionPublishedDate,\n",
+					"AH.caseDecisionOutcome                      AS caseDecisionOutcome,\n",
+					"AH.caseCompletedDate                        AS caseCompletedDate,\n",
+					"CAST(AH.enforcementNotice AS BOOLEAN)       AS enforcementNotice,\n",
+					"AH.applicationReference                     AS applicationReference,\n",
+					"AH.applicationDate                          AS applicationDate,\n",
+					"AH.applicationDecision                      AS applicationDecision,\n",
+					"AH.applicationDecisionDate                  AS applicationDecisionDate,\n",
+					"AH.caseSubmissionDueDate                    AS caseSubmissionDueDate,\n",
+					"AH.siteAddressLine1                         AS siteAddressLine1,\n",
+					"AH.siteAddressLine2                         AS siteAddressLine2,\n",
+					"AH.siteAddressTown                          AS siteAddressTown,\n",
+					"AH.siteAddressCounty                        AS siteAddressCounty,\n",
+					"AH.siteAddressPostcode                      AS siteAddressPostcode,\n",
+					"AH.siteAccessDetails                        AS siteAccessDetails,\n",
+					"AH.siteSafetyDetails                        AS siteSafetyDetails,\n",
+					"CAST(AH.siteAreaSquareMetres AS BOOLEAN)    AS siteAreaSquareMetres,\n",
+					"CAST(AH.floorSpaceSquareMetres AS NUMERIC)  AS floorSpaceSquareMetres,\n",
+					"CAST(AH.isCorrectAppealType AS BOOLEAN)     AS isCorrectAppealType,\n",
+					"CAST(AH.isGreenBelt AS BOOLEAN)             AS isGreenBelt,\n",
+					"CAST(AH.inConservationArea AS BOOLEAN)      AS inConservationArea,\n",
+					"CAST(AH.ownsAllLand AS BOOLEAN)             AS ownsAllLand,\n",
+					"CAST(AH.ownsSomeLand AS BOOLEAN)            AS ownsSomeLand,\n",
+					"AH.knowsOtherOwners                         AS knowsOtherOwners,\n",
+					"AH.knowsAllOwners                           AS knowsAllOwners,\n",
+					"CAST(AH.advertisedAppeal AS BOOLEAN)        AS advertisedAppeal,\n",
+					"AH.notificationMethod                       AS notificationMethod,\n",
+					"CAST(AH.ownersInformed AS BOOLEAN)          AS ownersInformed,\n",
+					"AH.originalDevelopmentDescription           AS originalDevelopmentDescription,\n",
+					"CAST(AH.changedDevelopmentDescription       AS BOOLEAN) AS changedDevelopmentDescription,\n",
+					"AH.newConditionDetails                      AS newConditionDetails,\n",
+					"AH.nearbyCaseReferences                     AS nearbyCaseReferences,\n",
+					"AH.neighbouringSiteAddresses                AS neighbouringSiteAddresses,\n",
+					"AH.affectedListedBuildingNumbers            AS affectedListedBuildingNumbers,\n",
+					"CAST(AH.appellantCostsAppliedFor AS BOOLEAN) AS appellantCostsAppliedFor,\n",
+					"CAST(AH.lpaCostsAppliedFor AS BOOLEAN)       AS lpaCostsAppliedFor\n",
+					"\n",
+					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
+					"WHERE AH.IsActive = 'Y'"
+				],
+				"execution_count": 23
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"spark.sql(f\"drop table if exists odw_curated_db.sb_appeal_has;\")"
+				],
+				"execution_count": 1
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"This table has a column \"transcriptId\" which is set to NULL. The column is in the json schema but is not in any of the source data sets (yet). The spark data type is set to \"void\" as there is no data in the column and this prevents the table being created using SQL create table as delta command. Setting this column to StringType and creating the table using spark instead avoids this issue."
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"from pyspark.sql import SparkSession\r\n",
+					"from pyspark.sql.types import StringType\r\n",
+					"spark = SparkSession.builder.getOrCreate()\r\n",
+					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_sb_appeal_has\")\r\n",
+					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has\")\r\n",
+					"print(\"Table created\")"
+				],
+				"execution_count": 25
+			}
+		]
+	}
+}

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cf264b50-6614-46b5-b860-8514508208e5"
+				"spark.autotune.trackingId": "0d047df9-6d45-4b4b-a26a-2ea96bd70ad2"
 			}
 		},
 		"metadata": {
@@ -147,7 +147,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"--WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -167,7 +167,7 @@
 					"\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\"\n",
 					")"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4957abcf-2ec4-4991-bc9e-d5dce83d4608"
+				"spark.autotune.trackingId": "db1abfab-835c-4007-babd-17829078f20b"
 			}
 		},
 		"metadata": {
@@ -44,8 +44,8 @@
 				},
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
-				"cores": 4,
-				"memory": 28,
+				"cores": 16,
+				"memory": 112,
 				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
@@ -62,7 +62,7 @@
 				"source": [
 					"%%sql\n",
 					" \n",
-					"CREATE OR REPLACE VIEW odw_curated_db.vw_sb_appeal_has_POwerBI\n",
+					"CREATE OR REPLACE VIEW odw_curated_db.vw_appeal_has_powerbi\n",
 					" \n",
 					"AS\n",
 					" \n",
@@ -163,43 +163,10 @@
 					}
 				},
 				"source": [
-					"spark.sql(f\"drop table if exists odw_curated_db.sb_appeal_has_POwerBI;\")"
-				],
-				"execution_count": 14
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"This table has a column \"transcriptId\" which is set to NULL. The column is in the json schema but is not in any of the source data sets (yet). The spark data type is set to \"void\" as there is no data in the column and this prevents the table being created using SQL create table as delta command. Setting this column to StringType and creating the table using spark instead avoids this issue."
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"from pyspark.sql import SparkSession\r\n",
-					"from pyspark.sql.types import StringType\r\n",
 					"spark = SparkSession.builder.getOrCreate()\r\n",
-					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_sb_appeal_has_POwerBI\")\r\n",
-					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.sb_appeal_has_POwerBI\")\r\n",
-					"print(\"Table created\")"
+					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has_powerbi\")\r\n",
+					"view_df.write.mode(\"overwrite\").format(\"delta\").saveAsTable(\"odw_curated_db.appeal_has_powerbi\")"
 				],
 				"execution_count": 15
 			}

--- a/workspace/notebook/appeal_has_PowerBi.json
+++ b/workspace/notebook/appeal_has_PowerBi.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1163f98f-9e29-46be-b53f-340a905490f0"
+				"spark.autotune.trackingId": "4957abcf-2ec4-4991-bc9e-d5dce83d4608"
 			}
 		},
 		"metadata": {
@@ -202,30 +202,6 @@
 					"print(\"Table created\")"
 				],
 				"execution_count": 15
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"\n",
-					"SELECT * FROM odw_curated_db.sb_appeal_has_POwerBI;"
-				],
-				"execution_count": 16
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
