### PR TITLE
Feat/odw 1341 timesheets function app

### DIFF
--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -679,7 +679,7 @@ def appealserviceuser(req: func.HttpRequest) -> func.HttpResponse:
             else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
         )
     
-@_app.function_name(name="getTimesheets")
+@_app.function_name(name="get_timesheets")
 @_app.route(route="timesheets/{caseType}/{searchCriteria}", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
 @_app.generic_input_binding(arg_name="timesheet", type="sql",
                         CommandType="Text",

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -698,9 +698,6 @@ def appealserviceuser(req: func.HttpRequest) -> func.HttpResponse:
                 connection_string_setting="SqlConnectionString")
 def get_timesheets(req: func.HttpRequest, timesheet: func.SqlRowList) -> func.HttpResponse:
     try:
-        with open("timesheets_sql.sql", 'r') as timesheets_query:
-            timesheets_sql = timesheets_query.read()
-            timesheet.set('CommandText', timesheets_sql)
         rows = list(map(lambda r: json.loads(r.to_json()), timesheet))
         return func.HttpResponse(
             json.dumps(rows),

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -687,12 +687,17 @@ def appealserviceuser(req: func.HttpRequest) -> func.HttpResponse:
                         ConnectionStringSetting="SqlConnectionString",
                         data_type=DataType.STRING)
 def get_timesheets(req: func.HttpRequest, timesheet: func.SqlRowList) -> func.HttpResponse:
-    with open("timesheets_sql.sql", 'r') as timesheets_query:
-        timesheets_sql = timesheets_query.read()
-        timesheet.set('CommandText', timesheets_sql)
-    rows = list(map(lambda r: json.loads(r.to_json()), timesheet))
-    return func.HttpResponse(
-        json.dumps(rows),
-        status_code=200,
-        mimetype="application/json"
-    )
+    try:
+        with open("timesheets_sql.sql", 'r') as timesheets_query:
+            timesheets_sql = timesheets_query.read()
+            timesheet.set('CommandText', timesheets_sql)
+        rows = list(map(lambda r: json.loads(r.to_json()), timesheet))
+        return func.HttpResponse(
+            json.dumps(rows),
+            status_code=200,
+            mimetype="application/json"
+        )
+    except Exception as e:
+        return (
+            func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
+        )

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -692,7 +692,7 @@ def appealserviceuser(req: func.HttpRequest) -> func.HttpResponse:
 @_app.function_name(name="get_timesheets")
 @_app.route(route="timesheets/{caseType}/{searchCriteria}", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
 @_app.sql_input(arg_name="timesheet",
-                command_text="SELECT TOP (100) * FROM [odw_standardised_db].[dbo].[horizon_s62a_view_cases]",
+                command_text="SELECT TOP (100) * FROM [odw_harmonised_db].[dbo].[s62a_view_cases_dim] WHERE [Name] LIKE '@searchCriteria'",
                 command_type="Text",
                 parameters="@caseType={caseType},@searchCriteria={searchCriteria}",
                 connection_string_setting="SqlConnectionString")

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -12,10 +12,20 @@ from azure.functions.decorators.core import DataType
 import json
 import os
 
-_STORAGE = os.environ["MESSAGE_STORAGE_ACCOUNT"]
-_CONTAINER = os.environ["MESSAGE_STORAGE_CONTAINER"]
-_NAMESPACE = os.environ["ServiceBusConnection__fullyQualifiedNamespace"]
-_NAMESPACE_APPEALS = os.environ["SERVICEBUS_NAMESPACE_APPEALS"]
+
+try:
+    _STORAGE = os.environ["MESSAGE_STORAGE_ACCOUNT"]
+    _CONTAINER = os.environ["MESSAGE_STORAGE_CONTAINER"]
+    _NAMESPACE = os.environ["ServiceBusConnection__fullyQualifiedNamespace"]
+    _NAMESPACE_APPEALS = os.environ["SERVICEBUS_NAMESPACE_APPEALS"]
+except:
+    print("Warning: Missing Environment Variables")
+    _STORAGE = ""
+    _CONTAINER = ""
+    _NAMESPACE = ""
+    _NAMESPACE_APPEALS = ""
+
+
 _CREDENTIAL = CREDENTIAL
 _MAX_MESSAGE_COUNT = config["global"]["max_message_count"]
 _MAX_WAIT_TIME = config["global"]["max_wait_time"]
@@ -681,11 +691,11 @@ def appealserviceuser(req: func.HttpRequest) -> func.HttpResponse:
     
 @_app.function_name(name="get_timesheets")
 @_app.route(route="timesheets/{caseType}/{searchCriteria}", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
-@_app.generic_input_binding(arg_name="timesheet", type="sql",
-                        CommandType="Text",
-                        Parameters="@caseType={caseType},@searchCriteria={searchCriteria}",
-                        ConnectionStringSetting="SqlConnectionString",
-                        data_type=DataType.STRING)
+@_app.sql_input(arg_name="timesheet",
+                command_text="SELECT TOP (100) * FROM [odw_standardised_db].[dbo].[horizon_s62a_view_cases]",
+                command_type="Text",
+                parameters="@caseType={caseType},@searchCriteria={searchCriteria}",
+                connection_string_setting="SqlConnectionString")
 def get_timesheets(req: func.HttpRequest, timesheet: func.SqlRowList) -> func.HttpResponse:
     try:
         with open("timesheets_sql.sql", 'r') as timesheets_query:

--- a/functions/timesheets_sql.sql
+++ b/functions/timesheets_sql.sql
@@ -1,0 +1,1 @@
+SELECT TOP (100) * FROM [odw_standardised_db].[dbo].[horizon_s62a_view_cases]

--- a/functions/timesheets_sql.sql
+++ b/functions/timesheets_sql.sql
@@ -1,1 +1,0 @@
-SELECT TOP (100) * FROM [odw_standardised_db].[dbo].[horizon_s62a_view_cases]


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
