### PR TITLE
Theodw 1376 Refactor Appeal Document Unit Test notebook

### DIFF
--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,8 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-
-				"spark.autotune.trackingId": "d4ac936a-e2ed-43fd-9377-0d6ed8d4ef23"
+				"spark.autotune.trackingId": "fca3deff-686d-49d2-8c65-1c441a077b42"
 			}
 		},
 		"metadata": {
@@ -72,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": null
+				"execution_count": 100
 			},
 			{
 				"cell_type": "code",
@@ -101,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": null
+				"execution_count": 101
 			},
 			{
 				"cell_type": "code",
@@ -135,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": null
+				"execution_count": 102
 			},
 			{
 				"cell_type": "code",
@@ -154,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": null
+				"execution_count": 103
 			},
 			{
 				"cell_type": "code",
@@ -199,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": null
+				"execution_count": 104
 			},
 			{
 				"cell_type": "code",
@@ -217,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": null
+				"execution_count": 105
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": null
+				"execution_count": 106
 			},
 			{
 				"cell_type": "markdown",
@@ -275,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": null
+				"execution_count": 107
 			},
 			{
 				"cell_type": "markdown",
@@ -315,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": null
+				"execution_count": 108
 			},
 			{
 				"cell_type": "markdown",
@@ -349,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": null
+				"execution_count": 109
 			},
 			{
 				"cell_type": "markdown",
@@ -389,7 +388,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 110
 			},
 			{
 				"cell_type": "code",
@@ -415,7 +414,72 @@
 					"order by IngestionDate\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 111
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"Automating the above visual checks"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"SB_standardised_dataframe = spark.sql(\"\"\"\n",
+					"SELECT caseId, caseReference, version, size FROM odw_standardised_db.sb_appeal_document\n",
+					"WHERE documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
+					"ORDER BY ingested_datetime\n",
+					"\"\"\")\n",
+					"\n",
+					"SB_harmonised_dataframe = spark.sql(\"\"\"\n",
+					"SELECT caseId, caseReference, version, size FROM odw_harmonised_db.sb_appeal_document\n",
+					"WHERE documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
+					"ORDER BY IngestionDate\n",
+					"\"\"\")\n",
+					"\n",
+					"def compare_specific_columns(SB_standardised_dataframe, SB_harmonised_dataframe, columns, exitCode):\n",
+					"    # Select only the specified columns from both DataFrames\n",
+					"    SB_standardised_dataframe_selected = SB_standardised_dataframe.select(columns)\n",
+					"    SB_harmonised_dataframe_selected = SB_harmonised_dataframe.select(columns)\n",
+					"    \n",
+					"    # Check if the data is the same for the specified columns\n",
+					"    diff_df = SB_standardised_dataframe_selected.subtract(SB_harmonised_dataframe_selected).union(SB_harmonised_dataframe_selected.subtract(SB_standardised_dataframe_selected))\n",
+					"    if diff_df.count() == 0:\n",
+					"        print(\"DataFrames match for the specified columns.\")\n",
+					"        return True, exitCode\n",
+					"    else:\n",
+					"        print(\"DataFrames do not match for the specified columns.\")\n",
+					"        diff_df.show()\n",
+					"        exitCode += 1\n",
+					"        return False, exitCode\n",
+					"\n",
+					"# Specify the columns to compare\n",
+					"columns_to_compare = [\"caseId\", \"caseReference\", \"version\", \"size\"]\n",
+					"\n",
+					"# Compare the DataFrames for the specified columns and print the result\n",
+					"result, exitCode = compare_specific_columns(SB_standardised_dataframe, SB_harmonised_dataframe, columns_to_compare, exitCode)\n",
+					"\n",
+					"print(exitCode)"
+				],
+				"execution_count": 135
 			},
 			{
 				"cell_type": "markdown",
@@ -451,7 +515,7 @@
 					"%%sql\n",
 					"refresh  odw_harmonised_db.appeal_document"
 				],
-				"execution_count": null
+				"execution_count": 113
 			},
 			{
 				"cell_type": "code",
@@ -480,7 +544,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": null
+				"execution_count": 114
 			},
 			{
 				"cell_type": "code",
@@ -513,7 +577,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 115
 			},
 			{
 				"cell_type": "markdown",
@@ -555,7 +619,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": null
+				"execution_count": 116
 			},
 			{
 				"cell_type": "markdown",
@@ -596,7 +660,7 @@
 					"display(df_hrm_final)\n",
 					"display(df_cur)"
 				],
-				"execution_count": null
+				"execution_count": 117
 			},
 			{
 				"cell_type": "markdown",
@@ -637,25 +701,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"mssparkutils.notebook.exit(exitCode)"
-				],
-				"execution_count": null
+				"execution_count": 118
 			},
 			{
 				"cell_type": "code",
@@ -675,7 +721,7 @@
 					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
 					"data.printSchema()"
 				],
-				"execution_count": null
+				"execution_count": 119
 			},
 			{
 				"cell_type": "code",
@@ -704,7 +750,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 120
 			},
 			{
 				"cell_type": "code",
@@ -733,7 +779,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 121
 			},
 			{
 				"cell_type": "code",
@@ -763,7 +809,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 122
 			},
 			{
 				"cell_type": "code",
@@ -793,7 +839,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 123
 			},
 			{
 				"cell_type": "code",
@@ -813,7 +859,7 @@
 					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
 					"    return df.count() == 0 "
 				],
-				"execution_count": null
+				"execution_count": 124
 			},
 			{
 				"cell_type": "code",
@@ -836,7 +882,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": null
+				"execution_count": 125
 			},
 			{
 				"cell_type": "code",
@@ -869,7 +915,7 @@
 					"    return non_zero_differences.count() == 0\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 126
 			},
 			{
 				"cell_type": "code",
@@ -887,7 +933,7 @@
 				"source": [
 					"print(f\"Service bus std to hrm no documentIds dropped: {test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name)}\")"
 				],
-				"execution_count": null
+				"execution_count": 127
 			},
 			{
 				"cell_type": "code",
@@ -905,7 +951,7 @@
 				"source": [
 					"print(f\"Service bus hrm to hrm table final no documentIds dropped: {test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": null
+				"execution_count": 128
 			},
 			{
 				"cell_type": "code",
@@ -923,7 +969,7 @@
 				"source": [
 					"print(f\"hrm table final to curated no documentIds dropped: {test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": null
+				"execution_count": 129
 			},
 			{
 				"cell_type": "code",
@@ -941,7 +987,7 @@
 				"source": [
 					"print(f\"Horizon std table to hrm table final no documentIds dropped: {test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": null
+				"execution_count": 130
 			},
 			{
 				"cell_type": "code",
@@ -959,7 +1005,7 @@
 				"source": [
 					"print(f\"AIE std table to hrm table no documentIds dropped: {test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name)}\")"
 				],
-				"execution_count": null
+				"execution_count": 131
 			},
 			{
 				"cell_type": "code",
@@ -977,7 +1023,7 @@
 				"source": [
 					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": null
+				"execution_count": 132
 			},
 			{
 				"cell_type": "code",
@@ -995,7 +1041,25 @@
 				"source": [
 					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": null
+				"execution_count": 133
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"mssparkutils.notebook.exit(exitCode)"
+				],
+				"execution_count": 134
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8ef359f5-630f-46da-b3fb-052252503dd2"
+				"spark.autotune.trackingId": "811df9f7-ca95-4f5c-ac63-e58ba0f434ed"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 1
+				"execution_count": 53
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 2
+				"execution_count": 54
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 3
+				"execution_count": 55
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 4
+				"execution_count": 56
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 5
+				"execution_count": 57
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 6
+				"execution_count": 58
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 7
+				"execution_count": 59
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 8
+				"execution_count": 60
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 9
+				"execution_count": 61
 			},
 			{
 				"cell_type": "markdown",
@@ -348,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 10
+				"execution_count": 62
 			},
 			{
 				"cell_type": "markdown",
@@ -388,7 +388,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 11
+				"execution_count": 63
 			},
 			{
 				"cell_type": "code",
@@ -414,7 +414,7 @@
 					"order by IngestionDate\n",
 					""
 				],
-				"execution_count": 12
+				"execution_count": 64
 			},
 			{
 				"cell_type": "markdown",
@@ -468,7 +468,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 38
+				"execution_count": 65
 			},
 			{
 				"cell_type": "markdown",
@@ -504,7 +504,7 @@
 					"%%sql\n",
 					"refresh  odw_harmonised_db.appeal_document"
 				],
-				"execution_count": 14
+				"execution_count": 66
 			},
 			{
 				"cell_type": "code",
@@ -533,7 +533,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 15
+				"execution_count": 67
 			},
 			{
 				"cell_type": "code",
@@ -563,7 +563,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 16
+				"execution_count": 68
 			},
 			{
 				"cell_type": "markdown",
@@ -617,7 +617,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 39
+				"execution_count": 69
 			},
 			{
 				"cell_type": "markdown",
@@ -659,7 +659,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 18
+				"execution_count": 70
 			},
 			{
 				"cell_type": "code",
@@ -690,7 +690,7 @@
 					"if ODT_and_horizon_dataframe.isEmpty():\n",
 					"    exitCode =+ 1"
 				],
-				"execution_count": 44
+				"execution_count": 71
 			},
 			{
 				"cell_type": "markdown",
@@ -731,7 +731,7 @@
 					"display(df_hrm_final)\n",
 					"display(df_cur)"
 				],
-				"execution_count": 19
+				"execution_count": 72
 			},
 			{
 				"cell_type": "code",
@@ -761,7 +761,7 @@
 					"#display(df_hrm_final)\n",
 					"#display(df_cur)"
 				],
-				"execution_count": 51
+				"execution_count": 73
 			},
 			{
 				"cell_type": "code",
@@ -774,14 +774,52 @@
 						"transient": {
 							"deleting": false
 						}
-					}
+					},
+					"collapsed": false
 				},
 				"source": [
-					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
+					"# delete after troubleshooting\n",
 					"\n",
-					"display(df_hzn_std)"
+					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = '12535309' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
+					"\n",
+					"#df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\") #12535309\n",
+					"\n",
+					"display(df_hzn_std) # isn't displaying - investigate after lunch"
 				],
-				"execution_count": 52
+				"execution_count": 102
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"# delete after troubleshooting\n",
+					"\n",
+					"#df_top10_ordered = spark.sql(\"\"\"\n",
+					"#SELECT * \n",
+					"#FROM odw_standardised_db.horizon_appeals_document_metadata \n",
+					"#ORDER BY ingested_datetime DESC \n",
+					"#LIMIT 10\n",
+					"#\"\"\")\n",
+					"#display(df_top10_ordered)\n",
+					"\n",
+					"\n",
+					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = '12535309'\")\n",
+					"\n",
+					"display(df_hzn_std) # isn't displaying - investigate after lunch\n",
+					""
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -822,7 +860,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": 20
+				"execution_count": 75
 			},
 			{
 				"cell_type": "code",
@@ -842,7 +880,7 @@
 					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
 					"data.printSchema()"
 				],
-				"execution_count": 21
+				"execution_count": 76
 			},
 			{
 				"cell_type": "code",
@@ -871,7 +909,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 22
+				"execution_count": 77
 			},
 			{
 				"cell_type": "code",
@@ -900,7 +938,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 23
+				"execution_count": 78
 			},
 			{
 				"cell_type": "code",
@@ -930,7 +968,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 24
+				"execution_count": 79
 			},
 			{
 				"cell_type": "code",
@@ -960,7 +998,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 25
+				"execution_count": 80
 			},
 			{
 				"cell_type": "code",
@@ -980,7 +1018,7 @@
 					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
 					"    return df.count() == 0 "
 				],
-				"execution_count": 26
+				"execution_count": 81
 			},
 			{
 				"cell_type": "code",
@@ -1003,7 +1041,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": 27
+				"execution_count": 82
 			},
 			{
 				"cell_type": "code",
@@ -1036,7 +1074,7 @@
 					"    return non_zero_differences.count() == 0\r\n",
 					""
 				],
-				"execution_count": 28
+				"execution_count": 83
 			},
 			{
 				"cell_type": "code",
@@ -1054,7 +1092,7 @@
 				"source": [
 					"print(f\"Service bus std to hrm no documentIds dropped: {test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name)}\")"
 				],
-				"execution_count": 29
+				"execution_count": 84
 			},
 			{
 				"cell_type": "code",
@@ -1072,7 +1110,7 @@
 				"source": [
 					"print(f\"Service bus hrm to hrm table final no documentIds dropped: {test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 30
+				"execution_count": 85
 			},
 			{
 				"cell_type": "code",
@@ -1090,7 +1128,7 @@
 				"source": [
 					"print(f\"hrm table final to curated no documentIds dropped: {test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 31
+				"execution_count": 86
 			},
 			{
 				"cell_type": "code",
@@ -1108,7 +1146,7 @@
 				"source": [
 					"print(f\"Horizon std table to hrm table final no documentIds dropped: {test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 32
+				"execution_count": 87
 			},
 			{
 				"cell_type": "code",
@@ -1126,7 +1164,7 @@
 				"source": [
 					"print(f\"AIE std table to hrm table no documentIds dropped: {test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name)}\")"
 				],
-				"execution_count": 33
+				"execution_count": 88
 			},
 			{
 				"cell_type": "code",
@@ -1144,7 +1182,7 @@
 				"source": [
 					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 34
+				"execution_count": 89
 			},
 			{
 				"cell_type": "code",
@@ -1162,7 +1200,7 @@
 				"source": [
 					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 35
+				"execution_count": 90
 			},
 			{
 				"cell_type": "code",
@@ -1180,7 +1218,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 36
+				"execution_count": 91
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5b8e4ef1-5407-45e9-be49-d7d386da4e48"
+				"spark.autotune.trackingId": "1d11d162-34b1-480b-ba60-55a4e8ec947a"
 			}
 		},
 		"metadata": {
@@ -628,9 +628,12 @@
 					}
 				},
 				"source": [
-					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
+					"if test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final):\n",
+					"    pass\n",
+					"else:\n",
+					"    exitCode += 1"
 				],
-				"execution_count": 50
+				"execution_count": 67
 			},
 			{
 				"cell_type": "code",
@@ -646,9 +649,12 @@
 					}
 				},
 				"source": [
-					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
+					"if test_document_row_counts_match(hrm_table_final, curated_table_name):\n",
+					"    pass\n",
+					"else:\n",
+					"    exitCode += 1"
 				],
-				"execution_count": 51
+				"execution_count": 68
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "33bed6ef-dad2-40d2-962a-b744c0b8e295"
+				"spark.autotune.trackingId": "1306348e-321d-499e-ac9c-0a94e4ea39d6"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 69
+				"execution_count": 119
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 70
+				"execution_count": 120
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 71
+				"execution_count": 121
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 72
+				"execution_count": 122
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 73
+				"execution_count": 123
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 74
+				"execution_count": 124
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 75
+				"execution_count": 125
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 76
+				"execution_count": 126
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 77
+				"execution_count": 127
 			},
 			{
 				"cell_type": "markdown",
@@ -348,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 78
+				"execution_count": 128
 			},
 			{
 				"cell_type": "code",
@@ -392,7 +392,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 79
+				"execution_count": 129
 			},
 			{
 				"cell_type": "code",
@@ -436,7 +436,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 80
+				"execution_count": 130
 			},
 			{
 				"cell_type": "code",
@@ -468,45 +468,7 @@
 					"if ODT_and_horizon_dataframe.isEmpty():\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 81
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"\n",
-					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
-					"data.printSchema()"
-				],
-				"execution_count": 82
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"%run /utils/unit-tests/py_unit_tests_functions"
-				],
-				"execution_count": 83
+				"execution_count": 131
 			},
 			{
 				"cell_type": "code",
@@ -527,7 +489,7 @@
 					"else:\n",
 					"    exitCode += 1  "
 				],
-				"execution_count": 84
+				"execution_count": 132
 			},
 			{
 				"cell_type": "code",
@@ -548,7 +510,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 85
+				"execution_count": 133
 			},
 			{
 				"cell_type": "code",
@@ -569,7 +531,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 86
+				"execution_count": 134
 			},
 			{
 				"cell_type": "code",
@@ -590,7 +552,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 87
+				"execution_count": 135
 			},
 			{
 				"cell_type": "code",
@@ -612,7 +574,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 88
+				"execution_count": 136
 			},
 			{
 				"cell_type": "code",
@@ -633,7 +595,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 89
+				"execution_count": 137
 			},
 			{
 				"cell_type": "code",
@@ -654,7 +616,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 90
+				"execution_count": 138
 			},
 			{
 				"cell_type": "code",
@@ -672,7 +634,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 91
+				"execution_count": 139
 			},
 			{
 				"cell_type": "markdown",
@@ -963,6 +925,25 @@
 					"    odw_curated_db.appeal_document\n",
 					"WHERE\n",
 					"     documentId = '10847936'"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
+					"data.printSchema()"
 				],
 				"execution_count": null
 			}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1d11d162-34b1-480b-ba60-55a4e8ec947a"
+				"spark.autotune.trackingId": "33bed6ef-dad2-40d2-962a-b744c0b8e295"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 1
+				"execution_count": 69
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 2
+				"execution_count": 70
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 3
+				"execution_count": 71
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 4
+				"execution_count": 72
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 5
+				"execution_count": 73
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 6
+				"execution_count": 74
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 7
+				"execution_count": 75
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 8
+				"execution_count": 76
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 9
+				"execution_count": 77
 			},
 			{
 				"cell_type": "markdown",
@@ -348,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 10
+				"execution_count": 78
 			},
 			{
 				"cell_type": "code",
@@ -392,7 +392,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 54
+				"execution_count": 79
 			},
 			{
 				"cell_type": "code",
@@ -436,7 +436,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 17
+				"execution_count": 80
 			},
 			{
 				"cell_type": "code",
@@ -468,7 +468,7 @@
 					"if ODT_and_horizon_dataframe.isEmpty():\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 57
+				"execution_count": 81
 			},
 			{
 				"cell_type": "code",
@@ -488,7 +488,7 @@
 					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
 					"data.printSchema()"
 				],
-				"execution_count": 25
+				"execution_count": 82
 			},
 			{
 				"cell_type": "code",
@@ -506,7 +506,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 44
+				"execution_count": 83
 			},
 			{
 				"cell_type": "code",
@@ -527,7 +527,7 @@
 					"else:\n",
 					"    exitCode += 1  "
 				],
-				"execution_count": 59
+				"execution_count": 84
 			},
 			{
 				"cell_type": "code",
@@ -548,7 +548,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 62
+				"execution_count": 85
 			},
 			{
 				"cell_type": "code",
@@ -569,7 +569,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 63
+				"execution_count": 86
 			},
 			{
 				"cell_type": "code",
@@ -590,7 +590,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 65
+				"execution_count": 87
 			},
 			{
 				"cell_type": "code",
@@ -612,7 +612,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 66
+				"execution_count": 88
 			},
 			{
 				"cell_type": "code",
@@ -633,7 +633,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 67
+				"execution_count": 89
 			},
 			{
 				"cell_type": "code",
@@ -654,7 +654,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 68
+				"execution_count": 90
 			},
 			{
 				"cell_type": "code",
@@ -672,7 +672,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 52
+				"execution_count": 91
 			},
 			{
 				"cell_type": "markdown",
@@ -726,7 +726,7 @@
 					"where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
 					"order by ingested_datetime"
 				],
-				"execution_count": 55
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -751,7 +751,7 @@
 					"where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
 					"order by IngestionDate"
 				],
-				"execution_count": 56
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -964,7 +964,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": 58
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "038a24fb-4af1-473e-ab2c-30fdedf743e1"
+				"spark.autotune.trackingId": "a3fb84c9-1db9-4a29-b81e-890e1d5503fc"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 335
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 336
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 337
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 338
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 339
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 340
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 341
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 342
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 343
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -348,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 344
+				"execution_count": 10
 			},
 			{
 				"cell_type": "markdown",
@@ -388,7 +388,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 345
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -414,7 +414,7 @@
 					"order by IngestionDate\n",
 					""
 				],
-				"execution_count": 346
+				"execution_count": 12
 			},
 			{
 				"cell_type": "markdown",
@@ -462,10 +462,13 @@
 					"\n",
 					"sb_columns_to_compare = [\"caseId\", \"caseReference\", \"version\", \"size\"]\n",
 					"\n",
-					"if not compare_dataframes(SB_standardised_dataframe, SB_harmonised_dataframe, sb_columns_to_compare):\n",
-					"    exitCode += 1"
+					"if compare_dataframes(SB_standardised_dataframe, SB_harmonised_dataframe, sb_columns_to_compare):\n",
+					"    pass\n",
+					"else:\n",
+					"    exitCode += 1\n",
+					""
 				],
-				"execution_count": 347
+				"execution_count": 38
 			},
 			{
 				"cell_type": "markdown",
@@ -501,7 +504,7 @@
 					"%%sql\n",
 					"refresh  odw_harmonised_db.appeal_document"
 				],
-				"execution_count": 348
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -530,7 +533,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 349
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -560,7 +563,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 350
+				"execution_count": 16
 			},
 			{
 				"cell_type": "markdown",
@@ -609,10 +612,12 @@
 					"\n",
 					"horizon_columns_to_compare = [\"caseReference\", \"filename\", \"size\"]\n",
 					"\n",
-					"if not compare_dataframes(horizon_standardised_dataframe, horizon_harmonised_dataframe, horizon_columns_to_compare):\n",
+					"if compare_dataframes(horizon_standardised_dataframe, horizon_harmonised_dataframe, horizon_columns_to_compare):\n",
+					"    pass\n",
+					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 351
+				"execution_count": 39
 			},
 			{
 				"cell_type": "markdown",
@@ -624,7 +629,7 @@
 					}
 				},
 				"source": [
-					"###### **Check if there is data coming from ODT and Horizon**"
+					"###### **Check if there is data coming from ODT (back-office-appeals) and Horizon**"
 				]
 			},
 			{
@@ -654,11 +659,15 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 371
+				"execution_count": 18
 			},
 			{
-				"cell_type": "markdown",
+				"cell_type": "code",
 				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
 					"nteract": {
 						"transient": {
 							"deleting": false
@@ -666,8 +675,22 @@
 					}
 				},
 				"source": [
-					"<mark>automate the above tomorrow</mark>"
-				]
+					"# automate the above - checking whether there is data coming from ODT (back-office-appeals) and Horizon\n",
+					"\n",
+					"check_ODT_and_horizon_data_query = \"\"\"\n",
+					"(SELECT DISTINCT\n",
+					"*\n",
+					"FROM odw_harmonised_db.appeal_document\n",
+					"WHERE horizonfolderid IS NULL AND sourcesystem = 'back-office-appeals'\n",
+					"ORDER BY ingestiondate DESC)\n",
+					"\"\"\"\n",
+					"\n",
+					"ODT_and_horizon_dataframe = get_dataframe(check_ODT_and_horizon_data_query)\n",
+					"\n",
+					"if ODT_and_horizon_dataframe.isEmpty():\n",
+					"    exitCode =+ 1"
+				],
+				"execution_count": 44
 			},
 			{
 				"cell_type": "markdown",
@@ -708,7 +731,7 @@
 					"display(df_hrm_final)\n",
 					"display(df_cur)"
 				],
-				"execution_count": 353
+				"execution_count": 19
 			},
 			{
 				"cell_type": "markdown",
@@ -749,7 +772,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": 354
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -769,7 +792,7 @@
 					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
 					"data.printSchema()"
 				],
-				"execution_count": 355
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -798,7 +821,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 356
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -827,7 +850,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 357
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -857,7 +880,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 358
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -887,7 +910,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 359
+				"execution_count": 25
 			},
 			{
 				"cell_type": "code",
@@ -907,7 +930,7 @@
 					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
 					"    return df.count() == 0 "
 				],
-				"execution_count": 360
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -930,7 +953,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": 361
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -963,7 +986,7 @@
 					"    return non_zero_differences.count() == 0\r\n",
 					""
 				],
-				"execution_count": 362
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -981,7 +1004,7 @@
 				"source": [
 					"print(f\"Service bus std to hrm no documentIds dropped: {test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name)}\")"
 				],
-				"execution_count": 363
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -999,7 +1022,7 @@
 				"source": [
 					"print(f\"Service bus hrm to hrm table final no documentIds dropped: {test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 364
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -1017,7 +1040,7 @@
 				"source": [
 					"print(f\"hrm table final to curated no documentIds dropped: {test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 365
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
@@ -1035,7 +1058,7 @@
 				"source": [
 					"print(f\"Horizon std table to hrm table final no documentIds dropped: {test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 366
+				"execution_count": 32
 			},
 			{
 				"cell_type": "code",
@@ -1053,7 +1076,7 @@
 				"source": [
 					"print(f\"AIE std table to hrm table no documentIds dropped: {test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name)}\")"
 				],
-				"execution_count": 367
+				"execution_count": 33
 			},
 			{
 				"cell_type": "code",
@@ -1071,7 +1094,7 @@
 				"source": [
 					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 368
+				"execution_count": 34
 			},
 			{
 				"cell_type": "code",
@@ -1089,7 +1112,7 @@
 				"source": [
 					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 369
+				"execution_count": 35
 			},
 			{
 				"cell_type": "code",
@@ -1107,7 +1130,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 370
+				"execution_count": 36
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2ebb5d18-d3f0-4c60-87d1-a98aa1faa96b"
+				"spark.autotune.trackingId": "038a24fb-4af1-473e-ab2c-30fdedf743e1"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 248
+				"execution_count": 335
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 249
+				"execution_count": 336
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 250
+				"execution_count": 337
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 251
+				"execution_count": 338
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 252
+				"execution_count": 339
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 253
+				"execution_count": 340
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 254
+				"execution_count": 341
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 255
+				"execution_count": 342
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 256
+				"execution_count": 343
 			},
 			{
 				"cell_type": "markdown",
@@ -348,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 257
+				"execution_count": 344
 			},
 			{
 				"cell_type": "markdown",
@@ -388,7 +388,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 258
+				"execution_count": 345
 			},
 			{
 				"cell_type": "code",
@@ -414,7 +414,7 @@
 					"order by IngestionDate\n",
 					""
 				],
-				"execution_count": 259
+				"execution_count": 346
 			},
 			{
 				"cell_type": "markdown",
@@ -465,7 +465,7 @@
 					"if not compare_dataframes(SB_standardised_dataframe, SB_harmonised_dataframe, sb_columns_to_compare):\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 260
+				"execution_count": 347
 			},
 			{
 				"cell_type": "markdown",
@@ -501,7 +501,7 @@
 					"%%sql\n",
 					"refresh  odw_harmonised_db.appeal_document"
 				],
-				"execution_count": 261
+				"execution_count": 348
 			},
 			{
 				"cell_type": "code",
@@ -530,7 +530,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 262
+				"execution_count": 349
 			},
 			{
 				"cell_type": "code",
@@ -560,7 +560,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 263
+				"execution_count": 350
 			},
 			{
 				"cell_type": "markdown",
@@ -612,7 +612,7 @@
 					"if not compare_dataframes(horizon_standardised_dataframe, horizon_harmonised_dataframe, horizon_columns_to_compare):\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 264
+				"execution_count": 351
 			},
 			{
 				"cell_type": "markdown",
@@ -650,11 +650,24 @@
 					"*\n",
 					"FROM odw_harmonised_db.appeal_document\n",
 					"\n",
-					"where  horizonfolderid  is null and sourcesystem = 'ODT'\n",
+					"where  horizonfolderid  is null and sourcesystem = 'back-office-appeals'\n",
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 284
+				"execution_count": 371
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"<mark>automate the above tomorrow</mark>"
+				]
 			},
 			{
 				"cell_type": "markdown",
@@ -695,7 +708,7 @@
 					"display(df_hrm_final)\n",
 					"display(df_cur)"
 				],
-				"execution_count": 266
+				"execution_count": 353
 			},
 			{
 				"cell_type": "markdown",
@@ -736,7 +749,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": 267
+				"execution_count": 354
 			},
 			{
 				"cell_type": "code",
@@ -756,7 +769,7 @@
 					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
 					"data.printSchema()"
 				],
-				"execution_count": 268
+				"execution_count": 355
 			},
 			{
 				"cell_type": "code",
@@ -785,7 +798,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 269
+				"execution_count": 356
 			},
 			{
 				"cell_type": "code",
@@ -814,7 +827,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 270
+				"execution_count": 357
 			},
 			{
 				"cell_type": "code",
@@ -844,7 +857,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 271
+				"execution_count": 358
 			},
 			{
 				"cell_type": "code",
@@ -874,7 +887,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 272
+				"execution_count": 359
 			},
 			{
 				"cell_type": "code",
@@ -894,7 +907,7 @@
 					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
 					"    return df.count() == 0 "
 				],
-				"execution_count": 273
+				"execution_count": 360
 			},
 			{
 				"cell_type": "code",
@@ -917,7 +930,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": 274
+				"execution_count": 361
 			},
 			{
 				"cell_type": "code",
@@ -950,7 +963,7 @@
 					"    return non_zero_differences.count() == 0\r\n",
 					""
 				],
-				"execution_count": 275
+				"execution_count": 362
 			},
 			{
 				"cell_type": "code",
@@ -968,7 +981,7 @@
 				"source": [
 					"print(f\"Service bus std to hrm no documentIds dropped: {test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name)}\")"
 				],
-				"execution_count": 276
+				"execution_count": 363
 			},
 			{
 				"cell_type": "code",
@@ -986,7 +999,7 @@
 				"source": [
 					"print(f\"Service bus hrm to hrm table final no documentIds dropped: {test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 277
+				"execution_count": 364
 			},
 			{
 				"cell_type": "code",
@@ -1004,7 +1017,7 @@
 				"source": [
 					"print(f\"hrm table final to curated no documentIds dropped: {test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 278
+				"execution_count": 365
 			},
 			{
 				"cell_type": "code",
@@ -1022,7 +1035,7 @@
 				"source": [
 					"print(f\"Horizon std table to hrm table final no documentIds dropped: {test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 279
+				"execution_count": 366
 			},
 			{
 				"cell_type": "code",
@@ -1040,7 +1053,7 @@
 				"source": [
 					"print(f\"AIE std table to hrm table no documentIds dropped: {test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name)}\")"
 				],
-				"execution_count": 280
+				"execution_count": 367
 			},
 			{
 				"cell_type": "code",
@@ -1058,7 +1071,7 @@
 				"source": [
 					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 281
+				"execution_count": 368
 			},
 			{
 				"cell_type": "code",
@@ -1076,7 +1089,7 @@
 				"source": [
 					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 282
+				"execution_count": 369
 			},
 			{
 				"cell_type": "code",
@@ -1094,7 +1107,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 283
+				"execution_count": 370
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a3fb84c9-1db9-4a29-b81e-890e1d5503fc"
+				"spark.autotune.trackingId": "607fb908-929c-4301-822b-0281630155b0"
 			}
 		},
 		"metadata": {
@@ -732,6 +732,36 @@
 					"display(df_cur)"
 				],
 				"execution_count": 19
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"collapsed": false
+				},
+				"source": [
+					"# need to workout which of the above tables isn't displaying\n",
+					"\n",
+					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
+					"df_sb_hrm = spark.sql(\"select * from odw_harmonised_db.sb_appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' order by IngestionDate\")\n",
+					"df_hrm_final = spark.sql(\"select * from odw_harmonised_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'order by IngestionDate\")\n",
+					"df_cur = spark.sql(\"select * from odw_curated_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\")\n",
+					"\n",
+					"\n",
+					"display(df_hzn_std) # isn't displaying - investigate after lunch\n",
+					"#display(df_sb_hrm)\n",
+					"#display(df_hrm_final)\n",
+					"#display(df_cur)"
+				],
+				"execution_count": 51
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "811df9f7-ca95-4f5c-ac63-e58ba0f434ed"
+				"spark.autotune.trackingId": "5b8e4ef1-5407-45e9-be49-d7d386da4e48"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 53
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 54
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 55
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 56
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 57
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 58
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 59
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 60
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 61
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -348,86 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 62
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"##### Trace service bus data from standardised to harmonised\n",
-					"We need to make sure the data has loaded through correctly. To do this efficiently, we will select a sample record and check that the data is maintained as it moves through the medallian architecture."
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"SELECT * FROM  odw_standardised_db.sb_appeal_document\n",
-					"where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
-					"order by ingested_datetime\n",
-					""
-				],
-				"execution_count": 63
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"SELECT * FROM  odw_harmonised_db.sb_appeal_document\n",
-					"where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
-					"order by IngestionDate\n",
-					""
-				],
-				"execution_count": 64
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"Automating the above visual checks"
-				]
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -443,6 +364,9 @@
 					}
 				},
 				"source": [
+					"# Trace service bus data from standardised to harmonised\n",
+					"# automated version of previous visual check which is now moved to bottom of notebook\n",
+					"\n",
 					"sb_standardised_query = \"\"\"\n",
 					"SELECT caseId, caseReference, version, size \n",
 					"FROM odw_standardised_db.sb_appeal_document\n",
@@ -468,11 +392,15 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 65
+				"execution_count": 54
 			},
 			{
-				"cell_type": "markdown",
+				"cell_type": "code",
 				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
 					"nteract": {
 						"transient": {
 							"deleting": false
@@ -480,118 +408,9 @@
 					}
 				},
 				"source": [
-					"#### Trace Horizon data to Harmonised"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"refresh  odw_harmonised_db.appeal_document"
-				],
-				"execution_count": 66
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"SELECT DISTINCT\n",
-					"*\n",
-					"FROM odw_harmonised_db.appeal_document\n",
+					"# Trace Horizon data to Harmonised\n",
+					"# automated version of previous visual check which is now moved to bottom of notebook\n",
 					"\n",
-					"where  documentid = '12471993'\n",
-					"order BY\n",
-					"    ingestiondate DESC"
-				],
-				"execution_count": 67
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"SELECT DISTINCT\n",
-					"*\n",
-					"FROM odw_standardised_db.horizon_appeals_document_metadata\n",
-					"where documentid = '12471993' \n",
-					"and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\n",
-					"\n",
-					"order by ingested_datetime\n",
-					""
-				],
-				"execution_count": 68
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"Automate the above visual checks"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"horizon_standardised_query = \"\"\"\n",
 					"SELECT caseReference, filename, size \n",
 					"FROM odw_standardised_db.horizon_appeals_document_metadata\n",
@@ -617,7 +436,237 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 69
+				"execution_count": 17
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Check if there is data coming from ODT (back-office-appeals) and Horizon\n",
+					"# automated version of previous visual check which is now moved to bottom of notebook\n",
+					"\n",
+					"check_ODT_and_horizon_data_query = \"\"\"\n",
+					"(SELECT DISTINCT\n",
+					"*\n",
+					"FROM odw_harmonised_db.appeal_document\n",
+					"WHERE horizonfolderid IS NULL AND sourcesystem = 'back-office-appeals'\n",
+					"ORDER BY ingestiondate DESC)\n",
+					"\"\"\"\n",
+					"\n",
+					"ODT_and_horizon_dataframe = get_dataframe(check_ODT_and_horizon_data_query)\n",
+					"\n",
+					"if ODT_and_horizon_dataframe.isEmpty():\n",
+					"    exitCode += 1"
+				],
+				"execution_count": 57
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"\n",
+					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
+					"data.printSchema()"
+				],
+				"execution_count": 25
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"%run /utils/unit-tests/py_unit_tests_functions"
+				],
+				"execution_count": 44
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name):\n",
+					"    pass  \n",
+					"else:\n",
+					"    exitCode += 1  "
+				],
+				"execution_count": 59
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final):\n",
+					"    pass\n",
+					"else:\n",
+					"    exitCode += 1"
+				],
+				"execution_count": 62
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name):\n",
+					"    pass\n",
+					"else:\n",
+					"    exitCode += 1"
+				],
+				"execution_count": 63
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final):\n",
+					"    pass\n",
+					"else:\n",
+					"    exitCode += 1"
+				],
+				"execution_count": 65
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name):\n",
+					"    pass\n",
+					"else:\n",
+					"    exitCode += 1\n",
+					""
+				],
+				"execution_count": 66
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
+				],
+				"execution_count": 50
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
+				],
+				"execution_count": 51
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"mssparkutils.notebook.exit(exitCode)"
+				],
+				"execution_count": 52
 			},
 			{
 				"cell_type": "markdown",
@@ -629,7 +678,23 @@
 					}
 				},
 				"source": [
-					"###### **Check if there is data coming from ODT (back-office-appeals) and Horizon**"
+					"# Visual checks moved to below notebook exit\n",
+					"This is so they won't run when notebook is called during automation run"
+				]
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"Trace service bus data from standardised to harmonised\n",
+					"\n",
+					"We need to make sure the data has loaded through correctly. To do this efficiently, we will select a sample record and check that the data is maintained as it moves through the medallian architecture"
 				]
 			},
 			{
@@ -651,15 +716,11 @@
 				},
 				"source": [
 					"%%sql\n",
-					"SELECT DISTINCT\n",
-					"*\n",
-					"FROM odw_harmonised_db.appeal_document\n",
-					"\n",
-					"where  horizonfolderid  is null and sourcesystem = 'back-office-appeals'\n",
-					"order BY\n",
-					"    ingestiondate DESC"
+					"SELECT * FROM  odw_standardised_db.sb_appeal_document\n",
+					"where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
+					"order by ingested_datetime"
 				],
-				"execution_count": 70
+				"execution_count": 55
 			},
 			{
 				"cell_type": "code",
@@ -672,25 +733,19 @@
 						"transient": {
 							"deleting": false
 						}
-					}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
 				},
 				"source": [
-					"# automate the above - checking whether there is data coming from ODT (back-office-appeals) and Horizon\n",
-					"\n",
-					"check_ODT_and_horizon_data_query = \"\"\"\n",
-					"(SELECT DISTINCT\n",
-					"*\n",
-					"FROM odw_harmonised_db.appeal_document\n",
-					"WHERE horizonfolderid IS NULL AND sourcesystem = 'back-office-appeals'\n",
-					"ORDER BY ingestiondate DESC)\n",
-					"\"\"\"\n",
-					"\n",
-					"ODT_and_horizon_dataframe = get_dataframe(check_ODT_and_horizon_data_query)\n",
-					"\n",
-					"if ODT_and_horizon_dataframe.isEmpty():\n",
-					"    exitCode =+ 1"
+					"%%sql\n",
+					"SELECT * FROM  odw_harmonised_db.sb_appeal_document\n",
+					"where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
+					"order by IngestionDate"
 				],
-				"execution_count": 71
+				"execution_count": 56
 			},
 			{
 				"cell_type": "markdown",
@@ -702,7 +757,7 @@
 					}
 				},
 				"source": [
-					"### Horizon and Service Bus data successfully combined and flags set appropriately"
+					"Trace Horizon data to Harmonised"
 				]
 			},
 			{
@@ -717,21 +772,15 @@
 							"deleting": false
 						}
 					},
-					"collapsed": false
+					"microsoft": {
+						"language": "sparksql"
+					}
 				},
 				"source": [
-					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
-					"df_sb_hrm = spark.sql(\"select * from odw_harmonised_db.sb_appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' order by IngestionDate\")\n",
-					"df_hrm_final = spark.sql(\"select * from odw_harmonised_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'order by IngestionDate\")\n",
-					"df_cur = spark.sql(\"select * from odw_curated_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\")\n",
-					"\n",
-					"\n",
-					"display(df_hzn_std)\n",
-					"display(df_sb_hrm)\n",
-					"display(df_hrm_final)\n",
-					"display(df_cur)"
+					"%%sql\n",
+					"refresh  odw_harmonised_db.appeal_document"
 				],
-				"execution_count": 72
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -745,23 +794,21 @@
 							"deleting": false
 						}
 					},
-					"collapsed": false
+					"microsoft": {
+						"language": "sparksql"
+					}
 				},
 				"source": [
-					"# need to workout which of the above tables isn't displaying\n",
+					"%%sql\n",
+					"SELECT DISTINCT\n",
+					"*\n",
+					"FROM odw_harmonised_db.appeal_document\n",
 					"\n",
-					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
-					"df_sb_hrm = spark.sql(\"select * from odw_harmonised_db.sb_appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' order by IngestionDate\")\n",
-					"df_hrm_final = spark.sql(\"select * from odw_harmonised_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'order by IngestionDate\")\n",
-					"df_cur = spark.sql(\"select * from odw_curated_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\")\n",
-					"\n",
-					"\n",
-					"display(df_hzn_std) # isn't displaying - investigate after lunch\n",
-					"#display(df_sb_hrm)\n",
-					"#display(df_hrm_final)\n",
-					"#display(df_cur)"
+					"where  documentid = '12471993'\n",
+					"order BY\n",
+					"    ingestiondate DESC"
 				],
-				"execution_count": 73
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -775,49 +822,19 @@
 							"deleting": false
 						}
 					},
-					"collapsed": false
+					"microsoft": {
+						"language": "sparksql"
+					}
 				},
 				"source": [
-					"# delete after troubleshooting\n",
+					"%%sql\n",
+					"SELECT DISTINCT\n",
+					"*\n",
+					"FROM odw_standardised_db.horizon_appeals_document_metadata\n",
+					"where documentid = '12471993' \n",
+					"and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\n",
 					"\n",
-					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = '12535309' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
-					"\n",
-					"#df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\") #12535309\n",
-					"\n",
-					"display(df_hzn_std) # isn't displaying - investigate after lunch"
-				],
-				"execution_count": 102
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"collapsed": false
-				},
-				"source": [
-					"# delete after troubleshooting\n",
-					"\n",
-					"#df_top10_ordered = spark.sql(\"\"\"\n",
-					"#SELECT * \n",
-					"#FROM odw_standardised_db.horizon_appeals_document_metadata \n",
-					"#ORDER BY ingested_datetime DESC \n",
-					"#LIMIT 10\n",
-					"#\"\"\")\n",
-					"#display(df_top10_ordered)\n",
-					"\n",
-					"\n",
-					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = '12535309'\")\n",
-					"\n",
-					"display(df_hzn_std) # isn't displaying - investigate after lunch\n",
-					""
+					"order by ingested_datetime"
 				],
 				"execution_count": null
 			},
@@ -831,7 +848,88 @@
 					}
 				},
 				"source": [
-					"#### Data updated in curated correctly"
+					"Check if there is data coming from ODT (back-office-appeals) and Horizon"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					}
+				},
+				"source": [
+					"%%sql\n",
+					"SELECT DISTINCT\n",
+					"*\n",
+					"FROM odw_harmonised_db.appeal_document\n",
+					"\n",
+					"where  horizonfolderid  is null and sourcesystem = 'back-office-appeals'\n",
+					"order BY\n",
+					"    ingestiondate DESC"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"Horizon and Service Bus data successfully combined and flags set appropriately"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
+					"df_sb_hrm = spark.sql(\"select * from odw_harmonised_db.sb_appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' order by IngestionDate\")\n",
+					"df_hrm_final = spark.sql(\"select * from odw_harmonised_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'order by IngestionDate\")\n",
+					"df_cur = spark.sql(\"select * from odw_curated_db.appeal_document where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\")\n",
+					"\n",
+					"\n",
+					"display(df_hzn_std) # as of 25-09-2024 this table has not been displaying\n",
+					"display(df_sb_hrm)\n",
+					"display(df_hrm_final)\n",
+					"display(df_cur)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"Data updated in curated correctly"
 				]
 			},
 			{
@@ -860,365 +958,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": 75
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"\n",
-					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
-					"data.printSchema()"
-				],
-				"execution_count": 76
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def test_sb_std_to_sb_hrm_no_dropping_records(sb_std_table: str, sb_hrm_table: str) -> bool:\n",
-					"    df: DataFrame = spark.sql(f\"\"\"\n",
-					"    select documentId\n",
-					"    from {std_db_name}.{sb_std_table}\n",
-					"    where documentId not in\n",
-					"    (\n",
-					"        select documentId\n",
-					"        from {hrm_db_name}.{sb_hrm_table}\n",
-					"    )\n",
-					"    \"\"\")\n",
-					"\n",
-					"    return df.count() == 0"
-				],
-				"execution_count": 77
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def test_sb_hrm_to_hrm_final_no_dropping_records(sb_hrm_table: str, hrm_table_final: str) -> bool:\n",
-					"    df: DataFrame = spark.sql(f\"\"\"\n",
-					"    select documentId\n",
-					"    from {hrm_db_name}.{sb_hrm_table}\n",
-					"    where documentId not in\n",
-					"    (\n",
-					"        select documentId\n",
-					"        from {hrm_db_name}.{hrm_table_final}\n",
-					"    )\n",
-					"    \"\"\")\n",
-					"\n",
-					"    return df.count() == 0"
-				],
-				"execution_count": 78
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def test_hrm_to_curated_no_dropping_records(hrm_table_final: str, curated_table_name: str) -> bool:\n",
-					"    df: DataFrame = spark.sql(f\"\"\"\n",
-					"    select documentId\n",
-					"    from {hrm_db_name}.{hrm_table_final}\n",
-					"    where IsActive = 'Y'\n",
-					"    and documentId not in\n",
-					"    (\n",
-					"        select documentId\n",
-					"        from {curated_db_name}.{curated_table_name}\n",
-					"    )\n",
-					"    \"\"\")\n",
-					"\n",
-					"    return df.count() == 0"
-				],
-				"execution_count": 79
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name: str, hrm_table_final: str) -> bool:\n",
-					"    df: DataFrame = spark.sql(f\"\"\"\n",
-					"    select documentId\n",
-					"    from {std_db_name}.{horizon_std_table_name}\n",
-					"    where ingested_datetime = (select max(ingested_datetime) from {std_db_name}.{horizon_std_table_name})\n",
-					"    and documentId not in\n",
-					"    (\n",
-					"        select documentId\n",
-					"        from {hrm_db_name}.{hrm_table_final}\n",
-					"    )\n",
-					"    \"\"\")\n",
-					"\n",
-					"    return df.count() == 0"
-				],
-				"execution_count": 80
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def test_aie_std_to_hrm_no_dropping_records(aie_std_table_name: str, aie_hrm_table_name: str) -> bool:\n",
-					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
-					"    return df.count() == 0 "
-				],
-				"execution_count": 81
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name: str, hrm_table_final: str) -> bool:\n",
-					"    if aie_appeals_documents_count > 0:\n",
-					"        df: DataFrame = aie_hrm_documentIds.subtract(hrm_final_documentIds)\n",
-					"        return df.count() == 0\n",
-					"    else:\n",
-					"        return True"
-				],
-				"execution_count": 82
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def test_document_row_counts_match(hrm_table_final: str, curated_table_name: str) -> DataFrame:\r\n",
-					"    # Count rows per documentId in harmonised final table\r\n",
-					"    hrm_final_counts: DataFrame = hrm_final_df_active.groupBy(\"documentId\").agg(F.count(\"*\").alias(\"hrm_final_count\"))\r\n",
-					"\r\n",
-					"    # Count rows per documentId in curated table\r\n",
-					"    curated_counts: DataFrame = curated_df.groupBy(\"documentId\").agg(F.count(\"*\").alias(\"curated_count\"))\r\n",
-					"\r\n",
-					"    # Join both tables on documentId to compare the counts\r\n",
-					"    comparison_df: DataFrame = hrm_final_counts.join(curated_counts, \"documentId\", how=\"outer\")\r\n",
-					"\r\n",
-					"    comparison_df: DataFrame = comparison_df.withColumn(\"count_difference\", F.col(\"hrm_final_count\") - F.col(\"curated_count\"))\r\n",
-					"\r\n",
-					"    non_zero_differences: DataFrame = comparison_df.filter(\"count_difference > 0\")\r\n",
-					"\r\n",
-					"    return non_zero_differences.count() == 0\r\n",
-					""
-				],
-				"execution_count": 83
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(f\"Service bus std to hrm no documentIds dropped: {test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name)}\")"
-				],
-				"execution_count": 84
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(f\"Service bus hrm to hrm table final no documentIds dropped: {test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final)}\")"
-				],
-				"execution_count": 85
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(f\"hrm table final to curated no documentIds dropped: {test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name)}\")"
-				],
-				"execution_count": 86
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(f\"Horizon std table to hrm table final no documentIds dropped: {test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final)}\")"
-				],
-				"execution_count": 87
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(f\"AIE std table to hrm table no documentIds dropped: {test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name)}\")"
-				],
-				"execution_count": 88
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
-				],
-				"execution_count": 89
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
-				],
-				"execution_count": 90
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"mssparkutils.notebook.exit(exitCode)"
-				],
-				"execution_count": 91
+				"execution_count": 58
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fca3deff-686d-49d2-8c65-1c441a077b42"
+				"spark.autotune.trackingId": "213a9c48-03c8-4d51-86ab-f2ae257c122d"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 100
+				"execution_count": 175
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 101
+				"execution_count": 176
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 102
+				"execution_count": 177
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 103
+				"execution_count": 178
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 104
+				"execution_count": 179
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 105
+				"execution_count": 180
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 106
+				"execution_count": 181
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 107
+				"execution_count": 182
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 108
+				"execution_count": 183
 			},
 			{
 				"cell_type": "markdown",
@@ -348,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 109
+				"execution_count": 184
 			},
 			{
 				"cell_type": "markdown",
@@ -388,7 +388,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 110
+				"execution_count": 185
 			},
 			{
 				"cell_type": "code",
@@ -414,7 +414,7 @@
 					"order by IngestionDate\n",
 					""
 				],
-				"execution_count": 111
+				"execution_count": 186
 			},
 			{
 				"cell_type": "markdown",
@@ -477,9 +477,9 @@
 					"# Compare the DataFrames for the specified columns and print the result\n",
 					"result, exitCode = compare_specific_columns(SB_standardised_dataframe, SB_harmonised_dataframe, columns_to_compare, exitCode)\n",
 					"\n",
-					"print(exitCode)"
+					""
 				],
-				"execution_count": 135
+				"execution_count": 187
 			},
 			{
 				"cell_type": "markdown",
@@ -515,7 +515,7 @@
 					"%%sql\n",
 					"refresh  odw_harmonised_db.appeal_document"
 				],
-				"execution_count": 113
+				"execution_count": 188
 			},
 			{
 				"cell_type": "code",
@@ -544,7 +544,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 114
+				"execution_count": 189
 			},
 			{
 				"cell_type": "code",
@@ -568,16 +568,81 @@
 					"SELECT DISTINCT\n",
 					"*\n",
 					"FROM odw_standardised_db.horizon_appeals_document_metadata\n",
-					"--where documentid = '10847936'\n",
-					"--where documentid = '11514958' \n",
 					"where documentid = '12471993' \n",
-					"-- and\n",
 					"and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\n",
 					"\n",
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 115
+				"execution_count": 190
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"Automate the above visual checks"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"horizon_standardised_dataframe = spark.sql(\"\"\"\n",
+					"SELECT caseReference, filename, size \n",
+					"FROM odw_standardised_db.horizon_appeals_document_metadata\n",
+					"where documentid = '12471993' \n",
+					"and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\n",
+					"order by ingested_datetime\n",
+					"\"\"\")\n",
+					"\n",
+					"horizon_harmonised_dataframe = spark.sql(\"\"\"\n",
+					"SELECT caseReference, filename, size\n",
+					"FROM odw_harmonised_db.appeal_document\n",
+					"where  documentid = '12471993'\n",
+					"order BY\n",
+					"    ingestiondate DESC\n",
+					"\"\"\")\n",
+					"\n",
+					"\n",
+					"def compare_specific_columns(horizon_standardised_dataframe, horizon_harmonised_dataframe, columns, exitCode):\n",
+					"    # Select only the specified columns from both DataFrames\n",
+					"    horizon_standardised_dataframe_selected = horizon_standardised_dataframe.select(columns)\n",
+					"    horizon_harmonised_dataframe_selected = horizon_harmonised_dataframe.select(columns)\n",
+					"    \n",
+					"    # Check if the data is the same for the specified columns\n",
+					"    diff_df = horizon_standardised_dataframe_selected.subtract(horizon_harmonised_dataframe_selected).union(horizon_harmonised_dataframe_selected.subtract(horizon_standardised_dataframe_selected))\n",
+					"    if diff_df.count() == 0:\n",
+					"        print(\"DataFrames match for the specified columns.\")\n",
+					"        return True, exitCode\n",
+					"    else:\n",
+					"        print(\"DataFrames do not match for the specified columns.\")\n",
+					"        diff_df.show()\n",
+					"        exitCode += 1\n",
+					"        return False, exitCode\n",
+					"\n",
+					"# Specify the columns to compare\n",
+					"columns_to_compare = [\"caseReference\", \"filename\", \"size\"]\n",
+					"\n",
+					"# Compare the DataFrames for the specified columns and print the result\n",
+					"result, exitCode = compare_specific_columns(horizon_standardised_dataframe, horizon_harmonised_dataframe, columns_to_compare, exitCode)"
+				],
+				"execution_count": 191
 			},
 			{
 				"cell_type": "markdown",
@@ -619,7 +684,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 116
+				"execution_count": 192
 			},
 			{
 				"cell_type": "markdown",
@@ -660,7 +725,7 @@
 					"display(df_hrm_final)\n",
 					"display(df_cur)"
 				],
-				"execution_count": 117
+				"execution_count": 193
 			},
 			{
 				"cell_type": "markdown",
@@ -701,7 +766,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": 118
+				"execution_count": 194
 			},
 			{
 				"cell_type": "code",
@@ -721,7 +786,7 @@
 					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
 					"data.printSchema()"
 				],
-				"execution_count": 119
+				"execution_count": 195
 			},
 			{
 				"cell_type": "code",
@@ -750,7 +815,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 120
+				"execution_count": 196
 			},
 			{
 				"cell_type": "code",
@@ -779,7 +844,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 121
+				"execution_count": 197
 			},
 			{
 				"cell_type": "code",
@@ -809,7 +874,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 122
+				"execution_count": 198
 			},
 			{
 				"cell_type": "code",
@@ -839,7 +904,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 123
+				"execution_count": 199
 			},
 			{
 				"cell_type": "code",
@@ -859,7 +924,7 @@
 					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
 					"    return df.count() == 0 "
 				],
-				"execution_count": 124
+				"execution_count": 200
 			},
 			{
 				"cell_type": "code",
@@ -882,7 +947,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": 125
+				"execution_count": 201
 			},
 			{
 				"cell_type": "code",
@@ -915,7 +980,7 @@
 					"    return non_zero_differences.count() == 0\r\n",
 					""
 				],
-				"execution_count": 126
+				"execution_count": 202
 			},
 			{
 				"cell_type": "code",
@@ -933,7 +998,7 @@
 				"source": [
 					"print(f\"Service bus std to hrm no documentIds dropped: {test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name)}\")"
 				],
-				"execution_count": 127
+				"execution_count": 203
 			},
 			{
 				"cell_type": "code",
@@ -951,7 +1016,7 @@
 				"source": [
 					"print(f\"Service bus hrm to hrm table final no documentIds dropped: {test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 128
+				"execution_count": 204
 			},
 			{
 				"cell_type": "code",
@@ -969,7 +1034,7 @@
 				"source": [
 					"print(f\"hrm table final to curated no documentIds dropped: {test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 129
+				"execution_count": 205
 			},
 			{
 				"cell_type": "code",
@@ -987,7 +1052,7 @@
 				"source": [
 					"print(f\"Horizon std table to hrm table final no documentIds dropped: {test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 130
+				"execution_count": 206
 			},
 			{
 				"cell_type": "code",
@@ -1005,7 +1070,7 @@
 				"source": [
 					"print(f\"AIE std table to hrm table no documentIds dropped: {test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name)}\")"
 				],
-				"execution_count": 131
+				"execution_count": 207
 			},
 			{
 				"cell_type": "code",
@@ -1023,7 +1088,7 @@
 				"source": [
 					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 132
+				"execution_count": 208
 			},
 			{
 				"cell_type": "code",
@@ -1041,7 +1106,7 @@
 				"source": [
 					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 133
+				"execution_count": 209
 			},
 			{
 				"cell_type": "code",
@@ -1059,7 +1124,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 134
+				"execution_count": 210
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "607fb908-929c-4301-822b-0281630155b0"
+				"spark.autotune.trackingId": "8ef359f5-630f-46da-b3fb-052252503dd2"
 			}
 		},
 		"metadata": {
@@ -762,6 +762,26 @@
 					"#display(df_cur)"
 				],
 				"execution_count": 51
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"df_hzn_std = spark.sql(\"SELECT * from odw_standardised_db.horizon_appeals_document_metadata where documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65' and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\")\n",
+					"\n",
+					"display(df_hzn_std)"
+				],
+				"execution_count": 52
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "213a9c48-03c8-4d51-86ab-f2ae257c122d"
+				"spark.autotune.trackingId": "2ebb5d18-d3f0-4c60-87d1-a98aa1faa96b"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 175
+				"execution_count": 248
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 176
+				"execution_count": 249
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 177
+				"execution_count": 250
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 178
+				"execution_count": 251
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 179
+				"execution_count": 252
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 180
+				"execution_count": 253
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +237,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 181
+				"execution_count": 254
 			},
 			{
 				"cell_type": "markdown",
@@ -274,7 +274,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 182
+				"execution_count": 255
 			},
 			{
 				"cell_type": "markdown",
@@ -314,7 +314,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1 "
 				],
-				"execution_count": 183
+				"execution_count": 256
 			},
 			{
 				"cell_type": "markdown",
@@ -348,7 +348,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 184
+				"execution_count": 257
 			},
 			{
 				"cell_type": "markdown",
@@ -388,7 +388,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 185
+				"execution_count": 258
 			},
 			{
 				"cell_type": "code",
@@ -414,7 +414,7 @@
 					"order by IngestionDate\n",
 					""
 				],
-				"execution_count": 186
+				"execution_count": 259
 			},
 			{
 				"cell_type": "markdown",
@@ -443,43 +443,29 @@
 					}
 				},
 				"source": [
-					"SB_standardised_dataframe = spark.sql(\"\"\"\n",
-					"SELECT caseId, caseReference, version, size FROM odw_standardised_db.sb_appeal_document\n",
+					"sb_standardised_query = \"\"\"\n",
+					"SELECT caseId, caseReference, version, size \n",
+					"FROM odw_standardised_db.sb_appeal_document\n",
 					"WHERE documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
 					"ORDER BY ingested_datetime\n",
-					"\"\"\")\n",
+					"\"\"\"\n",
 					"\n",
-					"SB_harmonised_dataframe = spark.sql(\"\"\"\n",
-					"SELECT caseId, caseReference, version, size FROM odw_harmonised_db.sb_appeal_document\n",
+					"sb_harmonised_query = \"\"\"\n",
+					"SELECT caseId, caseReference, version, size \n",
+					"FROM odw_harmonised_db.sb_appeal_document\n",
 					"WHERE documentid = 'fa4b88ff-2f61-4b45-ad11-0e588f21cc65'\n",
 					"ORDER BY IngestionDate\n",
-					"\"\"\")\n",
+					"\"\"\"\n",
 					"\n",
-					"def compare_specific_columns(SB_standardised_dataframe, SB_harmonised_dataframe, columns, exitCode):\n",
-					"    # Select only the specified columns from both DataFrames\n",
-					"    SB_standardised_dataframe_selected = SB_standardised_dataframe.select(columns)\n",
-					"    SB_harmonised_dataframe_selected = SB_harmonised_dataframe.select(columns)\n",
-					"    \n",
-					"    # Check if the data is the same for the specified columns\n",
-					"    diff_df = SB_standardised_dataframe_selected.subtract(SB_harmonised_dataframe_selected).union(SB_harmonised_dataframe_selected.subtract(SB_standardised_dataframe_selected))\n",
-					"    if diff_df.count() == 0:\n",
-					"        print(\"DataFrames match for the specified columns.\")\n",
-					"        return True, exitCode\n",
-					"    else:\n",
-					"        print(\"DataFrames do not match for the specified columns.\")\n",
-					"        diff_df.show()\n",
-					"        exitCode += 1\n",
-					"        return False, exitCode\n",
+					"SB_standardised_dataframe = get_dataframe(sb_standardised_query)\n",
+					"SB_harmonised_dataframe = get_dataframe(sb_harmonised_query)\n",
 					"\n",
-					"# Specify the columns to compare\n",
-					"columns_to_compare = [\"caseId\", \"caseReference\", \"version\", \"size\"]\n",
+					"sb_columns_to_compare = [\"caseId\", \"caseReference\", \"version\", \"size\"]\n",
 					"\n",
-					"# Compare the DataFrames for the specified columns and print the result\n",
-					"result, exitCode = compare_specific_columns(SB_standardised_dataframe, SB_harmonised_dataframe, columns_to_compare, exitCode)\n",
-					"\n",
-					""
+					"if not compare_dataframes(SB_standardised_dataframe, SB_harmonised_dataframe, sb_columns_to_compare):\n",
+					"    exitCode += 1"
 				],
-				"execution_count": 187
+				"execution_count": 260
 			},
 			{
 				"cell_type": "markdown",
@@ -515,7 +501,7 @@
 					"%%sql\n",
 					"refresh  odw_harmonised_db.appeal_document"
 				],
-				"execution_count": 188
+				"execution_count": 261
 			},
 			{
 				"cell_type": "code",
@@ -544,7 +530,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 189
+				"execution_count": 262
 			},
 			{
 				"cell_type": "code",
@@ -574,7 +560,7 @@
 					"order by ingested_datetime\n",
 					""
 				],
-				"execution_count": 190
+				"execution_count": 263
 			},
 			{
 				"cell_type": "markdown",
@@ -603,46 +589,30 @@
 					}
 				},
 				"source": [
-					"horizon_standardised_dataframe = spark.sql(\"\"\"\n",
+					"horizon_standardised_query = \"\"\"\n",
 					"SELECT caseReference, filename, size \n",
 					"FROM odw_standardised_db.horizon_appeals_document_metadata\n",
-					"where documentid = '12471993' \n",
-					"and ingested_datetime = (select max(ingested_datetime) from odw_standardised_db.horizon_appeals_document_metadata)\n",
-					"order by ingested_datetime\n",
-					"\"\"\")\n",
+					"WHERE documentid = '12471993' \n",
+					"AND ingested_datetime = (SELECT MAX(ingested_datetime) FROM odw_standardised_db.horizon_appeals_document_metadata)\n",
+					"ORDER BY ingested_datetime\n",
+					"\"\"\"\n",
 					"\n",
-					"horizon_harmonised_dataframe = spark.sql(\"\"\"\n",
-					"SELECT caseReference, filename, size\n",
+					"horizon_harmonised_query = \"\"\"\n",
+					"SELECT caseReference, filename, size \n",
 					"FROM odw_harmonised_db.appeal_document\n",
-					"where  documentid = '12471993'\n",
-					"order BY\n",
-					"    ingestiondate DESC\n",
-					"\"\"\")\n",
+					"WHERE documentid = '12471993'\n",
+					"ORDER BY ingestiondate DESC\n",
+					"\"\"\"\n",
 					"\n",
+					"horizon_standardised_dataframe = get_dataframe(horizon_standardised_query)\n",
+					"horizon_harmonised_dataframe = get_dataframe(horizon_harmonised_query)\n",
 					"\n",
-					"def compare_specific_columns(horizon_standardised_dataframe, horizon_harmonised_dataframe, columns, exitCode):\n",
-					"    # Select only the specified columns from both DataFrames\n",
-					"    horizon_standardised_dataframe_selected = horizon_standardised_dataframe.select(columns)\n",
-					"    horizon_harmonised_dataframe_selected = horizon_harmonised_dataframe.select(columns)\n",
-					"    \n",
-					"    # Check if the data is the same for the specified columns\n",
-					"    diff_df = horizon_standardised_dataframe_selected.subtract(horizon_harmonised_dataframe_selected).union(horizon_harmonised_dataframe_selected.subtract(horizon_standardised_dataframe_selected))\n",
-					"    if diff_df.count() == 0:\n",
-					"        print(\"DataFrames match for the specified columns.\")\n",
-					"        return True, exitCode\n",
-					"    else:\n",
-					"        print(\"DataFrames do not match for the specified columns.\")\n",
-					"        diff_df.show()\n",
-					"        exitCode += 1\n",
-					"        return False, exitCode\n",
+					"horizon_columns_to_compare = [\"caseReference\", \"filename\", \"size\"]\n",
 					"\n",
-					"# Specify the columns to compare\n",
-					"columns_to_compare = [\"caseReference\", \"filename\", \"size\"]\n",
-					"\n",
-					"# Compare the DataFrames for the specified columns and print the result\n",
-					"result, exitCode = compare_specific_columns(horizon_standardised_dataframe, horizon_harmonised_dataframe, columns_to_compare, exitCode)"
+					"if not compare_dataframes(horizon_standardised_dataframe, horizon_harmonised_dataframe, horizon_columns_to_compare):\n",
+					"    exitCode += 1"
 				],
-				"execution_count": 191
+				"execution_count": 264
 			},
 			{
 				"cell_type": "markdown",
@@ -684,7 +654,7 @@
 					"order BY\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 192
+				"execution_count": 284
 			},
 			{
 				"cell_type": "markdown",
@@ -725,7 +695,7 @@
 					"display(df_hrm_final)\n",
 					"display(df_cur)"
 				],
-				"execution_count": 193
+				"execution_count": 266
 			},
 			{
 				"cell_type": "markdown",
@@ -766,7 +736,7 @@
 					"WHERE\n",
 					"     documentId = '10847936'"
 				],
-				"execution_count": 194
+				"execution_count": 267
 			},
 			{
 				"cell_type": "code",
@@ -786,7 +756,7 @@
 					"data: DataFrame = spark.sql(\"SELECT * FROM odw_curated_db.appeal_document\")\n",
 					"data.printSchema()"
 				],
-				"execution_count": 195
+				"execution_count": 268
 			},
 			{
 				"cell_type": "code",
@@ -815,7 +785,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 196
+				"execution_count": 269
 			},
 			{
 				"cell_type": "code",
@@ -844,7 +814,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 197
+				"execution_count": 270
 			},
 			{
 				"cell_type": "code",
@@ -874,7 +844,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 198
+				"execution_count": 271
 			},
 			{
 				"cell_type": "code",
@@ -904,7 +874,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 199
+				"execution_count": 272
 			},
 			{
 				"cell_type": "code",
@@ -924,7 +894,7 @@
 					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
 					"    return df.count() == 0 "
 				],
-				"execution_count": 200
+				"execution_count": 273
 			},
 			{
 				"cell_type": "code",
@@ -947,7 +917,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": 201
+				"execution_count": 274
 			},
 			{
 				"cell_type": "code",
@@ -980,7 +950,7 @@
 					"    return non_zero_differences.count() == 0\r\n",
 					""
 				],
-				"execution_count": 202
+				"execution_count": 275
 			},
 			{
 				"cell_type": "code",
@@ -998,7 +968,7 @@
 				"source": [
 					"print(f\"Service bus std to hrm no documentIds dropped: {test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name)}\")"
 				],
-				"execution_count": 203
+				"execution_count": 276
 			},
 			{
 				"cell_type": "code",
@@ -1016,7 +986,7 @@
 				"source": [
 					"print(f\"Service bus hrm to hrm table final no documentIds dropped: {test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 204
+				"execution_count": 277
 			},
 			{
 				"cell_type": "code",
@@ -1034,7 +1004,7 @@
 				"source": [
 					"print(f\"hrm table final to curated no documentIds dropped: {test_hrm_to_curated_no_dropping_records(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 205
+				"execution_count": 278
 			},
 			{
 				"cell_type": "code",
@@ -1052,7 +1022,7 @@
 				"source": [
 					"print(f\"Horizon std table to hrm table final no documentIds dropped: {test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 206
+				"execution_count": 279
 			},
 			{
 				"cell_type": "code",
@@ -1070,7 +1040,7 @@
 				"source": [
 					"print(f\"AIE std table to hrm table no documentIds dropped: {test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name)}\")"
 				],
-				"execution_count": 207
+				"execution_count": 280
 			},
 			{
 				"cell_type": "code",
@@ -1088,7 +1058,7 @@
 				"source": [
 					"print(f\"AIE hrm table to hrm table final no documentIds dropped: {test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name, hrm_table_final)}\")"
 				],
-				"execution_count": 208
+				"execution_count": 281
 			},
 			{
 				"cell_type": "code",
@@ -1106,7 +1076,7 @@
 				"source": [
 					"print(f\"Document row counts match for each document in harmonised final to curated: {test_document_row_counts_match(hrm_table_final, curated_table_name)}\")"
 				],
-				"execution_count": 209
+				"execution_count": 282
 			},
 			{
 				"cell_type": "code",
@@ -1124,7 +1094,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 210
+				"execution_count": 283
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_functions.json
+++ b/workspace/notebook/py_unit_tests_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "80f7bd63-f449-4a0c-b43f-8cd6ecf55431"
+				"spark.autotune.trackingId": "d0fc55af-a502-4c20-8f25-a527eb372d93"
 			}
 		},
 		"metadata": {
@@ -128,6 +128,54 @@
 					"    return spark_dataframe"
 				],
 				"execution_count": 14
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def get_dataframe(query: str) -> DataFrame:\n",
+					"    return spark.sql(query)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def compare_dataframes(df1: DataFrame, df2: DataFrame, columns: list) -> bool:\n",
+					"    df1_selected = df1.select(columns)\n",
+					"    df2_selected = df2.select(columns)\n",
+					"    \n",
+					"    diff_df = df1_selected.exceptAll(df2_selected).union(df2_selected.exceptAll(df1_selected))\n",
+					"    if diff_df.count() == 0:\n",
+					"        print(\"DataFrames match for the specified columns.\")\n",
+					"        return True\n",
+					"    else:\n",
+					"        print(\"DataFrames do not match for the specified columns.\")\n",
+					"        diff_df.show()\n",
+					"        return False"
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_functions.json
+++ b/workspace/notebook/py_unit_tests_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d0fc55af-a502-4c20-8f25-a527eb372d93"
+				"spark.autotune.trackingId": "b8473532-56e9-454b-9e7f-585f3533e12b"
 			}
 		},
 		"metadata": {
@@ -479,6 +479,199 @@
 					"                            \"\"\")\r\n",
 					"\r\n",
 					"    return df.count() == 0"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def test_sb_std_to_sb_hrm_no_dropping_records(sb_std_table: str, sb_hrm_table: str) -> bool:\n",
+					"    df: DataFrame = spark.sql(f\"\"\"\n",
+					"    select documentId\n",
+					"    from {std_db_name}.{sb_std_table}\n",
+					"    where documentId not in\n",
+					"    (\n",
+					"        select documentId\n",
+					"        from {hrm_db_name}.{sb_hrm_table}\n",
+					"    )\n",
+					"    \"\"\")\n",
+					"\n",
+					"    return df.count() == 0"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def test_sb_hrm_to_hrm_final_no_dropping_records(sb_hrm_table: str, hrm_table_final: str) -> bool:\n",
+					"    df: DataFrame = spark.sql(f\"\"\"\n",
+					"    select documentId\n",
+					"    from {hrm_db_name}.{sb_hrm_table}\n",
+					"    where documentId not in\n",
+					"    (\n",
+					"        select documentId\n",
+					"        from {hrm_db_name}.{hrm_table_final}\n",
+					"    )\n",
+					"    \"\"\")\n",
+					"\n",
+					"    return df.count() == 0"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def test_hrm_to_curated_no_dropping_records(hrm_table_final: str, curated_table_name: str) -> bool:\n",
+					"    df: DataFrame = spark.sql(f\"\"\"\n",
+					"    select documentId\n",
+					"    from {hrm_db_name}.{hrm_table_final}\n",
+					"    where IsActive = 'Y'\n",
+					"    and documentId not in\n",
+					"    (\n",
+					"        select documentId\n",
+					"        from {curated_db_name}.{curated_table_name}\n",
+					"    )\n",
+					"    \"\"\")\n",
+					"\n",
+					"    return df.count() == 0"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def test_horizon_to_hrm_final_no_dropping_records(horizon_std_table_name: str, hrm_table_final: str) -> bool:\n",
+					"    df: DataFrame = spark.sql(f\"\"\"\n",
+					"    select documentId\n",
+					"    from {std_db_name}.{horizon_std_table_name}\n",
+					"    where ingested_datetime = (select max(ingested_datetime) from {std_db_name}.{horizon_std_table_name})\n",
+					"    and documentId not in\n",
+					"    (\n",
+					"        select documentId\n",
+					"        from {hrm_db_name}.{hrm_table_final}\n",
+					"    )\n",
+					"    \"\"\")\n",
+					"\n",
+					"    return df.count() == 0"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def test_aie_std_to_hrm_no_dropping_records(aie_std_table_name: str, aie_hrm_table_name: str) -> bool:\n",
+					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
+					"    return df.count() == 0"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def test_aie_hrm_to_hrm_final_no_dropping_records(aie_hrm_table_name: str, hrm_table_final: str) -> bool:\n",
+					"    if aie_appeals_documents_count > 0:\n",
+					"        df: DataFrame = aie_hrm_documentIds.subtract(hrm_final_documentIds)\n",
+					"        return df.count() == 0\n",
+					"    else:\n",
+					"        return True"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def test_document_row_counts_match(hrm_table_final: str, curated_table_name: str) -> DataFrame:\n",
+					"    # Count rows per documentId in harmonised final table\n",
+					"    hrm_final_counts: DataFrame = hrm_final_df_active.groupBy(\"documentId\").agg(F.count(\"*\").alias(\"hrm_final_count\"))\n",
+					"\n",
+					"    # Count rows per documentId in curated table\n",
+					"    curated_counts: DataFrame = curated_df.groupBy(\"documentId\").agg(F.count(\"*\").alias(\"curated_count\"))\n",
+					"\n",
+					"    # Join both tables on documentId to compare the counts\n",
+					"    comparison_df: DataFrame = hrm_final_counts.join(curated_counts, \"documentId\", how=\"outer\")\n",
+					"\n",
+					"    comparison_df: DataFrame = comparison_df.withColumn(\"count_difference\", F.col(\"hrm_final_count\") - F.col(\"curated_count\"))\n",
+					"\n",
+					"    non_zero_differences: DataFrame = comparison_df.filter(\"count_difference > 0\")\n",
+					"\n",
+					"    return non_zero_differences.count() == 0"
 				],
 				"execution_count": null
 			}


### PR DESCRIPTION
Automated the visual SQL tests and moved those to after the notebook exits so they don't run when notebook is called by pytest scripts.

Took functions out of notebook and had a general tidy up