### PR TITLE
fixing syntax errors in notebook json

### DIFF
--- a/workspace/notebook/Bug_1378_review.json
+++ b/workspace/notebook/Bug_1378_review.json
@@ -244,7 +244,7 @@
 				"source": [
 					"##### Curated check - nsip_data"
 				]
-			},odw_curated_db.nsip_project
+			},
 			{
 				"cell_type": "code",
 				"metadata": {
@@ -569,7 +569,7 @@
 				"source": [
 					"%%sql \n",
 					"select odtsourcesystem, count(*) \n",
-					"from odw_harmonised_db.nsip_s51_advice\n",odw_curated_db.nsip_project
+					"from odw_harmonised_db.nsip_s51_advice\n",
 					"where caseReference = 'TR020002'\n",
 					"group by odtsourcesystem"
 				],

--- a/workspace/notebook/py_unit_tests_appeals_events.json
+++ b/workspace/notebook/py_unit_tests_appeals_events.json
@@ -861,4 +861,4 @@
 			}
 		]
 	}
-}odw_curated_db.nsip_project
+}


### PR DESCRIPTION
Removed table name that was somehow added to the notebook json and caused validation error. Invalid json structure. 
