### PR TITLE
Updating notebook: entraid-post-deployment-notebook

### DIFF
--- a/workspace/notebook/entraid-post-deployment-notebook.json
+++ b/workspace/notebook/entraid-post-deployment-notebook.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e53b9bbe-6725-447a-827f-d380c4e901e4"
+				"spark.autotune.trackingId": "00cd82db-89f0-4a20-ac44-1892ba754295"
 			}
 		},
 		"metadata": {
@@ -72,7 +72,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"from notebookutils import mssparkutils"
 				],
-				"execution_count": 56
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -115,7 +115,7 @@
 					"    spark_dataframe.write.format(\"delta\").saveAsTable(f\"{db_name}.{table_name}\")\n",
 					"    print(\"Table created\")"
 				],
-				"execution_count": 57
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -137,7 +137,29 @@
 					"entity_id: int = 128\n",
 					"table_name_replace: str = entity_name.replace(\"-\", \"_\")"
 				],
-				"execution_count": 58
+				"execution_count": 9
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"recreate: bool = False\n",
+					"\n",
+					"if recreate:\n",
+					"    spark.sql(f\"DROP TABLE IF EXISTS odw_standardised_db.{entity_name}\")\n",
+					"    spark.sql(f\"DROP TABLE IF EXISTS odw_harmonised_db.{entity_name}\")"
+				],
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -147,7 +169,7 @@
 					"print('entraid_raw_container '+entraid_raw_container)\n",
 					"files = mssparkutils.fs.mkdirs(entraid_raw_container)"
 				],
-				"execution_count": 59
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -185,7 +207,7 @@
 					"        print('Table ' +full_table_name +\" created\") \n",
 					""
 				],
-				"execution_count": 60
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -223,7 +245,7 @@
 					"        print('Table ' +full_table_name +\" created\") \n",
 					""
 				],
-				"execution_count": 61
+				"execution_count": 13
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
