### PR TITLE
fix(infrastructure): group assignments need object_id (not id with gr…

### DIFF
--- a/infrastructure/modules/synapse-ingestion/locals.tf
+++ b/infrastructure/modules/synapse-ingestion/locals.tf
@@ -88,7 +88,7 @@ locals {
   service_principal_names = distinct(flatten([for v in concat(local.service_bus_topic_subscriptions_roles, local.service_bus_role_assignments) : v.service_principal_names]))
 
   user_object_ids              = { for u in data.azuread_user.users : lower(u.user_principal_name) => u.id }
-  group_object_ids             = { for g in data.azuread_group.groups : lower(g.display_name) => g.id }
+  group_object_ids             = { for g in data.azuread_group.groups : lower(g.display_name) => g.object_id }
   service_principal_object_ids = { for s in data.azuread_service_principal.service_principals : lower(s.display_name) => s.id }
 
   service_bus_subscription_role_assignments = distinct(concat(


### PR DESCRIPTION
…oup/ prefix)

**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
