### PR TITLE
Feat/odw/mcp 59

### DIFF
--- a/workspace/dataset/AzureSqlTableMiPinsDev.json
+++ b/workspace/dataset/AzureSqlTableMiPinsDev.json
@@ -10,7 +10,7 @@
 		"schema": [],
 		"typeProperties": {
 			"schema": "load",
-			"table": "appeals_has_curated_mipins"
+			"table": "appeal_event_curated_mipins"
 		}
 	}
 }

--- a/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
+++ b/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
@@ -3,7 +3,10 @@
 	"properties": {
 		"linkedServiceName": {
 			"referenceName": "ls_ssql_builtin",
-			"type": "LinkedServiceReference"
+			"type": "LinkedServiceReference",
+			"parameters": {
+				"db_name": "odw_curated_db"
+			}
 		},
 		"annotations": [],
 		"type": "AzureSqlTable",

--- a/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
+++ b/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
@@ -2,8 +2,11 @@
 	"name": "appeal_event_curated_mipins_sourceconn",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "Mipins_Dev",
-			"type": "LinkedServiceReference"
+			"referenceName": "ls_ssql_builtin",
+			"type": "LinkedServiceReference",
+			"parameters": {
+				"db_name": "odw_curated_db"
+			}
 		},
 		"annotations": [],
 		"type": "AzureSqlTable",
@@ -101,7 +104,7 @@
 			}
 		],
 		"typeProperties": {
-			"schema": "Load",
+			"schema": "dbo",
 			"table": "appeal_event_curated_mipins"
 		}
 	}

--- a/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
+++ b/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
@@ -2,8 +2,11 @@
 	"name": "appeal_event_curated_mipins_sourceconn",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_sql_mipins_dev",
-			"type": "LinkedServiceReference"
+			"referenceName": "ls_ssql_builtin",
+			"type": "LinkedServiceReference",
+			"parameters": {
+				"db_name": "odw_curated_db"
+			}
 		},
 		"annotations": [],
 		"type": "AzureSqlTable",
@@ -101,7 +104,7 @@
 			}
 		],
 		"typeProperties": {
-			"schema": "Load",
+			"schema": "dbo",
 			"table": "appeal_event_curated_mipins"
 		}
 	}

--- a/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
+++ b/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
@@ -2,11 +2,8 @@
 	"name": "appeal_event_curated_mipins_sourceconn",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_ssql_builtin",
-			"type": "LinkedServiceReference",
-			"parameters": {
-				"db_name": "odw_curated_db"
-			}
+			"referenceName": "ls_sql_mipins_dev",
+			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
 		"type": "AzureSqlTable",
@@ -104,7 +101,7 @@
 			}
 		],
 		"typeProperties": {
-			"schema": "dbo",
+			"schema": "Load",
 			"table": "appeal_event_curated_mipins"
 		}
 	}

--- a/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
+++ b/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
@@ -1,0 +1,108 @@
+{
+	"name": "appeal_event_curated_mipins_sourceconn",
+	"properties": {
+		"linkedServiceName": {
+			"referenceName": "ls_ssql_builtin",
+			"type": "LinkedServiceReference"
+		},
+		"annotations": [],
+		"type": "AzureSqlTable",
+		"schema": [
+			{
+				"name": "eventId",
+				"type": "nvarchar"
+			},
+			{
+				"name": "caseReference",
+				"type": "nvarchar"
+			},
+			{
+				"name": "eventType",
+				"type": "nvarchar"
+			},
+			{
+				"name": "eventName",
+				"type": "nvarchar"
+			},
+			{
+				"name": "eventStatus",
+				"type": "nvarchar"
+			},
+			{
+				"name": "isUrgent",
+				"type": "bit"
+			},
+			{
+				"name": "eventPublished",
+				"type": "bit"
+			},
+			{
+				"name": "eventStartDateTime",
+				"type": "datetime2",
+				"scale": 7
+			},
+			{
+				"name": "eventEndDateTime",
+				"type": "datetime2",
+				"scale": 7
+			},
+			{
+				"name": "NotificationOfSiteVisit",
+				"type": "datetime2",
+				"scale": 7
+			},
+			{
+				"name": "addressLine1",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressLine2",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressTown",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressCounty",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressPostcode",
+				"type": "nvarchar"
+			},
+			{
+				"name": "Migrated",
+				"type": "nvarchar"
+			},
+			{
+				"name": "ODTSourceSystem",
+				"type": "nvarchar"
+			},
+			{
+				"name": "SourceSystemID",
+				"type": "nvarchar"
+			},
+			{
+				"name": "IngestionDate",
+				"type": "nvarchar"
+			},
+			{
+				"name": "ValidTo",
+				"type": "nvarchar"
+			},
+			{
+				"name": "RowID",
+				"type": "nvarchar"
+			},
+			{
+				"name": "IsActive",
+				"type": "nvarchar"
+			}
+		],
+		"typeProperties": {
+			"schema": "dbo",
+			"table": "appeal_event_curated_mipins"
+		}
+	}
+}

--- a/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
+++ b/workspace/dataset/appeal_event_curated_mipins_sourceconn.json
@@ -2,11 +2,8 @@
 	"name": "appeal_event_curated_mipins_sourceconn",
 	"properties": {
 		"linkedServiceName": {
-			"referenceName": "ls_ssql_builtin",
-			"type": "LinkedServiceReference",
-			"parameters": {
-				"db_name": "odw_curated_db"
-			}
+			"referenceName": "Mipins_Dev",
+			"type": "LinkedServiceReference"
 		},
 		"annotations": [],
 		"type": "AzureSqlTable",
@@ -104,7 +101,7 @@
 			}
 		],
 		"typeProperties": {
-			"schema": "dbo",
+			"schema": "Load",
 			"table": "appeal_event_curated_mipins"
 		}
 	}

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "622cdd38-ba3b-4916-a0d7-59e97d9c9f24"
+				"spark.autotune.trackingId": "61e51462-eb20-46e4-8335-b1db557a08e4"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 				},
 				"source": [
 					"%%sql\n",
-					"CREATE OR REPLACE TEMPORARY VIEW vw_Appeal_event_curated_mipins \n",
+					"CREATE OR REPLACE  VIEW vw_Appeal_event_curated_mipins \n",
 					"AS\n",
 					"SELECT\n",
 					"    eventId\n",
@@ -88,10 +88,35 @@
 					"    ,addressTown\n",
 					"    ,addressCounty\n",
 					"    ,addressPostcode\n",
+					"    ,Migrated\n",
+					"    ,ODTSourceSystem\n",
+					"    ,SourceSystemID\n",
+					"    ,IngestionDate\n",
+					"    ,ValidTo\n",
+					"    ,RowID\n",
+					"    ,IsActive\n",
 					"FROM\n",
 					"    odw_harmonised_db.sb_appeal_event"
 				],
-				"execution_count": 1
+				"execution_count": 9
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"spark.sql(f\"drop table if exists odw_curated_db.appeal_event_curated_mipins;\")"
+				],
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -125,13 +150,40 @@
 					"                    ,addressTown\n",
 					"                    ,addressCounty\n",
 					"                    ,addressPostcode\n",
+					"                    ,Migrated\n",
+					"                    ,ODTSourceSystem\n",
+					"                    ,SourceSystemID\n",
+					"                    ,IngestionDate\n",
+					"                    ,ValidTo\n",
+					"                    ,RowID\n",
+					"                    ,IsActive\n",
 					"                FROM\n",
 					"                    vw_Appeal_event_curated_mipins\n",
 					"            \"\"\")\n",
 					"\n",
 					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
 				],
-				"execution_count": 6
+				"execution_count": 11
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"#%%sql\n",
+					"#select * from odw_curated_db.appeal_event_curated_mipins"
+				],
+				"execution_count": 12
 			}
 		]
 	}

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -1,0 +1,138 @@
+{
+	"name": "appeal_event_curated_mipins",
+	"properties": {
+		"folder": {
+			"name": "odw-curated"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "622cdd38-ba3b-4916-a0d7-59e97d9c9f24"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"CREATE OR REPLACE TEMPORARY VIEW vw_Appeal_event_curated_mipins \n",
+					"AS\n",
+					"SELECT\n",
+					"    eventId\n",
+					"    ,caseReference\n",
+					"    ,eventType\n",
+					"    ,eventName\n",
+					"    ,eventStatus\n",
+					"    ,CAST(IsUrgent AS Boolean) AS IsUrgent\n",
+					"    ,CAST(eventPublished AS Boolean) AS eventPublished\n",
+					"    ,CAST(eventStartDateTime AS Timestamp) AS eventStartDateTime\n",
+					"    ,CAST(eventEndDateTime AS Timestamp)  AS eventEndDateTime\n",
+					"    ,CAST(NotificationOfSiteVisit AS Timestamp) AS NotificationOfSiteVisit\n",
+					"    ,addressLine1\n",
+					"    ,addressLine2\n",
+					"    ,addressTown\n",
+					"    ,addressCounty\n",
+					"    ,addressPostcode\n",
+					"FROM\n",
+					"    odw_harmonised_db.sb_appeal_event"
+				],
+				"execution_count": 1
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"df = spark.sql(\"\"\"\n",
+					"                SELECT\n",
+					"                    eventId\n",
+					"                    ,caseReference\n",
+					"                    ,eventType\n",
+					"                    ,eventName\n",
+					"                    ,eventStatus\n",
+					"                    ,isUrgent\n",
+					"                    ,eventPublished\n",
+					"                    ,eventStartDateTime\n",
+					"                    ,eventEndDateTime\n",
+					"                    ,NotificationOfSiteVisit\n",
+					"                    ,addressLine1\n",
+					"                    ,addressLine2\n",
+					"                    ,addressTown\n",
+					"                    ,addressCounty\n",
+					"                    ,addressPostcode\n",
+					"                FROM\n",
+					"                    vw_Appeal_event_curated_mipins\n",
+					"            \"\"\")\n",
+					"\n",
+					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
+				],
+				"execution_count": 6
+			}
+		]
+	}
+}

--- a/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
@@ -22,6 +22,7 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
+						"preCopyScript": "drop table load.appeal_event_curated_mipins",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",

--- a/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
@@ -1,0 +1,60 @@
+{
+	"name": "pln_copy_appeal_event_curated_mipins",
+	"properties": {
+		"activities": [
+			{
+				"name": "copy_appeal_event_curated_mipins",
+				"type": "Copy",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"source": {
+						"type": "AzureSqlSource",
+						"queryTimeout": "02:00:00",
+						"partitionOption": "None"
+					},
+					"sink": {
+						"type": "AzureSqlSink",
+						"preCopyScript": "drop table appeal_event_curated_mipins",
+						"writeBehavior": "insert",
+						"sqlWriterUseTableLock": false,
+						"tableOption": "autoCreate",
+						"disableMetricsCollection": false
+					},
+					"enableStaging": false,
+					"translator": {
+						"type": "TabularTranslator",
+						"typeConversion": true,
+						"typeConversionSettings": {
+							"allowDataTruncation": true,
+							"treatBooleanAsNumber": false
+						}
+					}
+				},
+				"inputs": [
+					{
+						"referenceName": "appeal_event_curated_mipins_sourceconn",
+						"type": "DatasetReference"
+					}
+				],
+				"outputs": [
+					{
+						"referenceName": "appeal_event_curated_mipins_sourceconn",
+						"type": "DatasetReference"
+					}
+				]
+			}
+		],
+		"folder": {
+			"name": "mipins"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
@@ -22,7 +22,6 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
-						"preCopyScript": "drop table appeal_event_curated_mipins",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",

--- a/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
@@ -45,7 +45,7 @@
 				],
 				"outputs": [
 					{
-						"referenceName": "appeal_event_curated_mipins_sourceconn",
+						"referenceName": "AzureSqlTableMiPinsDev",
 						"type": "DatasetReference"
 					}
 				]


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
