### PR TITLE
Feat/odw/mcp 59

### DIFF
--- a/workspace/dataset/appeal_service_user_conn.json
+++ b/workspace/dataset/appeal_service_user_conn.json
@@ -5,7 +5,7 @@
 			"referenceName": "ls_ssql_builtin",
 			"type": "LinkedServiceReference",
 			"parameters": {
-				"db_name": "odw_curated"
+				"db_name": "odw_curated_db"
 			}
 		},
 		"annotations": [],

--- a/workspace/dataset/appeal_service_user_conn.json
+++ b/workspace/dataset/appeal_service_user_conn.json
@@ -1,0 +1,125 @@
+{
+	"name": "appeal_service_user_conn",
+	"properties": {
+		"linkedServiceName": {
+			"referenceName": "ls_ssql_builtin",
+			"type": "LinkedServiceReference"
+		},
+		"annotations": [],
+		"type": "AzureSqlTable",
+		"schema": [
+			{
+				"name": "id",
+				"type": "nvarchar"
+			},
+			{
+				"name": "caseReference",
+				"type": "nvarchar"
+			},
+			{
+				"name": "salutation",
+				"type": "nvarchar"
+			},
+			{
+				"name": "FirstName",
+				"type": "nvarchar"
+			},
+			{
+				"name": "lastName",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressLine1",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressLine2",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressTown",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressCounty",
+				"type": "nvarchar"
+			},
+			{
+				"name": "postcode",
+				"type": "nvarchar"
+			},
+			{
+				"name": "addressCountry",
+				"type": "nvarchar"
+			},
+			{
+				"name": "organisation",
+				"type": "nvarchar"
+			},
+			{
+				"name": "organisationType",
+				"type": "nvarchar"
+			},
+			{
+				"name": "role",
+				"type": "nvarchar"
+			},
+			{
+				"name": "telephoneNumber",
+				"type": "nvarchar"
+			},
+			{
+				"name": "otherPhoneNumber",
+				"type": "nvarchar"
+			},
+			{
+				"name": "faxNumber",
+				"type": "nvarchar"
+			},
+			{
+				"name": "emailAddress",
+				"type": "nvarchar"
+			},
+			{
+				"name": "webAddress",
+				"type": "nvarchar"
+			},
+			{
+				"name": "serviceUserType",
+				"type": "nvarchar"
+			},
+			{
+				"name": "sourceSystem",
+				"type": "nvarchar"
+			},
+			{
+				"name": "sourceSUID",
+				"type": "nvarchar"
+			},
+			{
+				"name": "ODTSourceSystem",
+				"type": "nvarchar"
+			},
+			{
+				"name": "ingestionDate",
+				"type": "nvarchar"
+			},
+			{
+				"name": "ValidTo",
+				"type": "nvarchar"
+			},
+			{
+				"name": "RowID",
+				"type": "nvarchar"
+			},
+			{
+				"name": "IsActive",
+				"type": "nvarchar"
+			}
+		],
+		"typeProperties": {
+			"schema": "dbo",
+			"table": "appeal_service_user_curated_mipins"
+		}
+	}
+}

--- a/workspace/dataset/appeal_service_user_conn.json
+++ b/workspace/dataset/appeal_service_user_conn.json
@@ -3,7 +3,10 @@
 	"properties": {
 		"linkedServiceName": {
 			"referenceName": "ls_ssql_builtin",
-			"type": "LinkedServiceReference"
+			"type": "LinkedServiceReference",
+			"parameters": {
+				"db_name": "odw_curated"
+			}
 		},
 		"annotations": [],
 		"type": "AzureSqlTable",

--- a/workspace/dataset/appeal_service_user_mipinsdevconn.json
+++ b/workspace/dataset/appeal_service_user_mipinsdevconn.json
@@ -1,0 +1,16 @@
+{
+	"name": "appeal_service_user_mipinsdevconn",
+	"properties": {
+		"linkedServiceName": {
+			"referenceName": "ls_sql_mipins_dev",
+			"type": "LinkedServiceReference"
+		},
+		"annotations": [],
+		"type": "AzureSqlTable",
+		"schema": [],
+		"typeProperties": {
+			"schema": "load",
+			"table": "appeal_service_user_curated_mipins"
+		}
+	}
+}

--- a/workspace/notebook/appeal_service_user_curated_mipins.json
+++ b/workspace/notebook/appeal_service_user_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8734fcc4-9ffd-4fbc-be70-39e9083b48b7"
+				"spark.autotune.trackingId": "a4418118-4772-4a8a-9294-4cda170fbc2f"
 			}
 		},
 		"metadata": {
@@ -128,7 +128,7 @@
 					"\n",
 					""
 				],
-				"execution_count": 1
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeal_service_user_curated_mipins;\")"
 				],
-				"execution_count": 2
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"\n",
 					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_service_user_curated_mipins\")"
 				],
-				"execution_count": 3
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"#%%sql\n",
 					"#select * from odw_curated_db.appeal_service_user_curated_mipins"
 				],
-				"execution_count": 4
+				"execution_count": 8
 			}
 		]
 	}

--- a/workspace/notebook/appeal_service_user_curated_mipins.json
+++ b/workspace/notebook/appeal_service_user_curated_mipins.json
@@ -1,0 +1,225 @@
+{
+	"name": "appeal_service_user_curated_mipins",
+	"properties": {
+		"folder": {
+			"name": "odw-curated"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "8734fcc4-9ffd-4fbc-be70-39e9083b48b7"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"CREATE OR REPLACE  VIEW vw_Appeal_Service_User_curated_mipins \n",
+					"AS\n",
+					"SELECT\n",
+					"    id\n",
+					"    ,caseReference\n",
+					"    ,salutation\n",
+					"    ,FirstName\n",
+					"    ,lastName\n",
+					"    ,addressLine1\n",
+					"    ,addressLine2\n",
+					"    ,addressTown\n",
+					"    ,addressCounty\n",
+					"    ,postcode\n",
+					"    ,addressCountry\n",
+					"    ,organisation\n",
+					"    ,organisationType\n",
+					"    ,role\n",
+					"    ,telephoneNumber\n",
+					"    ,otherPhoneNumber\n",
+					"    ,faxNumber\n",
+					"    ,emailAddress\n",
+					"    ,webAddress\n",
+					"    ,serviceUserType\n",
+					"    ,sourceSystem\n",
+					"    ,sourceSUID\n",
+					"    ,ODTSourceSystem\n",
+					"    ,ingestionDate\n",
+					"    ,ValidTo\n",
+					"    ,RowID\n",
+					"    ,IsActive\n",
+					"\n",
+					"FROM\n",
+					"    odw_harmonised_db.sb_service_user\n",
+					"\n",
+					"    union all\n",
+					"\n",
+					"    SELECT\n",
+					"    id\n",
+					"    ,caseReference\n",
+					"    ,salutation\n",
+					"    ,FirstName\n",
+					"    ,lastName\n",
+					"    ,addressLine1\n",
+					"    ,addressLine2\n",
+					"    ,addressTown\n",
+					"    ,addressCounty\n",
+					"    ,postcode\n",
+					"    ,addressCountry\n",
+					"    ,organisation\n",
+					"    ,organisationType\n",
+					"    ,role\n",
+					"    ,telephoneNumber\n",
+					"    ,otherPhoneNumber\n",
+					"    ,faxNumber\n",
+					"    ,emailAddress\n",
+					"    ,webAddress\n",
+					"    ,serviceUserType\n",
+					"    ,sourceSystem\n",
+					"    ,sourceSUID\n",
+					"    ,ODTSourceSystem\n",
+					"    ,ingestionDate\n",
+					"    ,ValidTo\n",
+					"    ,RowID\n",
+					"    ,IsActive\n",
+					"\n",
+					"FROM\n",
+					"    odw_harmonised_db.service_user\n",
+					"\n",
+					""
+				],
+				"execution_count": 1
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"spark.sql(f\"drop table if exists odw_curated_db.appeal_service_user_curated_mipins;\")"
+				],
+				"execution_count": 2
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"df = spark.sql(\"\"\"\n",
+					"   SELECT\n",
+					"    id\n",
+					"    ,caseReference\n",
+					"    ,salutation\n",
+					"    ,FirstName\n",
+					"    ,lastName\n",
+					"    ,addressLine1\n",
+					"    ,addressLine2\n",
+					"    ,addressTown\n",
+					"    ,addressCounty\n",
+					"    ,postcode\n",
+					"    ,addressCountry\n",
+					"    ,organisation\n",
+					"    ,organisationType\n",
+					"    ,role\n",
+					"    ,telephoneNumber\n",
+					"    ,otherPhoneNumber\n",
+					"    ,faxNumber\n",
+					"    ,emailAddress\n",
+					"    ,webAddress\n",
+					"    ,serviceUserType\n",
+					"    ,sourceSystem\n",
+					"    ,sourceSUID\n",
+					"    ,ODTSourceSystem\n",
+					"    ,ingestionDate\n",
+					"    ,ValidTo\n",
+					"    ,RowID\n",
+					"    ,IsActive\n",
+					"    \n",
+					"FROM \n",
+					"    vw_Appeal_Service_User_curated_mipins\n",
+					"    \"\"\")\n",
+					"\n",
+					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_service_user_curated_mipins\")"
+				],
+				"execution_count": 3
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"#%%sql\n",
+					"#select * from odw_curated_db.appeal_service_user_curated_mipins"
+				],
+				"execution_count": 4
+			}
+		]
+	}
+}

--- a/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
@@ -22,7 +22,6 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
-						"preCopyScript": "drop table if exists load.appeal_service_user_curated_mipins",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",

--- a/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
@@ -22,6 +22,7 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
+						"preCopyScript": "drop table if exists load.appeal_service_user_curated_mipins",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",

--- a/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
@@ -1,0 +1,60 @@
+{
+	"name": "pln_copy_appeal_service_user_curated_mipins",
+	"properties": {
+		"activities": [
+			{
+				"name": "copy_service_user_curated_mipins",
+				"type": "Copy",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"source": {
+						"type": "AzureSqlSource",
+						"queryTimeout": "02:00:00",
+						"partitionOption": "None"
+					},
+					"sink": {
+						"type": "AzureSqlSink",
+						"preCopyScript": "drop table if exists load.appeal_service_user_curated_mipins",
+						"writeBehavior": "insert",
+						"sqlWriterUseTableLock": false,
+						"tableOption": "autoCreate",
+						"disableMetricsCollection": false
+					},
+					"enableStaging": false,
+					"translator": {
+						"type": "TabularTranslator",
+						"typeConversion": true,
+						"typeConversionSettings": {
+							"allowDataTruncation": true,
+							"treatBooleanAsNumber": false
+						}
+					}
+				},
+				"inputs": [
+					{
+						"referenceName": "appeal_service_user_conn",
+						"type": "DatasetReference"
+					}
+				],
+				"outputs": [
+					{
+						"referenceName": "appeal_service_user_mipinsdevconn",
+						"type": "DatasetReference"
+					}
+				]
+			}
+		],
+		"folder": {
+			"name": "mipins"
+		},
+		"annotations": []
+	}
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
