### PR TITLE
Fix/data validation notebooks s51 and rel reps

### DIFF
--- a/workspace/notebook/py_utils_curated_validate_nsip_representation.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "447ada7c-b0ef-47c2-a858-d2ffae9bc43e"
+				"spark.autotune.trackingId": "68710bfc-f328-477a-b0fb-e8f161490b35"
 			}
 		},
 		"metadata": {
@@ -136,7 +136,7 @@
 					}
 				},
 				"source": [
-					"#### Import validation funcitons notebook"
+					"#### Function to validate a list of rows of data."
 				]
 			},
 			{
@@ -153,7 +153,42 @@
 					}
 				},
 				"source": [
-					"%run utils/data-validation/py_utils_curated_validate_functions"
+					"def validate_data(data: list, schema: dict, primary_key: str) -> str:\n",
+					"\n",
+					"    \"\"\"\n",
+					"    Function to validate a list of rows of data.\n",
+					"    Validation includes a format check against ISO-8601.\n",
+					"\n",
+					"    Args:\n",
+					"        data: list\n",
+					"        schema: dictionary\n",
+					"        primary_key: string\n",
+					"\n",
+					"    Returns:\n",
+					"        success: string\n",
+					"        \"Success\" or \"Failed\" for the result of the validation\n",
+					"    \"\"\"\n",
+					"    \n",
+					"    format_checker = FormatChecker()\n",
+					"    format_checker.checks(\"date-time\")(is_iso8601_date_time)\n",
+					"    validator = Draft202012Validator(schema, format_checker=format_checker)\n",
+					"\n",
+					"    success = \"Success\"\n",
+					"\n",
+					"    for index, row in enumerate(data, start=1):\n",
+					"        errors = list(validator.iter_errors(row))\n",
+					"        if errors:\n",
+					"            success = \"Failed\"\n",
+					"            print(f\"{len(errors)} error(s) found in row {index}\")\n",
+					"            key_value = row.get(primary_key)\n",
+					"            print(f\"{primary_key}: {key_value}\")\n",
+					"            for error in errors:\n",
+					"                print(error.message)\n",
+					"                print(\"-\"*100)\n",
+					"            print(\"#\"*100)\n",
+					"            print(\"#\"*100)\n",
+					"\n",
+					"    return success"
 				],
 				"execution_count": 14
 			},

--- a/workspace/notebook/py_utils_curated_validate_nsip_s51_advice.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_s51_advice.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bad888e2-447c-47a1-b199-bbc60da86b3d"
+				"spark.autotune.trackingId": "374845ff-394f-46ba-8d1b-e87543c81dec"
 			}
 		},
 		"metadata": {
@@ -136,7 +136,7 @@
 					}
 				},
 				"source": [
-					"#### Import validation functions notebook"
+					"#### Function to validate a list of rows of data."
 				]
 			},
 			{
@@ -153,7 +153,42 @@
 					}
 				},
 				"source": [
-					"%run utils/data-validation/py_utils_curated_validate_functions"
+					"def validate_data(data: list, schema: dict, primary_key: str) -> str:\n",
+					"\n",
+					"    \"\"\"\n",
+					"    Function to validate a list of rows of data.\n",
+					"    Validation includes a format check against ISO-8601.\n",
+					"\n",
+					"    Args:\n",
+					"        data: list\n",
+					"        schema: dictionary\n",
+					"        primary_key: string\n",
+					"\n",
+					"    Returns:\n",
+					"        success: string\n",
+					"        \"Success\" or \"Failed\" for the result of the validation\n",
+					"    \"\"\"\n",
+					"    \n",
+					"    format_checker = FormatChecker()\n",
+					"    format_checker.checks(\"date-time\")(is_iso8601_date_time)\n",
+					"    validator = Draft202012Validator(schema, format_checker=format_checker)\n",
+					"\n",
+					"    success = \"Success\"\n",
+					"\n",
+					"    for index, row in enumerate(data, start=1):\n",
+					"        errors = list(validator.iter_errors(row))\n",
+					"        if errors:\n",
+					"            success = \"Failed\"\n",
+					"            print(f\"{len(errors)} error(s) found in row {index}\")\n",
+					"            key_value = row.get(primary_key)\n",
+					"            print(f\"{primary_key}: {key_value}\")\n",
+					"            for error in errors:\n",
+					"                print(error.message)\n",
+					"                print(\"-\"*100)\n",
+					"            print(\"#\"*100)\n",
+					"            print(\"#\"*100)\n",
+					"\n",
+					"    return success"
 				],
 				"execution_count": 140
 			},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
