### PR TITLE
Pd/fix/appeal has curated

### DIFF
--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d926fba2-4f02-44d8-affc-5c7b0ca90e72"
+				"spark.autotune.trackingId": "a6c4b2e2-1004-4e30-8bc0-43dbec18bbac"
 			}
 		},
 		"metadata": {
@@ -143,7 +143,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 23
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -164,7 +164,25 @@
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has\")\r\n",
 					"view_df.write.mode(\"overwrite\").format(\"delta\").saveAsTable(\"odw_curated_db.appeal_has\")"
 				],
-				"execution_count": 25
+				"execution_count": 7
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# spark.sql(f\"drop table if exists odw_curated_db.appeal_has;\")"
+				],
+				"execution_count": 6
 			}
 		]
 	}

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c02aaa54-7ad5-405b-8db4-8d0d4fa199f1"
+				"spark.autotune.trackingId": "d926fba2-4f02-44d8-affc-5c7b0ca90e72"
 			}
 		},
 		"metadata": {
@@ -44,8 +44,8 @@
 				},
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
-				"cores": 16,
-				"memory": 112,
+				"cores": 4,
+				"memory": 28,
 				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
@@ -101,7 +101,7 @@
 					"AH.lpaStatement                             AS lpaStatement,\n",
 					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
 					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
-					"AH.caseClosedDate                           AS caseClosedDate,\n",
+					"AH.transferredCaseClosedDate                           AS caseClosedDate,\n",
 					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
 					"AH.caseDecisionPublishedDate                AS caseDecisionPublishedDate,\n",
 					"AH.caseDecisionOutcome                      AS caseDecisionOutcome,\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
