### PR TITLE
disabling provider registration for keyvault block

### DIFF
--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -22,6 +22,7 @@ provider "azurerm" {
       purge_soft_delete_on_destroy = false
     }
   }
+  skip_provider_registration = true
 }
 
 provider "azurerm" {


### PR DESCRIPTION
Disabling the provider registration in the keyvault block as this still caused a failure in test.

Successful pipeline result here https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=93205&view=results