### PR TITLE
switched back to spark version 3.3

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -207,7 +207,7 @@ spark_pool_timeout_minutes = 60
 spark_pool_version         = "3.3"
 
 spark_pool_preview_enabled = true
-spark_pool_preview_version = "3.4"
+spark_pool_preview_version = "3.3"
 
 sql_pool_collation = "SQL_Latin1_General_CP1_CI_AS"
 sql_pool_enabled   = false

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -208,7 +208,7 @@ spark_pool_timeout_minutes = 60
 spark_pool_version         = "3.3"
 
 spark_pool_preview_enabled = true
-spark_pool_preview_version = "3.4"
+spark_pool_preview_version = "3.3"
 
 sql_pool_collation = "SQL_Latin1_General_CP1_CI_AS"
 sql_pool_enabled   = false

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -208,7 +208,7 @@ spark_pool_timeout_minutes = 60
 spark_pool_version         = "3.3"
 
 spark_pool_preview_enabled = true
-spark_pool_preview_version = "3.4"
+spark_pool_preview_version = "3.3"
 
 sql_pool_collation = "SQL_Latin1_General_CP1_CI_AS"
 sql_pool_enabled   = false


### PR DESCRIPTION
Switched back to spark pool version 3.3 due to incompatibility with the azure rm version. This needs upgrading in order to make use of spark 3.4 or later.