### PR TITLE
Updating notebook: appeals_has_curated_mipins

### DIFF
--- a/workspace/notebook/appeals_has_curated_mipins.json
+++ b/workspace/notebook/appeals_has_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c7452358-ce4f-46ec-8956-c472d347ee27"
+				"spark.autotune.trackingId": "c091de0d-5fb3-4fa9-b611-2fc7a84b1168"
 			}
 		},
 		"metadata": {
@@ -69,6 +69,7 @@
 					"SELECT DISTINCT \n",
 					"CAST(AH.caseId AS INT)                      AS caseId,\n",
 					"AH.caseReference                            AS caseReference,\n",
+					"AH.submissionId                             AS submissionId,\n",
 					"AH.caseStatus                               AS caseStatus,\n",
 					"AH.caseType                                 AS caseType,\n",
 					"AH.caseProcedure                            AS caseProcedure,\n",
@@ -101,7 +102,7 @@
 					"AH.lpaStatement                             AS lpaStatement,\n",
 					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
 					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
-					"AH.transferredCaseClosedDate                AS caseClosedDate,\n",
+					"AH.transferredCaseClosedDate                AS transferredCaseClosedDate,\n",
 					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
 					"AH.caseDecisionPublishedDate                AS caseDecisionPublishedDate,\n",
 					"AH.caseDecisionOutcome                      AS caseDecisionOutcome,\n",
@@ -144,7 +145,7 @@
 					"AH.IsActive                                  AS IsActive\n",
 					"FROM odw_harmonised_db.sb_appeal_has AS AH"
 				],
-				"execution_count": 42
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -162,7 +163,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeals_has_curated_mipins;\")"
 				],
-				"execution_count": 43
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -183,7 +184,7 @@
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeals_has_curated_mipins\")\r\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeals_has_curated_mipins\")"
 				],
-				"execution_count": 44
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -203,7 +204,7 @@
 					"#%%sql\r\n",
 					"#select * from odw_curated_db.appeals_has_curated_mipins"
 				],
-				"execution_count": 45
+				"execution_count": 13
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
