### PR TITLE
Fix/non delta tables curated

### DIFF
--- a/workspace/notebook/appeals_event.json
+++ b/workspace/notebook/appeals_event.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a5d596f9-8e14-458f-8e6a-c573e50c295c"
+				"spark.autotune.trackingId": "968ed070-8832-48bd-a900-13700cf38583"
 			}
 		},
 		"metadata": {
@@ -223,7 +223,7 @@
 				"source": [
 					"if not spark.catalog.tableExists('appeals_event', dbName='odw_curated_db'):\r\n",
 					"    df = spark.sql(\"SELECT * FROM vw_Appeals_Event_Input LIMIT 0\")\r\n",
-					"    df.write.mode(\"Overwrite\").format(\"delta\").partitionBy(\"IsActive\").saveAsTable(\"odw_curated_db.appeals_event\")"
+					"    df.write.mode(\"Overwrite\").partitionBy(\"IsActive\").saveAsTable(\"odw_curated_db.appeals_event\")"
 				],
 				"execution_count": 5
 			},

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c02aaa54-7ad5-405b-8db4-8d0d4fa199f1"
+				"spark.autotune.trackingId": "2f3ce742-6226-43ab-bf1a-a9b6418a6869"
 			}
 		},
 		"metadata": {
@@ -44,8 +44,8 @@
 				},
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
-				"cores": 16,
-				"memory": 112,
+				"cores": 4,
+				"memory": 28,
 				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
@@ -162,7 +162,7 @@
 					"from pyspark.sql import SparkSession\r\n",
 					"spark = SparkSession.builder.getOrCreate()\r\n",
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has\")\r\n",
-					"view_df.write.mode(\"overwrite\").format(\"delta\").saveAsTable(\"odw_curated_db.appeal_has\")"
+					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_has\")"
 				],
 				"execution_count": 25
 			}

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0e61181f-329a-4890-a1ac-0da99aaffbf7"
+				"spark.autotune.trackingId": "934733a4-dde1-4b71-a89e-896b4c727cdf"
 			}
 		},
 		"metadata": {
@@ -165,7 +165,7 @@
 					"from pyspark.sql import SparkSession\n",
 					"spark = SparkSession.builder.getOrCreate()\n",
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_s51_advice')\n",
-					"view_df.write.mode(\"overwrite\").format(\"delta\").saveAsTable('odw_curated_db.nsip_s51_advice')"
+					"view_df.write.mode(\"overwrite\").saveAsTable('odw_curated_db.nsip_s51_advice')"
 				],
 				"execution_count": 7
 			}

--- a/workspace/notebook/py_unit_tests_nsip_s51_advice.json
+++ b/workspace/notebook/py_unit_tests_nsip_s51_advice.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "83c280aa-c14c-441f-ae0e-44a1ceb1b78f"
+				"spark.autotune.trackingId": "34df4145-218c-4a07-8497-14639e3db4ca"
 			}
 		},
 		"metadata": {
@@ -891,24 +891,6 @@
 					"select * from odw_harmonised_db.sb_s51_advice where adviceId = 25680508;\n",
 					"select * from odw_harmonised_db.nsip_s51_advice where adviceId = 25680508;\n",
 					"select * from odw_curated_db.nsip_s51_advice where adviceId = 25680508;"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run utils/data-validation/py_utils_curated_validate_nsip_s51_advice"
 				],
 				"execution_count": null
 			}

--- a/workspace/pipeline/rel_1273_s51.json
+++ b/workspace/pipeline/rel_1273_s51.json
@@ -212,7 +212,13 @@
 						"referenceName": "py_sb_horizon_harmonised_nsip_s51_advice",
 						"type": "NotebookReference"
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			},
 			{
@@ -239,7 +245,13 @@
 						"referenceName": "nsip_s51_advice",
 						"type": "NotebookReference"
 					},
-					"snapshot": true
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
 				}
 			},
 			{
@@ -264,6 +276,39 @@
 				"typeProperties": {
 					"notebook": {
 						"referenceName": "py_unit_tests_nsip_s51_advice",
+						"type": "NotebookReference"
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "py_utils_curated_validate_nsip_s51_advice",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "py_unit_tests_nsip_s51_advice",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_utils_curated_validate_nsip_s51_advice",
 						"type": "NotebookReference"
 					},
 					"snapshot": true


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
