### PR TITLE
Feat/theodw 673

### DIFF
--- a/workspace/notebook/py_create_lake_databases.json
+++ b/workspace/notebook/py_create_lake_databases.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "dabb209e-6531-416c-86dd-91a1f6799487"
+				"spark.autotune.trackingId": "0a270a98-0950-47d9-a674-47e8d1fde0e5"
 			}
 		},
 		"metadata": {
@@ -42,14 +42,13 @@
 				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
-					"authResource": "https://dev.azuresynapse.net",
-					"authHeader": null
+					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.2",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
-				"extraHeader": null
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -71,7 +70,7 @@
 					"from notebookutils import mssparkutils\r\n",
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 21
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -98,7 +97,10 @@
 					"curated_database_name = 'odw_curated_db'\r\n",
 					"curated_database_location = 'abfss://odw-curated@' + storage_account + '/'\r\n",
 					"config_database_name = 'odw_config_db'\r\n",
-					"config_database_location = 'abfss://odw-config@' + storage_account + '/'"
+					"config_database_location = 'abfss://odw-config@' + storage_account + '/'\r\n",
+					"\r\n",
+					"curated_migration_database_name = 'odw_curated_migration_db'\r\n",
+					"curated_migration_database_location = 'abfss://odw-curated-migration@' + storage_account + '/'"
 				],
 				"execution_count": 23
 			},
@@ -106,10 +108,12 @@
 				"cell_type": "code",
 				"source": [
 					"#spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(workspace_database_name, workspace_database_location))\r\n",
-					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(standardised_database_name, standardised_database_location))\r\n",
-					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(harmonised_database_name, harmonised_database_location))\r\n",
-					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(curated_database_name, curated_database_location))\r\n",
-					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(config_database_name, config_database_location))"
+					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(standardised_database_name, standardised_database_location))\r\n",
+					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(harmonised_database_name, harmonised_database_location))\r\n",
+					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(curated_database_name, curated_database_location))\r\n",
+					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(config_database_name, config_database_location))\r\n",
+					"\r\n",
+					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(curated_migration_database_name, curated_migration_database_location))"
 				],
 				"execution_count": 24
 			}

--- a/workspace/notebook/py_create_lake_databases.json
+++ b/workspace/notebook/py_create_lake_databases.json
@@ -22,7 +22,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0a270a98-0950-47d9-a674-47e8d1fde0e5"
+				"spark.autotune.trackingId": "2f6c0d92-eb50-429a-9f84-9b34391a395b"
 			}
 		},
 		"metadata": {
@@ -102,20 +102,20 @@
 					"curated_migration_database_name = 'odw_curated_migration_db'\r\n",
 					"curated_migration_database_location = 'abfss://odw-curated-migration@' + storage_account + '/'"
 				],
-				"execution_count": 23
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"#spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(workspace_database_name, workspace_database_location))\r\n",
-					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(standardised_database_name, standardised_database_location))\r\n",
-					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(harmonised_database_name, harmonised_database_location))\r\n",
-					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(curated_database_name, curated_database_location))\r\n",
-					"# spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(config_database_name, config_database_location))\r\n",
+					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(standardised_database_name, standardised_database_location))\r\n",
+					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(harmonised_database_name, harmonised_database_location))\r\n",
+					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(curated_database_name, curated_database_location))\r\n",
+					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(config_database_name, config_database_location))\r\n",
 					"\r\n",
 					"spark.sql(\"CREATE DATABASE IF NOT EXISTS {0} LOCATION '{1}'\".format(curated_migration_database_name, curated_migration_database_location))"
 				],
-				"execution_count": 24
+				"execution_count": 4
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
