### PR TITLE
Updating notebook: py_spark_df_ingestion_functions

### DIFF
--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2ae5c3d1-096b-45e4-ad47-3c3419513616"
+				"spark.autotune.trackingId": "37c3deea-f29b-4579-ba45-375c49970082"
 			}
 		},
 		"metadata": {
@@ -92,7 +92,7 @@
 					"    from notebookutils import mssparkutils\n",
 					"\n",
 					"    # Write the DataFrame with the new column to a new temporary table\n",
-					"    temp_table_name: str = 'temporary_table'\n",
+					"    temp_table_name: str = f\"{table_name}_tmp\"\n",
 					"    df.write.mode(\"overwrite\").format(\"delta\").saveAsTable(f\"{db_name}.{temp_table_name}\")\n",
 					"\n",
 					"    # Drop the original table\n",


### PR DESCRIPTION
Fix hard coded temp table name that was causing parallel loads to fail