### PR TITLE
Updating notebook: py_sb_reload_from_raw_storage

### DIFF
--- a/workspace/notebook/py_sb_reload_from_raw_storage.json
+++ b/workspace/notebook/py_sb_reload_from_raw_storage.json
@@ -11,16 +11,16 @@
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {
-			"driverMemory": "112g",
-			"driverCores": 16,
-			"executorMemory": "112g",
-			"executorCores": 16,
-			"numExecutors": 2,
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 155,
 			"conf": {
 				"spark.dynamicAllocation.enabled": "false",
-				"spark.dynamicAllocation.minExecutors": "2",
-				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "005d009c-f5b2-4ce1-91f4-4a59b3a35d47"
+				"spark.dynamicAllocation.minExecutors": "155",
+				"spark.dynamicAllocation.maxExecutors": "155",
+				"spark.autotune.trackingId": "825d59c4-0478-449a-bd43-be7612e4bb25"
 			}
 		},
 		"metadata": {
@@ -44,8 +44,8 @@
 				},
 				"sparkVersion": "3.3",
 				"nodeCount": 3,
-				"cores": 16,
-				"memory": 112,
+				"cores": 64,
+				"memory": 400,
 				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30


### PR DESCRIPTION
Reducing spark config resource request for reload notebook. Temporarily increased this to speed up reloads but for cost reasons this needs reducing back to small.