### PR TITLE
Fix/release 2 0 0

### DIFF
--- a/workspace/notebook/Bug_1378_review.json
+++ b/workspace/notebook/Bug_1378_review.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fc1ef18c-05cf-423e-873c-70ef2d5c74c0"
+				"spark.autotune.trackingId": "2820658a-9729-45da-ac16-75820eb619a7"
 			}
 		},
 		"metadata": {
@@ -127,6 +127,9 @@
 							"deleting": false
 						}
 					},
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -176,6 +179,9 @@
 							"deleting": false
 						}
 					},
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -212,6 +218,9 @@
 							"deleting": false
 						}
 					},
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -239,12 +248,15 @@
 			{
 				"cell_type": "code",
 				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
 					"%%sql\n",
 					"SELECT * \n",
-					"FROM odw_curated_db.nsip_data \n",
+					"FROM odw_curated_db.nsip_project\n",
 					"where caseReference = 'TR020002'"
 				],
 				"execution_count": null
@@ -260,6 +272,9 @@
 						"transient": {
 							"deleting": false
 						}
+					},
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},
@@ -286,6 +301,9 @@
 							"deleting": false
 						}
 					},
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -309,6 +327,9 @@
 						"transient": {
 							"deleting": false
 						}
+					},
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},
@@ -334,6 +355,9 @@
 							"deleting": false
 						}
 					},
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -355,6 +379,9 @@
 						"transient": {
 							"deleting": false
 						}
+					},
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},
@@ -379,6 +406,9 @@
 						"transient": {
 							"deleting": false
 						}
+					},
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},
@@ -405,6 +435,9 @@
 							"deleting": false
 						}
 					},
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -428,27 +461,8 @@
 							"deleting": false
 						}
 					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"select *\n",
-					"from odw_curated_db.nsip_representation\n",
-					"where caseRef = 'TR020002'"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},
@@ -471,6 +485,34 @@
 						"transient": {
 							"deleting": false
 						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"select *\n",
+					"from odw_curated_db.nsip_representation\n",
+					"where caseRef = 'TR020002'"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},
@@ -494,6 +536,9 @@
 							"deleting": false
 						}
 					},
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -515,6 +560,9 @@
 						"transient": {
 							"deleting": false
 						}
+					},
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},
@@ -538,6 +586,9 @@
 						"transient": {
 							"deleting": false
 						}
+					},
+					"microsoft": {
+						"language": "sparksql"
 					},
 					"collapsed": false
 				},

--- a/workspace/notebook/Bug_1378_review.json
+++ b/workspace/notebook/Bug_1378_review.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2820658a-9729-45da-ac16-75820eb619a7"
+				"spark.autotune.trackingId": "6e72823b-b2ac-4994-8f21-5591ddd5b738"
 			}
 		},
 		"metadata": {
@@ -620,7 +620,7 @@
 				},
 				"source": [
 					"def test_case_exists(case: str) -> bool:\n",
-					"    df: DataFrame = spark.sql(f\"select * from odw_curated_db.nsip_data where caseReference = '{case}'\")\n",
+					"    df: DataFrame = spark.sql(f\"select * from odw_curated_db.nsip_project where caseReference = '{case}'\")\n",
 					"    return df.count() > 0"
 				],
 				"execution_count": null

--- a/workspace/notebook/Developer_QA.json
+++ b/workspace/notebook/Developer_QA.json
@@ -20,15 +20,15 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b9a6664e-c10b-4e74-b0af-d06bcfe0257d"
+				"spark.autotune.trackingId": "57c9331f-817e-466e-a1ac-90e038393331"
 			}
 		},
 		"metadata": {
 			"saveOutput": true,
 			"enableDebugMode": false,
 			"kernelspec": {
-				"name": "synapse_pyspark",
-				"display_name": "Synapse PySpark"
+				"name": "synapse_sparksql",
+				"display_name": "sql"
 			},
 			"language_info": {
 				"name": "sql"
@@ -122,7 +122,7 @@
 					"    ,projectDescriptionWelsh\r\n",
 					"    ,projectLocationWelsh \r\n",
 					"FROM \r\n",
-					"    odw_curated_db.nsip_data \r\n",
+					"    odw_curated_db.nsip_project\r\n",
 					"where \r\n",
 					"    caseReference = 'EN020014' "
 				],

--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fed72c0c-dfa7-4a95-8a1b-f3ae2a423f23"
+				"spark.autotune.trackingId": "fd5fe360-bbc0-4b65-b513-defbf6175226"
 			}
 		},
 		"metadata": {
@@ -127,7 +127,7 @@
 					"        ,SU.sourceSuid\n",
 					"        ,ND.sourceSystem\n",
 					"    FROM odw_curated_db.service_user SU\n",
-					"    Inner JOIN odw_curated_db.nsip_data ND ON SU.caseReference=ND.casereference\n",
+					"    Inner JOIN odw_curated_db.nsip_project ND ON SU.caseReference=ND.casereference\n",
 					"    WHERE\n",
 					"        SU.sourceSystem = 'back-office-applications'\n",
 					"        OR\n",

--- a/workspace/notebook/nsip_document.json
+++ b/workspace/notebook/nsip_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4bad4713-5275-444f-a4d0-f2856e2f2473"
+				"spark.autotune.trackingId": "9828f6c1-05a4-493d-b334-b82b90c8f7ce"
 			}
 		},
 		"metadata": {
@@ -161,7 +161,7 @@
 					"Doc.transcriptId\t\r\n",
 					"\r\n",
 					"FROM odw_harmonised_db.nsip_document AS Doc\r\n",
-					"LEFT JOIN odw_curated_db.nsip_data Dat\r\n",
+					"LEFT JOIN odw_curated_db.nsip_project Dat\r\n",
 					"    ON Dat.casereference = Doc.caseRef\r\n",
 					"\r\n",
 					"WHERE Doc.IsActive = 'Y';"

--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "83e2cc4f-0cb8-499c-bce8-b312061e2c1b"
+				"spark.autotune.trackingId": "78e43bc6-677f-49b1-8510-0007c37a495a"
 			}
 		},
 		"metadata": {
@@ -95,8 +95,8 @@
 					"    temp_table_name: str = f\"{table_name}_tmp\"\n",
 					"    df.write.mode(\"overwrite\").format(\"delta\").saveAsTable(f\"{db_name}.{temp_table_name}\")\n",
 					"\n",
-					"    # Drop the original table\n",
-					"    spark.sql(f\"DROP TABLE IF EXISTS {db_name}.{table_name}\")\n",
+					"    # Drop the original table and empty the location\n",
+					"    mssparkutils.notebook.run('/utils/py_delete_table', 600, arguments={ 'db_name': db_name, 'table_name': table_name })\n",
 					"\n",
 					"    # Rename the temporary table to replace the original table\n",
 					"    spark.sql(f\"ALTER TABLE {db_name}.{temp_table_name} RENAME TO {db_name}.{table_name}\")"

--- a/workspace/notebook/py_unit_tests_appeals_events.json
+++ b/workspace/notebook/py_unit_tests_appeals_events.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "66753f59-7fbe-46ca-b382-f89df4110487"
+				"spark.autotune.trackingId": "cacc2f1c-c7e4-489e-b7f2-bda06f233483"
 			}
 		},
 		"metadata": {
@@ -988,7 +988,7 @@
 					"SELECT\r\n",
 					"    *\r\n",
 					"FROM\r\n",
-					"    odw_curated_db.nsip_data\r\n",
+					"    odw_curated_db.nsip_project\r\n",
 					"WHERE\r\n",
 					"     caseid = '100000913'"
 				],

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0d051258-a275-43eb-a694-f71d3f3e783a"
+				"spark.autotune.trackingId": "13538af2-b784-4d06-96e4-bd756b4f7644"
 			}
 		},
 		"metadata": {
@@ -94,7 +94,7 @@
 					"std_table_name: str = 'sb_nsip_project'\r\n",
 					"hrm_table_name: str = 'sb_nsip_project'\r\n",
 					"hrm_table_final: str = 'nsip_project'\r\n",
-					"curated_table_name: str = 'nsip_data'\r\n",
+					"curated_table_name: str = 'nsip_project'\r\n",
 					"\r\n",
 					"## new curated database\r\n",
 					"curated_db_migration_name: str = 'odw_curated_migration_db'\r\n",
@@ -982,7 +982,7 @@
 					"SELECT\r\n",
 					"    *\r\n",
 					"FROM\r\n",
-					"    odw_curated_db.nsip_data\r\n",
+					"    odw_curated_db.nsip_project\r\n",
 					"WHERE\r\n",
 					"     caseid = '100000913'"
 				],

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8702eb12-655b-4ec5-85bb-9be30d03b5fa"
+				"spark.autotune.trackingId": "83d566fe-6854-4d08-b038-2c0c7d653e37"
 			}
 		},
 		"metadata": {
@@ -998,7 +998,7 @@
 				},
 				"source": [
 					"def test_case_exists(case: str) -> bool:\n",
-					"    df: DataFrame = spark.sql(f\"select * from odw_curated_db.nsip_data where caseReference = '{case}'\")\n",
+					"    df: DataFrame = spark.sql(f\"select * from odw_curated_db.nsip_project where caseReference = '{case}'\")\n",
 					"    return df.count() > 0"
 				],
 				"execution_count": null
@@ -1125,7 +1125,7 @@
 					}
 				},
 				"source": [
-					"print(f\"Case exists in nsip_data: {test_case_exists(case)}\")\n",
+					"print(f\"Case exists in nsip_project: {test_case_exists(case)}\")\n",
 					"print(f\"Case exists in service user: {test_case_exists_in_service_user(case)}\")\n",
 					"print(f\"Case exists in nsip_representation: {test_case_exists_in_nsip_representation(case)}\")\n",
 					"print(f\"Reps counts match: {test_reps_counts_match(query1, query2)}\")"

--- a/workspace/notebook/py_utils_curated_validate_nsip_project.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_project.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "223ab0da-d669-4578-80cd-2d3a9094b8b2"
+				"spark.autotune.trackingId": "89fd779d-f39a-454b-8d7f-900af652df5a"
 			}
 		},
 		"metadata": {
@@ -188,7 +188,7 @@
 					"SCHEMA = SCHEMAS[\"nsip-project.schema.json\"]\r\n",
 					"PRIMARY_KEY = \"caseId\"\r\n",
 					"DATABASE = \"odw_curated_db\"\r\n",
-					"TABLE = \"nsip_data\"\r\n",
+					"TABLE = \"nsip_project\"\r\n",
 					"QUERY = f\"SELECT * FROM `{DATABASE}`.`{TABLE}` limit 1000\"\r\n",
 					"OUTPUT_FILE = f\"{TABLE}.txt\""
 				],
@@ -213,7 +213,7 @@
 				},
 				"source": [
 					"%%sql\r\n",
-					"select * from odw_curated_db.nsip_data limit 50"
+					"select * from odw_curated_db.nsip_project limit 50"
 				],
 				"execution_count": 35
 			},
@@ -345,7 +345,7 @@
 				},
 				"source": [
 					"%%sql\r\n",
-					"SELECT * FROM odw_curated_db.nsip_data where CaseID = 3148152"
+					"SELECT * FROM odw_curated_db.nsip_project where CaseID = 3148152"
 				],
 				"execution_count": 39
 			},
@@ -505,7 +505,7 @@
 				},
 				"source": [
 					"%%sql \r\n",
-					"SELECT * FROM odw_curated_db.nsip_data where caseID = 3218393"
+					"SELECT * FROM odw_curated_db.nsip_project where caseID = 3218393"
 				],
 				"execution_count": 45
 			},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
