### PR TITLE
feat(infrastructure): add synpase linked service for graph api

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -214,6 +214,10 @@ synapse_aad_administrator = {
   object_id = "1c996957-30e4-40fe-b0b4-82d40f13c058"
 }
 
+synapse_linked_service_graph = {
+  client_id = "9a76d5d1-3c76-4197-a7a8-af759f63d9ef"
+}
+
 synapse_data_exfiltration_enabled  = false
 synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -215,6 +215,10 @@ synapse_aad_administrator = {
   object_id = "f0e4d89f-3288-48c9-ada9-1227a069c76e"
 }
 
+synapse_linked_service_graph = {
+  client_id = "e43812ea-09c7-422e-9545-6c941d791fa6"
+}
+
 synapse_data_exfiltration_enabled  = false
 synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -215,6 +215,10 @@ synapse_aad_administrator = {
   object_id = "ba5af92f-a1bf-4332-a3c9-613a0a8f1b12"
 }
 
+synapse_linked_service_graph = {
+  client_id = "25093723-7633-4a00-9376-ea7695ba1c46"
+}
+
 synapse_data_exfiltration_enabled  = false
 synapse_sql_administrator_username = "synadmin"
 synapse_role_assignments = {

--- a/infrastructure/modules/synapse-shir/outputs.tf
+++ b/infrastructure/modules/synapse-shir/outputs.tf
@@ -1,0 +1,4 @@
+output "integration_runtime_name" {
+  description = "The name of the integration runtime"
+  value       = azurerm_synapse_integration_runtime_self_hosted.synapse.name
+}

--- a/infrastructure/modules/synapse-workspace-private/graph-api-linked-service.tf
+++ b/infrastructure/modules/synapse-workspace-private/graph-api-linked-service.tf
@@ -1,0 +1,38 @@
+resource "azurerm_synapse_linked_service" "graph_api" {
+  name                 = "ls_ms_graph"
+  synapse_workspace_id = azurerm_synapse_workspace.synapse.id
+  type                 = "RestService"
+  type_properties_json = <<JSON
+{
+    "authenticationType": "AadServicePrincipal",
+    "clientId": "${var.synapse_linked_service_graph.client_id}",
+    "clientSecret": "${local.graph_api_client_secret_reference}",
+    "resource": "https://graph.microsoft.com",
+    "tenant": "${var.tenant_id}",
+    "url": "https://graph.microsoft.com/v1.0"
+}
+JSON
+
+  integration_runtime {
+    name = var.synapse_integration_runtime_name
+  }
+}
+
+resource "azurerm_key_vault_secret" "graph_api_client_secret" {
+  content_type    = "text/plain"
+  key_vault_id    = var.key_vault_id
+  name            = "synapse-graph-client-secret"
+  value           = "to-replace"
+  expiration_date = timeadd(timestamp(), "1h")
+
+  lifecycle {
+    ignore_changes = [
+      expiration_date,
+      value
+    ]
+  }
+}
+
+locals {
+  graph_api_client_secret_reference = "@Microsoft.KeyVault(https://${var.key_vault_name}.vault.azure.net/secrets/${azurerm_key_vault_secret.graph_api_client_secret.name}/)"
+}

--- a/infrastructure/modules/synapse-workspace-private/variables.tf
+++ b/infrastructure/modules/synapse-workspace-private/variables.tf
@@ -159,6 +159,18 @@ variable "synapse_data_exfiltration_enabled" {
   type        = bool
 }
 
+variable "synapse_integration_runtime_name" {
+  description = "The name of the integration runtime"
+  type        = string
+}
+
+variable "synapse_linked_service_graph" {
+  description = "Configuration for the graph linked service"
+  type = object({
+    client_id = string
+  })
+}
+
 variable "synapse_private_endpoint_dns_zone_id" {
   description = "The ID of the Private DNS Zone hosting privatelink.azuresynapse.net"
   type        = string

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -473,6 +473,13 @@ variable "synapse_data_exfiltration_enabled" {
   type        = bool
 }
 
+variable "synapse_linked_service_graph" {
+  description = "Configuration for the graph linked service"
+  type = object({
+    client_id = string
+  })
+}
+
 variable "synapse_role_assignments" {
   default     = {}
   description = "An object mapping RBAC roles to principal IDs for the Synapse Workspace"

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -31,6 +31,8 @@ module "synapse_workspace_private" {
   sql_pool_sku_name                     = var.sql_pool_sku_name
   synapse_aad_administrator             = var.synapse_aad_administrator
   synapse_data_exfiltration_enabled     = var.synapse_data_exfiltration_enabled
+  synapse_linked_service_graph          = var.synapse_linked_service_graph
+  synapse_integration_runtime_name      = module.synapse_shir.integration_runtime_name
   synapse_private_endpoint_dns_zone_id  = azurerm_private_dns_zone.synapse.id
   synapse_private_endpoint_subnet_name  = local.synapse_subnet_name
   synapse_private_endpoint_vnet_subnets = module.synapse_network.vnet_subnets
@@ -76,6 +78,8 @@ module "synapse_workspace_private_failover" {
   sql_pool_sku_name                     = var.sql_pool_sku_name
   synapse_aad_administrator             = var.synapse_aad_administrator
   synapse_data_exfiltration_enabled     = var.synapse_data_exfiltration_enabled
+  synapse_integration_runtime_name      = module.synapse_shir_failover[0].integration_runtime_name
+  synapse_linked_service_graph          = var.synapse_linked_service_graph
   synapse_private_endpoint_dns_zone_id  = azurerm_private_dns_zone.synapse.id
   synapse_private_endpoint_subnet_name  = local.synapse_subnet_name
   synapse_private_endpoint_vnet_subnets = module.synapse_network_failover.vnet_subnets


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
