### PR TITLE
Updating notebook: py_generate_schema_script

### DIFF
--- a/workspace/notebook/py_generate_schema_script.json
+++ b/workspace/notebook/py_generate_schema_script.json
@@ -21,12 +21,12 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bf9be226-efd9-47d5-9071-7ceb20970938"
+				"spark.autotune.trackingId": "a5c99336-94ba-45d3-8a08-3e147856e3f9"
 			}
 		},
 		"metadata": {
 			"saveOutput": true,
-			"enableDebugMode": false,
+			"enableDebugMode": true,
 			"kernelspec": {
 				"name": "synapse_pyspark",
 				"display_name": "Synapse PySpark"
@@ -74,7 +74,7 @@
 					"# array of file names with corresponding sheet name\n",
 					"files_with_specific_sheets = [{\"filename\": \"Specialist_TPO.xlsx\", \"sheet\": \"MiPINS-SQL\"},{\"filename\": \"Specialist_Hedgerow\", \"sheet\": \"MiPINS-SQL\"},{\"filename\": \"Specialist_HH\", \"sheet\": \"MiPINS-SQL\"}]"
 				],
-				"execution_count": 25
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -96,7 +96,25 @@
 					"specific_file = ''\n",
 					"path_to_source = \"abfss://odw-config@\"+storage_account+\"schema_creation/\""
 				],
-				"execution_count": 26
+				"execution_count": 5
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"%run /utils/py_mount_storage"
+				],
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -117,17 +135,9 @@
 					"import re\r\n",
 					"\r\n",
 					"jobId = mssparkutils.env.getJobId()\r\n",
-					"mssparkutils.fs.unmount(\"/schema\") \r\n",
-					"mssparkutils.fs.unmount(\"/source\") \r\n",
-					"mssparkutils.fs.unmount(\"/target\") \r\n",
-					"mssparkutils.fs.mount(path_to_source, \r\n",
-					"\"/source\", \r\n",
-					"{\"linkedService\":\"ls_storage\"} \r\n",
-					")   \r\n",
-					"mssparkutils.fs.mount(path_to_target, \r\n",
-					"\"/target\", \r\n",
-					"{\"linkedService\":\"ls_storage\"} \r\n",
-					")   \r\n",
+					"\r\n",
+					"mount_storage(path_to_source)\r\n",
+					"mount_storage(path_to_target)\r\n",
 					"\r\n",
 					"file = mssparkutils.fs.ls(path_to_source)\r\n",
 					"\r\n",
@@ -201,7 +211,7 @@
 					"    f.close()\r\n",
 					""
 				],
-				"execution_count": 27
+				"execution_count": 8
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
