### PR TITLE
Rel/2 0 6

### DIFF
--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "rel_2_0_5",
+				"name": "rel_2_0_6",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"policy": {
@@ -12,7 +12,7 @@
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "rel_2_0_5",
+						"referenceName": "rel_2_0_6",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true

--- a/workspace/pipeline/rel_2_0_6.json
+++ b/workspace/pipeline/rel_2_0_6.json
@@ -1,0 +1,27 @@
+{
+	"name": "rel_2_0_6",
+	"properties": {
+		"activities": [
+			{
+				"name": "Run master pipeline",
+				"type": "ExecutePipeline",
+				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_master",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
+			}
+		],
+		"folder": {
+			"name": "Releases/2.0.6"
+		},
+		"annotations": []
+	}
+}


### PR DESCRIPTION
Release 2.0.6.
Fixed table naming error in documents notebooks.
Running master pipeline in test once deployed as that failed with a network error last night.