### PR TITLE
Update function_app.py

### DIFF
--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -688,14 +688,14 @@ def appealserviceuser(req: func.HttpRequest) -> func.HttpResponse:
             else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
         )
 
-@_app.function_name(name="get_s62")
-@_app.route(route="get_s62", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
+@_app.function_name(name="gets62")
+@_app.route(route="gets62", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
 @_app.sql_input(arg_name="timesheet",
                 command_text="SELECT [name],[caseReference],[applicationType],[applicationValidated],[description],[lpa],[permissionSought],[procedureType],[status],[applicantName],[siteAddress],[sitePostcode],[siteGridReference],[agentName],[agentAddress],[dateReceived],[dateValid],[consultationStatDate],[consultationEndDate],[targetDecisionDate],[decisionDate],[decisionType],[appointedPerson],[caseAdministrator],[caseLeader],[caseOfficer],[eiaOfficer],[legalOfficer] FROM [odw_curated_db].[dbo].[s62a] WHERE [Name] LIKE Concat(Char(37), @searchCriteria, Char(37)) OR [caseReference]  LIKE Concat(Char(37), @searchCriteria, Char(37)) OR [description] LIKE Concat(Char(37), @searchCriteria, Char(37)) OR [applicantName] LIKE Concat(Char(37), @searchCriteria, Char(37)) OR [siteAddress] LIKE Concat(Char(37), @searchCriteria, Char(37)) OR [sitePostcode] LIKE Concat(Char(37), @searchCriteria, Char(37)) OR [siteGridReference] LIKE Concat(Char(37), @searchCriteria, Char(37))",
                 command_type="Text",
                 parameters="@searchCriteria={searchCriteria}",
                 connection_string_setting="SqlConnectionString")
-def get_s62(req: func.HttpRequest, timesheet: func.SqlRowList) -> func.HttpResponse:
+def gets62(req: func.HttpRequest, timesheet: func.SqlRowList) -> func.HttpResponse:
     """
     We need to use Char(37) to escape the % 
     https://stackoverflow.com/questions/71914897/how-do-i-use-sql-like-value-operator-with-azure-functions-sql-binding


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
