### PR TITLE
Fix/master send teams message

### DIFF
--- a/workspace/pipeline/pln_horizon_2.json
+++ b/workspace/pipeline/pln_horizon_2.json
@@ -233,6 +233,60 @@
 									"Message_subtitle": "Horizon relevant reps data load disabled"
 								}
 							}
+						},
+						{
+							"name": "Send service bus failed",
+							"type": "ExecutePipeline",
+							"dependsOn": [],
+							"policy": {
+								"secureInput": true
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "pln_utl_Send_Teams_Message",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"dataFactorySubscription": {
+										"value": "@variables('subscription_id')",
+										"type": "Expression"
+									},
+									"dataFactoryResourceGroup": {
+										"value": "@variables('resource_group')",
+										"type": "Expression"
+									},
+									"pipelineRunId": {
+										"value": "@pipeline().RunId",
+										"type": "Expression"
+									},
+									"teamsWebhookUrl": {
+										"value": "@variables('webhook_url')",
+										"type": "Expression"
+									},
+									"activityName": {
+										"value": "@pipeline().Pipeline",
+										"type": "Expression"
+									},
+									"activityMessage": "Service bus data failed",
+									"activityDuration": {
+										"value": "@concat(string(div(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(variables('start_time'),'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'H:', \nstring(mod(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(variables('start_time'),'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'M:00s')",
+										"type": "Expression"
+									},
+									"activityStatus": "Failed",
+									"Colour": {
+										"value": "@variables('failed_colour')",
+										"type": "Expression"
+									},
+									"Image": {
+										"value": "@variables('failed_image')",
+										"type": "Expression"
+									},
+									"Message_title": "ODW - Master pipeline failed",
+									"Message_subtitle": "ODW failed to load data from service bus"
+								}
+							}
 						}
 					],
 					"ifTrueActivities": [

--- a/workspace/pipeline/pln_horizon_2.json
+++ b/workspace/pipeline/pln_horizon_2.json
@@ -233,60 +233,6 @@
 									"Message_subtitle": "Horizon relevant reps data load disabled"
 								}
 							}
-						},
-						{
-							"name": "Send service bus failed",
-							"type": "ExecutePipeline",
-							"dependsOn": [],
-							"policy": {
-								"secureInput": true
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"pipeline": {
-									"referenceName": "pln_utl_Send_Teams_Message",
-									"type": "PipelineReference"
-								},
-								"waitOnCompletion": true,
-								"parameters": {
-									"dataFactorySubscription": {
-										"value": "@variables('subscription_id')",
-										"type": "Expression"
-									},
-									"dataFactoryResourceGroup": {
-										"value": "@variables('resource_group')",
-										"type": "Expression"
-									},
-									"pipelineRunId": {
-										"value": "@pipeline().RunId",
-										"type": "Expression"
-									},
-									"teamsWebhookUrl": {
-										"value": "@variables('webhook_url')",
-										"type": "Expression"
-									},
-									"activityName": {
-										"value": "@pipeline().Pipeline",
-										"type": "Expression"
-									},
-									"activityMessage": "Service bus data failed",
-									"activityDuration": {
-										"value": "@concat(string(div(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(variables('start_time'),'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'H:', \nstring(mod(div(sub(ticks(formatDateTime(utcNow(),'yyyy-MM-dd HH:mm:sss')),ticks(formatDateTime(variables('start_time'),'yyyy-MM-dd HH:mm:sss'))),600000000),60)),'M:00s')",
-										"type": "Expression"
-									},
-									"activityStatus": "Failed",
-									"Colour": {
-										"value": "@variables('failed_colour')",
-										"type": "Expression"
-									},
-									"Image": {
-										"value": "@variables('failed_image')",
-										"type": "Expression"
-									},
-									"Message_title": "ODW - Master pipeline failed",
-									"Message_subtitle": "ODW failed to load data from service bus"
-								}
-							}
 						}
 					],
 					"ifTrueActivities": [

--- a/workspace/pipeline/pln_master.json
+++ b/workspace/pipeline/pln_master.json
@@ -2247,7 +2247,57 @@
 						"referenceName": "pln_horizon_2",
 						"type": "PipelineReference"
 					},
-					"waitOnCompletion": true
+					"waitOnCompletion": true,
+					"parameters": {
+						"webhook_url": {
+							"value": "@variables('webhook_url')",
+							"type": "Expression"
+						},
+						"subscription_id": {
+							"value": "@variables('subscription_id')",
+							"type": "Expression"
+						},
+						"resource_group": {
+							"value": "@variables('resource_group')",
+							"type": "Expression"
+						},
+						"starting_colour": {
+							"value": "@variables('starting_colour')",
+							"type": "Expression"
+						},
+						"on_progress_colour": {
+							"value": "@variables('on_progress_colour')",
+							"type": "Expression"
+						},
+						"failed_colour": {
+							"value": "@variables('failed_colour')",
+							"type": "Expression"
+						},
+						"start_time": {
+							"value": "@variables('start_time')",
+							"type": "Expression"
+						},
+						"starting_image": {
+							"value": "@variables('starting_image')",
+							"type": "Expression"
+						},
+						"progress_image": {
+							"value": "@variables('progress_image')",
+							"type": "Expression"
+						},
+						"warning_image": {
+							"value": "@variables('warning_image')",
+							"type": "Expression"
+						},
+						"failed_image": {
+							"value": "@variables('failed_image')",
+							"type": "Expression"
+						},
+						"warning_colour": {
+							"value": "@variables('warning_colour')",
+							"type": "Expression"
+						}
+					}
 				}
 			},
 			{


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
