### PR TITLE
Feat/odw 1042 add submission id appeal has

### DIFF
--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "78059948-d9dc-49f8-af8c-85828fb94451"
+				"spark.autotune.trackingId": "02e56325-fd49-4b07-87a4-1ecb824fe206"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6a7552a2-d732-4aa2-9a6d-1773bd905614"
+				"spark.autotune.trackingId": "efc987e2-8cd6-4ef9-9b61-5d14c86d9a50"
 			}
 		},
 		"metadata": {
@@ -103,7 +103,7 @@
 					"AH.lpaStatement                             AS lpaStatement,\n",
 					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
 					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
-					"AH.transferredCaseClosedDate                AS caseClosedDate,\n",
+					"AH.transferredCaseClosedDate                AS transferredCaseClosedDate,\n",
 					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
 					"AH.caseDecisionPublishedDate                AS caseDecisionPublishedDate,\n",
 					"AH.caseDecisionOutcome                      AS caseDecisionOutcome,\n",
@@ -166,7 +166,7 @@
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has\")\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_has\")"
 				],
-				"execution_count": null
+				"execution_count": 2
 			}
 		]
 	}

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cefe6cab-ac59-4303-804d-f175cbe13ccf"
+				"spark.autotune.trackingId": "6a7552a2-d732-4aa2-9a6d-1773bd905614"
 			}
 		},
 		"metadata": {
@@ -145,7 +145,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 3
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -166,7 +166,7 @@
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has\")\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_has\")"
 				],
-				"execution_count": 4
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ef09edba-0283-4d26-8e04-13b0f8102b0b"
+				"spark.autotune.trackingId": "78059948-d9dc-49f8-af8c-85828fb94451"
 			}
 		},
 		"metadata": {
@@ -73,6 +73,7 @@
 					"AH.caseStatus                               AS caseStatus,\n",
 					"AH.caseType                                 AS caseType,\n",
 					"AH.caseProcedure                            AS caseProcedure,\n",
+					"AH.submissionId                             AS submissionId,\n",
 					"AH.lpaCode                                  AS lpaCode,\n",
 					"AH.caseOfficerId                            AS caseOfficerId,\n",
 					"AH.inspectorId                              AS inspectorId,\n",

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "adb014dc-e753-4e99-b401-867aa267cdf3"
+				"spark.autotune.trackingId": "cefe6cab-ac59-4303-804d-f175cbe13ccf"
 			}
 		},
 		"metadata": {
@@ -70,10 +70,10 @@
 					"\n",
 					"AH.caseId                                   AS caseId,\n",
 					"AH.caseReference                            AS caseReference,\n",
+					"AH.submissionId                             AS submissionId,\n",
 					"AH.caseStatus                               AS caseStatus,\n",
 					"AH.caseType                                 AS caseType,\n",
 					"AH.caseProcedure                            AS caseProcedure,\n",
-					"AH.submissionId                             AS submissionId,\n",
 					"AH.lpaCode                                  AS lpaCode,\n",
 					"AH.caseOfficerId                            AS caseOfficerId,\n",
 					"AH.inspectorId                              AS inspectorId,\n",

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "02e56325-fd49-4b07-87a4-1ecb824fe206"
+				"spark.autotune.trackingId": "adb014dc-e753-4e99-b401-867aa267cdf3"
 			}
 		},
 		"metadata": {
@@ -145,7 +145,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
 					"WHERE AH.IsActive = 'Y'"
 				],
-				"execution_count": 1
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -166,7 +166,7 @@
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeal_has\")\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_has\")"
 				],
-				"execution_count": 2
+				"execution_count": 4
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_has_appeals.json
+++ b/workspace/notebook/py_unit_tests_has_appeals.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d56fdf18-dbdb-4b80-a69f-e7bc5729129d"
+				"spark.autotune.trackingId": "6b35eb60-897a-43bc-9a0a-bb5f9d539779"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 8
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -94,7 +94,7 @@
 					"hrm_table_name: str = 'sb_appeal_has'\n",
 					"curated_table_name: str = 'appeal_has'"
 				],
-				"execution_count": 9
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -112,7 +112,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 10
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -135,7 +135,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -172,7 +172,7 @@
 					"cur_schema_correct: bool = test_compare_schemas(curated_schema, curated_table_schema)\n",
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")"
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -205,7 +205,7 @@
 					"standardised_count, harmonised_count, counts_match = test_std_same_rows_hrm(std_table_name, hrm_table_name)\n",
 					"print(f\"Standardised Count: {standardised_count: ,}\\nHarmonised Count: {harmonised_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -238,7 +238,7 @@
 					"harmonised_final_count, curated_count, counts_match = test_curated_row_count(hrm_table_name, curated_table_name)\n",
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": 14
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_has_appeals.json
+++ b/workspace/notebook/py_unit_tests_has_appeals.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "08161277-565e-478e-9693-51f161fd0943"
+				"spark.autotune.trackingId": "d60e9e29-2cf6-4101-ab0f-3ad28a4a96b8"
 			}
 		},
 		"metadata": {
@@ -170,8 +170,7 @@
 					"hrm_schema_correct: bool = test_compare_schemas(sb_hrm_schema, sb_hrm_table_schema)\n",
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"cur_schema_correct: bool = test_compare_schemas(curated_schema, curated_table_schema)\n",
-					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
-					"exitCode += int(not hrm_schema_correct)"
+					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")"
 				],
 				"execution_count": 5
 			},

--- a/workspace/notebook/py_unit_tests_has_appeals.json
+++ b/workspace/notebook/py_unit_tests_has_appeals.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e2a19f0c-5dae-4f9e-b1c7-a9fde98537d2"
+				"spark.autotune.trackingId": "4797e244-329d-4727-a1fe-6bf46246c57f"
 			}
 		},
 		"metadata": {
@@ -131,7 +131,9 @@
 					"sb_std_schema = create_spark_schema(std_db_name, entity_name)\n",
 					"sb_std_table_schema = spark.table(f\"{std_db_name}.{std_table_name}\").schema\n",
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
-					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
+					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema\n",
+					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
+					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
 				"execution_count": 8
 			},
@@ -166,7 +168,10 @@
 					"std_schema_correct: bool = test_compare_schemas(sb_std_schema, sb_std_table_schema)\n",
 					"print(f\"Service bus standardised schema correct: {std_schema_correct}\\nTable: {std_db_name}.{std_table_name}\\nDifferences shown above (if any)\")\n",
 					"hrm_schema_correct: bool = test_compare_schemas(sb_hrm_schema, sb_hrm_table_schema)\n",
-					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")"
+					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
+					"cur_schema_correct: bool = test_compare_schemas(curated_schema, curated_table_schema)\n",
+					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
+					"exitCode += int(not hrm_schema_correct)"
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/py_unit_tests_has_appeals.json
+++ b/workspace/notebook/py_unit_tests_has_appeals.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4797e244-329d-4727-a1fe-6bf46246c57f"
+				"spark.autotune.trackingId": "08161277-565e-478e-9693-51f161fd0943"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 5
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -94,7 +94,7 @@
 					"hrm_table_name: str = 'sb_appeal_has'\n",
 					"curated_table_name: str = 'appeal_has'"
 				],
-				"execution_count": 6
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -112,7 +112,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 7
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -135,7 +135,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 8
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -173,7 +173,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_has_appeals.json
+++ b/workspace/notebook/py_unit_tests_has_appeals.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d60e9e29-2cf6-4101-ab0f-3ad28a4a96b8"
+				"spark.autotune.trackingId": "d56fdf18-dbdb-4b80-a69f-e7bc5729129d"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 1
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -94,7 +94,7 @@
 					"hrm_table_name: str = 'sb_appeal_has'\n",
 					"curated_table_name: str = 'appeal_has'"
 				],
-				"execution_count": 2
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -112,7 +112,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 3
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -135,7 +135,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 4
+				"execution_count": 11
 			},
 			{
 				"cell_type": "markdown",
@@ -172,7 +172,7 @@
 					"cur_schema_correct: bool = test_compare_schemas(curated_schema, curated_table_schema)\n",
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")"
 				],
-				"execution_count": 5
+				"execution_count": 12
 			},
 			{
 				"cell_type": "markdown",
@@ -205,7 +205,7 @@
 					"standardised_count, harmonised_count, counts_match = test_std_same_rows_hrm(std_table_name, hrm_table_name)\n",
 					"print(f\"Standardised Count: {standardised_count: ,}\\nHarmonised Count: {harmonised_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "markdown",
@@ -238,7 +238,7 @@
 					"harmonised_final_count, curated_count, counts_match = test_curated_row_count(hrm_table_name, curated_table_name)\n",
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": null
+				"execution_count": 14
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_has_appeals.json
+++ b/workspace/notebook/py_unit_tests_has_appeals.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6b35eb60-897a-43bc-9a0a-bb5f9d539779"
+				"spark.autotune.trackingId": "d48bd463-0fe4-4ef5-a509-710b28704b02"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 20
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -94,7 +94,7 @@
 					"hrm_table_name: str = 'sb_appeal_has'\n",
 					"curated_table_name: str = 'appeal_has'"
 				],
-				"execution_count": 21
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -112,7 +112,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 22
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -135,7 +135,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -172,7 +172,7 @@
 					"cur_schema_correct: bool = test_compare_schemas(curated_schema, curated_table_schema)\n",
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -205,7 +205,7 @@
 					"standardised_count, harmonised_count, counts_match = test_std_same_rows_hrm(std_table_name, hrm_table_name)\n",
 					"print(f\"Standardised Count: {standardised_count: ,}\\nHarmonised Count: {harmonised_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -238,7 +238,7 @@
 					"harmonised_final_count, curated_count, counts_match = test_curated_row_count(hrm_table_name, curated_table_name)\n",
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": null
+				"execution_count": 7
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
