### PR TITLE
Updating notebook: py_sb_horizon_harmonised_nsip_project

### DIFF
--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_project.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_project.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c7f6da7c-b2fa-4bb6-af28-d90c9ee99f6c"
+				"spark.autotune.trackingId": "a7ec30d5-e74c-4f03-970a-6911dd1be1a5"
 			}
 		},
 		"metadata": {
@@ -199,7 +199,6 @@
 					"                        ,ValidTo\n",
 					"                        ,'' AS RowID\n",
 					"                        ,isMaterialChange\n",
-					"                        ,isMaterialChange\n",
 					"                    FROM \n",
 					"                        {service_bus_table}\n",
 					"                    \"\"\")"
@@ -323,7 +322,6 @@
 					"                        ,NULL AS ValidTo\n",
 					"                        ,'' AS RowID\n",
 					"                        ,CAST(NULL AS BOOLEAN) As isMaterialChange\n",
-					"                        ,CAST(NULL AS BOOLEAN) As isMaterialChange\n",
 					"                        ,'Y' AS IsActive\n",
 					"FROM\n",
 					"    {horizon_table} AS Horizon\n",
@@ -393,7 +391,6 @@
 					"    ,stage5ExtensionToDecisionDeadline\n",
 					"    ,jRPeriodEndDate\n",
 					"    ,dateProjectWithdrawn\n",
-					"    ,cast(isMaterialChange AS BOOLEAN)\n",
 					"    ,cast(isMaterialChange AS BOOLEAN)\n",
 					"    --Start Horizon only fields\n",
 					"    ,examTimetablePublishStatus\n",
@@ -790,10 +787,8 @@
 					"                    ,IFNULL(CAST(applicantdescriptionofproject AS String), '.')\n",
 					"                    ,IFNULL(CAST(HorizonCaseNumber AS int), '.')\n",
 					"                    ,IFNULL(CAST(isMaterialChange AS String), '.')\n",
-					"                    ,IFNULL(CAST(isMaterialChange AS String), '.')\n",
 					"            )\n",
 					"        ) AS RowID\n",
-					"        ,isMaterialChange\n",
 					"        ,isMaterialChange\n",
 					"        ,IsActive\n",
 					"    FROM \n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
