### PR TITLE
Faet/odw 1385

### DIFF
--- a/workspace/pipeline/pln_curated.json
+++ b/workspace/pipeline/pln_curated.json
@@ -344,6 +344,26 @@
 					},
 					"numExecutors": null
 				}
+			},
+			{
+				"name": "appeal-has",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "appeals_has",
+						"type": "NotebookReference"
+					},
+					"snapshot": true
+				}
 			}
 		],
 		"folder": {

--- a/workspace/pipeline/pln_curated.json
+++ b/workspace/pipeline/pln_curated.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "nsip project - hrm to cur",
+				"name": "nsip-project",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -30,11 +30,11 @@
 				}
 			},
 			{
-				"name": "service user - hrm to cur",
+				"name": "service-user",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
-						"activity": "nsip project - hrm to cur",
+						"activity": "nsip-project",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -67,7 +67,7 @@
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
-						"activity": "service user - hrm to cur",
+						"activity": "service-user",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -96,7 +96,7 @@
 				}
 			},
 			{
-				"name": "relevant representation",
+				"name": "nsip-representation",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
@@ -129,7 +129,7 @@
 				}
 			},
 			{
-				"name": "nsip exam timetable - Hrm to cur",
+				"name": "nsip-exam-timetable",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -155,7 +155,7 @@
 				}
 			},
 			{
-				"name": "nsip subscription - Hrm to Cur",
+				"name": "nsip-subscription",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -181,7 +181,7 @@
 				}
 			},
 			{
-				"name": "nsip s51 advice - Hrm to Cur",
+				"name": "nsip-s51-advice",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -207,7 +207,7 @@
 				}
 			},
 			{
-				"name": "nsip folder - Hrm to cur",
+				"name": "nsip-folder",
 				"description": "Ingests data from harmonised to curated",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
@@ -234,7 +234,7 @@
 				}
 			},
 			{
-				"name": "Document metadata - Hrm to Cur",
+				"name": "nsip-document",
 				"description": "Ingests data from harmonised to curated",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
@@ -261,7 +261,7 @@
 				}
 			},
 			{
-				"name": "Appeals - Event",
+				"name": "appeal-event",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -287,11 +287,11 @@
 				}
 			},
 			{
-				"name": "appeals service user",
+				"name": "appeal service user",
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
-						"activity": "service user - hrm to cur",
+						"activity": "service-user",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -320,7 +320,7 @@
 				}
 			},
 			{
-				"name": "Appeal Document Hrm to Cur",
+				"name": "appeal-document",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {

--- a/workspace/pipeline/pln_service_bus.json
+++ b/workspace/pipeline/pln_service_bus.json
@@ -1156,6 +1156,12 @@
 						"dependencyConditions": [
 							"Succeeded"
 						]
+					},
+					{
+						"activity": "nsip s51 advise - custom harmonised",
+						"dependencyConditions": [
+							"Succeeded"
+						]
 					}
 				],
 				"policy": {
@@ -1464,6 +1470,53 @@
 							"typeProperties": {
 								"notebook": {
 									"referenceName": "py_sb_horizon_harmonised_appeal_document",
+									"type": "NotebookReference"
+								},
+								"snapshot": true,
+								"conf": {
+									"spark.dynamicAllocation.enabled": null,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
+							}
+						}
+					]
+				}
+			},
+			{
+				"name": "nsip s51 advise - custom harmonised",
+				"type": "IfCondition",
+				"dependsOn": [
+					{
+						"activity": "If New Messages",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"userProperties": [],
+				"typeProperties": {
+					"expression": {
+						"value": "@equals(variables('entity_name'), 'nsip-s51-advice')",
+						"type": "Expression"
+					},
+					"ifTrueActivities": [
+						{
+							"name": "Harmonised step for nsip-s51-advice",
+							"type": "SynapseNotebook",
+							"dependsOn": [],
+							"policy": {
+								"timeout": "0.12:00:00",
+								"retry": 0,
+								"retryIntervalInSeconds": 30,
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"notebook": {
+									"referenceName": "py_sb_horizon_harmonised_nsip_s51_advice",
 									"type": "NotebookReference"
 								},
 								"snapshot": true,


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
