### PR TITLE
Updating trigger: tr_daily_7days_2100

### DIFF
--- a/workspace/trigger/tr_daily_7days_2100.json
+++ b/workspace/trigger/tr_daily_7days_2100.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"description": "Trigger to run the master pipeline 7 days a week at 21:00. Only valid for Prod.",
 		"annotations": [],
-		"runtimeState": "Started",
+		"runtimeState": "Stopped",
 		"pipelines": [
 			{
 				"pipelineReference": {


### PR DESCRIPTION
Disabling 2100 trigger. I used the release pipeline to disable it in Live mode but in Git mode it was still enabled, therefore each time we publish manually it will get enabled again. This will stop this from happening.