### PR TITLE
fixed appeal document script

### DIFF
--- a/workspace/testing/tests/test_appeal-document.py
+++ b/workspace/testing/tests/test_appeal-document.py
@@ -8,7 +8,7 @@ def test_appeal_document_notebook(credential_name, azure_credential, synapse_end
     warnings.filterwarnings("ignore", category=DeprecationWarning) 
 
     # run the testing notebook
-    notebookname: str = "py_unit_tests"
+    notebookname: str = "py_unit_tests_appeal_document"
     
     notebook_raw_params = {
         "sparkPool": "pinssynspodw",

--- a/workspace/testing/tests/test_entraid.py
+++ b/workspace/testing/tests/test_entraid.py
@@ -36,7 +36,7 @@ def test_entraid_notebook(credential_name, azure_credential, synapse_endpoint: s
     warnings.filterwarnings("ignore", category=DeprecationWarning) 
 
     # run the testing notebook
-    notebookname: str = "py_unit_tests"
+    notebookname: str = "py_unit_tests_entraid"
     
     # Trigger the Master Pipeline for Landing to Raw Zone
     notebook_raw_params = {


### PR DESCRIPTION
Fixed the script to test appeal document which now passes in the pipeline and when triggered locally. Saw a similar error in entraid so changed that but it still fails due to an issue with the notebook itself.