### PR TITLE
Hotfix/deployment errors

### DIFF
--- a/workspace/notebook/py_reload_from_raw_nsip_project.json
+++ b/workspace/notebook/py_reload_from_raw_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "568d306c-a372-42ed-bcc2-f0fe94293819"
+				"spark.autotune.trackingId": "8bdcd603-8ac2-49b3-a660-557a588294b2"
 			}
 		},
 		"metadata": {
@@ -256,8 +256,17 @@
 				"source": [
 					"def create_valid_dataframe() -> DataFrame:\r\n",
 					"    df: DataFrame = collect_all_raw_sb_data_historic(f\"{entity_name}\")\r\n",
-					"    # drop corrupt records loaded with bad files and any test columns created during testing\r\n",
-					"    valid_df: DataFrame = df.filter(col(\"_corrupt_record\").isNull()).drop(\"_corrupt_record\", \"baddata\", \"interestedpartyids\", \"applicantIds\", \"ProjectStatus\")\r\n",
+					"\r\n",
+					"    # compare the df with the table created from the data model schema\r\n",
+					"    in_current_not_in_existing, in_existing_not_in_current = compare_schema_fields_only(df.schema, spark.table(raw_table_name).schema)\r\n",
+					"    in_current_not_in_existing.discard('input_file')\r\n",
+					"\r\n",
+					"    # drop corrupt records loaded with bad files and any columns not present in the data model\r\n",
+					"    if '_corrupt_record' in df.columns:\r\n",
+					"        valid_df: DataFrame =  df.filter(col(\"_corrupt_record\").isNull()).drop(*in_current_not_in_existing)\r\n",
+					"    else:\r\n",
+					"        valid_df: DataFrame =  df.drop(*in_current_not_in_existing)\r\n",
+					"    \r\n",
 					"    return valid_df"
 				],
 				"execution_count": 138

--- a/workspace/notebook/py_util_partition_document_metadata.json
+++ b/workspace/notebook/py_util_partition_document_metadata.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "80660055-b20d-4de7-9598-9746c00001b9"
+				"spark.autotune.trackingId": "e616285e-2766-4c35-8b05-a7c600ce3182"
 			}
 		},
 		"metadata": {
@@ -154,7 +154,7 @@
 					"collapsed": false
 				},
 				"source": [
-					"existing_df = spark.sql(\"SELECT TOP 0 * FROM odw_harmonised_db.document_meta_data\")\r\n",
+					"existing_df = spark.sql(\"SELECT * FROM odw_harmonised_db.document_meta_data\")\r\n",
 					"updated_df = existing_df.withColumn(\"year\", year(existing_df[\"CreateDate\"]))\r\n",
 					"\r\n",
 					"table = 'odw_harmonised_db.document_meta_data_partitioned'\r\n",

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,32 +3,9 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "971 - Logging and monitoring",
-				"type": "ExecutePipeline",
-				"dependsOn": [],
-				"policy": {
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"pipeline": {
-						"referenceName": "rel_971_logging_monitoring",
-						"type": "PipelineReference"
-					},
-					"waitOnCompletion": true
-				}
-			},
-			{
 				"name": "1151 - appeals events",
 				"type": "ExecutePipeline",
-				"dependsOn": [
-					{
-						"activity": "971 - Logging and monitoring",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
+				"dependsOn": [],
 				"policy": {
 					"secureInput": false
 				},
@@ -42,34 +19,11 @@
 				}
 			},
 			{
-				"name": "1262 - Entra id",
-				"type": "ExecutePipeline",
-				"dependsOn": [
-					{
-						"activity": "1151 - appeals events",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"pipeline": {
-						"referenceName": "rel_1262_entra_id",
-						"type": "PipelineReference"
-					},
-					"waitOnCompletion": true
-				}
-			},
-			{
 				"name": "1269 - Document metadata",
 				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
-						"activity": "1262 - Entra id",
+						"activity": "1151 - appeals events",
 						"dependencyConditions": [
 							"Succeeded"
 						]

--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,27 +3,11 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "1151 - appeals events",
-				"type": "ExecutePipeline",
-				"dependsOn": [],
-				"policy": {
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"pipeline": {
-						"referenceName": "rel_1151_appeals_events",
-						"type": "PipelineReference"
-					},
-					"waitOnCompletion": true
-				}
-			},
-			{
 				"name": "1269 - Document metadata",
 				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
-						"activity": "1151 - appeals events",
+						"activity": "rel_1151_appeals_events",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -65,7 +49,7 @@
 				}
 			},
 			{
-				"name": "1296 - Appeals metadata",
+				"name": "1298 - Relevant representation",
 				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
@@ -81,30 +65,23 @@
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "rel_1296_appeals_metadata",
+						"referenceName": "rel_1298_relevant_representation",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true
 				}
 			},
 			{
-				"name": "1298 - Relevant representation",
+				"name": "rel_1151_appeals_events",
 				"type": "ExecutePipeline",
-				"dependsOn": [
-					{
-						"activity": "1296 - Appeals metadata",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
+				"dependsOn": [],
 				"policy": {
 					"secureInput": false
 				},
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "rel_1298_relevant_representation",
+						"referenceName": "rel_1151_appeals_events",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true

--- a/workspace/pipeline/rel_1151_appeals_events.json
+++ b/workspace/pipeline/rel_1151_appeals_events.json
@@ -30,7 +30,13 @@
 							"type": "string"
 						}
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			},
 			{
@@ -60,7 +66,13 @@
 							"type": "string"
 						}
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			},
 			{
@@ -90,7 +102,13 @@
 							"type": "string"
 						}
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			},
 			{
@@ -121,6 +139,10 @@
 				},
 				"userProperties": [],
 				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_horizon_Appeals_Event",
+						"type": "PipelineReference"
+					},
 					"waitOnCompletion": true
 				}
 			}

--- a/workspace/pipeline/rel_1273_s51.json
+++ b/workspace/pipeline/rel_1273_s51.json
@@ -131,7 +131,7 @@
 			}
 		],
 		"folder": {
-			"name": "Releases/1.1.1"
+			"name": "Releases/1.1.2"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/rel_1296_appeals_metadata.json
+++ b/workspace/pipeline/rel_1296_appeals_metadata.json
@@ -20,7 +20,7 @@
 			}
 		],
 		"folder": {
-			"name": "Releases/1.1.1"
+			"name": "Releases/1.1.2"
 		},
 		"annotations": []
 	}

--- a/workspace/pipeline/rel_1298_relevant_representation.json
+++ b/workspace/pipeline/rel_1298_relevant_representation.json
@@ -19,7 +19,13 @@
 						"referenceName": "py_reload_from_raw_nsip_representation",
 						"type": "NotebookReference"
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			},
 			{
@@ -31,6 +37,10 @@
 				},
 				"userProperties": [],
 				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_horizon_nsip_representation_main",
+						"type": "PipelineReference"
+					},
 					"waitOnCompletion": true
 				}
 			},
@@ -64,7 +74,13 @@
 						"referenceName": "py_sb_horizon_harmonised_nsip_representation",
 						"type": "NotebookReference"
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			},
 			{


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
