### PR TITLE
fix: typo

### DIFF
--- a/workspace/notebook/Developer_QA.json
+++ b/workspace/notebook/Developer_QA.json
@@ -122,7 +122,7 @@
 					"    ,projectDescriptionWelsh\r\n",
 					"    ,projectLocationWelsh \r\n",
 					"FROM \r\n",
-					"    odw_curated_db.nsip_projectect\r\n",
+					"    odw_curated_db.nsip_project\r\n",
 					"where \r\n",
 					"    caseReference = 'EN020014' "
 				],

--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -127,7 +127,7 @@
 					"        ,SU.sourceSuid\n",
 					"        ,ND.sourceSystem\n",
 					"    FROM odw_curated_db.service_user SU\n",
-					"    Inner JOIN odw_curated_db.nsip_projectect ND ON SU.caseReference=ND.casereference\n",
+					"    Inner JOIN odw_curated_db.nsip_project ND ON SU.caseReference=ND.casereference\n",
 					"    WHERE\n",
 					"        SU.sourceSystem = 'back-office-applications'\n",
 					"        OR\n",

--- a/workspace/notebook/nsip_document.json
+++ b/workspace/notebook/nsip_document.json
@@ -161,7 +161,7 @@
 					"doc.transcriptId\t\r\n",
 					"\r\n",
 					"FROM odw_harmonised_db.nsip_document AS doc\r\n",
-					"LEFT JOIN odw_curated_db.nsip_projectect proj\r\n",
+					"LEFT JOIN odw_curated_db.nsip_project proj\r\n",
 					"    ON proj.caseReference = doc.caseRef\r\n",
 					"\r\n",
 					"WHERE doc.IsActive = 'Y';"

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -982,7 +982,7 @@
 					"SELECT\r\n",
 					"    *\r\n",
 					"FROM\r\n",
-					"    odw_curated_db.nsip_projectect\r\n",
+					"    odw_curated_db.nsip_project\r\n",
 					"WHERE\r\n",
 					"     caseid = '100000913'"
 				],

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -998,7 +998,7 @@
 				},
 				"source": [
 					"def test_case_exists(case: str) -> bool:\n",
-					"    df: DataFrame = spark.sql(f\"select * from odw_curated_db.nsip_projectect where caseReference = '{case}'\")\n",
+					"    df: DataFrame = spark.sql(f\"select * from odw_curated_db.nsip_project where caseReference = '{case}'\")\n",
 					"    return df.count() > 0"
 				],
 				"execution_count": null

--- a/workspace/notebook/py_utils_curated_validate_nsip_project.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_project.json
@@ -213,7 +213,7 @@
 				},
 				"source": [
 					"%%sql\r\n",
-					"select * from odw_curated_db.nsip_projectect limit 50"
+					"select * from odw_curated_db.nsip_project limit 50"
 				],
 				"execution_count": 35
 			},
@@ -345,7 +345,7 @@
 				},
 				"source": [
 					"%%sql\r\n",
-					"SELECT * FROM odw_curated_db.nsip_projectect where CaseID = 3148152"
+					"SELECT * FROM odw_curated_db.nsip_project where CaseID = 3148152"
 				],
 				"execution_count": 39
 			},
@@ -505,7 +505,7 @@
 				},
 				"source": [
 					"%%sql \r\n",
-					"SELECT * FROM odw_curated_db.nsip_projectect where caseID = 3218393"
+					"SELECT * FROM odw_curated_db.nsip_project where caseID = 3218393"
 				],
 				"execution_count": 45
 			},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
