### PR TITLE
Feat/odw/mcp 71

### DIFF
--- a/workspace/dataset/Appeal_has_sink_con.json
+++ b/workspace/dataset/Appeal_has_sink_con.json
@@ -315,7 +315,7 @@
 			}
 		],
 		"typeProperties": {
-			"schema": "load",
+			"schema": "odw",
 			"table": "appeals_has_curated_mipins"
 		}
 	}

--- a/workspace/dataset/AzureSqlTableMiPinsDev.json
+++ b/workspace/dataset/AzureSqlTableMiPinsDev.json
@@ -9,7 +9,7 @@
 		"type": "AzureSqlTable",
 		"schema": [],
 		"typeProperties": {
-			"schema": "load",
+			"schema": "odw",
 			"table": "appeal_event_curated_mipins"
 		}
 	}

--- a/workspace/dataset/Entraid_sink.json
+++ b/workspace/dataset/Entraid_sink.json
@@ -9,7 +9,7 @@
 		"type": "AzureSqlTable",
 		"schema": [],
 		"typeProperties": {
-			"schema": "load",
+			"schema": "odw",
 			"table": "Entraid_curated"
 		}
 	}

--- a/workspace/dataset/appeal_service_user_mipinsdevconn.json
+++ b/workspace/dataset/appeal_service_user_mipinsdevconn.json
@@ -9,7 +9,7 @@
 		"type": "AzureSqlTable",
 		"schema": [],
 		"typeProperties": {
-			"schema": "load",
+			"schema": "odw",
 			"table": "appeal_service_user_curated_mipins"
 		}
 	}

--- a/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
@@ -22,7 +22,7 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
-						"preCopyScript": "drop table if exists load.appeal_event_curated_mipins",
+						"preCopyScript": "drop table if exists odw.appeal_event_curated_mipins",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",

--- a/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
@@ -31,7 +31,7 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
-						"preCopyScript": "drop table if exists load.appeals_has_curated_mipins",
+						"preCopyScript": "drop table if exists odw.appeals_has_curated_mipins",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",

--- a/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
@@ -22,7 +22,7 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
-						"preCopyScript": "drop table if exists load.appeal_service_user_curated_mipins",
+						"preCopyScript": "drop table if exists odw.appeal_service_user_curated_mipins",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",

--- a/workspace/pipeline/pln_copy_entraid_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_entraid_curated_mipins.json
@@ -22,7 +22,7 @@
 					},
 					"sink": {
 						"type": "AzureSqlSink",
-						"preCopyScript": "drop table if exists load.Entraid_curated",
+						"preCopyScript": "drop table if exists odw.Entraid_curated",
 						"writeBehavior": "insert",
 						"sqlWriterUseTableLock": false,
 						"tableOption": "autoCreate",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
