### PR TITLE
Fix/theodw 1492 missing migration records

### DIFF
--- a/workspace/notebook/py_unit_tests_functions.json
+++ b/workspace/notebook/py_unit_tests_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f738f063-3c3b-4ae9-b426-24091aafb13e"
+				"spark.autotune.trackingId": "9bc4faf2-450c-4c81-a822-9da887727d6b"
 			}
 		},
 		"metadata": {
@@ -507,7 +507,8 @@
 					"    (\n",
 					"        select {primary_key}\n",
 					"        from {hrm_db_name}.{sb_hrm_table}\n",
-					"    )\n",
+					"    ) \n",
+					"    and message_id is not null\n",
 					"    \"\"\")\n",
 					"    return df.count() == 0"
 				],

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7312e4b0-c534-42d9-b26e-672fc31ca1aa"
+				"spark.autotune.trackingId": "4b3b8fa4-3c67-4ba5-a446-f40ce594cde3"
 			}
 		},
 		"metadata": {
@@ -516,7 +516,7 @@
 					"# Verify that every project has an applicant\n",
 					"def test_no_project_from_horizon_dropped():\n",
 					"    df = spark.sql(f\"\"\"\n",
-					"        SELECT count(*)\n",
+					"        SELECT *\n",
 					"        FROM odw_standardised_db.horizon_nsip_data\n",
 					"        WHERE caseReference NOT IN (\n",
 					"            SELECT caseReference FROM odw_curated_migration_db.nsip_project\n",

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4b3b8fa4-3c67-4ba5-a446-f40ce594cde3"
+				"spark.autotune.trackingId": "18758b67-4100-48e0-b1a8-22a4f971e57e"
 			}
 		},
 		"metadata": {
@@ -99,7 +99,7 @@
 					"## new curated database\r\n",
 					"curated_db_migration_name: str = 'odw_curated_migration_db'\r\n",
 					"curated_table_migration_name: str = 'nsip_project'\r\n",
-					"primary_key: str = 'caseReference'"
+					"primary_key: str = 'caseId'"
 				],
 				"execution_count": 60
 			},

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d3a6dfae-f91f-45bd-b492-47399394cb02"
+				"spark.autotune.trackingId": "7312e4b0-c534-42d9-b26e-672fc31ca1aa"
 			}
 		},
 		"metadata": {
@@ -485,6 +485,56 @@
 					"print(f\"Horizon to curated no caseids are dropped: {result}\")"
 				],
 				"execution_count": 71
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Test 4: Test No CaseReference is dropped from horizon"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Verify that every project has an applicant\n",
+					"def test_no_project_from_horizon_dropped():\n",
+					"    df = spark.sql(f\"\"\"\n",
+					"        SELECT count(*)\n",
+					"        FROM odw_standardised_db.horizon_nsip_data\n",
+					"        WHERE caseReference NOT IN (\n",
+					"            SELECT caseReference FROM odw_curated_migration_db.nsip_project\n",
+					"        )\n",
+					"        AND expected_from = (\n",
+					"            SELECT MAX(expected_from) FROM odw_standardised_db.horizon_nsip_data\n",
+					"        )\n",
+					"    \"\"\")\n",
+					"\n",
+					"    return df.count() == 0\n",
+					"\n",
+					"if test_no_project_from_horizon_dropped(): \n",
+					"    pass\n",
+					"else:\n",
+					"    print('FAIL: test_no_project_from_horizon_dropped')\n",
+					"    # exitCode += 1"
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "66b06011-3d47-4f7d-87c9-d6e3e6167c51"
+				"spark.autotune.trackingId": "d3a6dfae-f91f-45bd-b492-47399394cb02"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\r\n",
 					"import pprint"
 				],
-				"execution_count": 211
+				"execution_count": 59
 			},
 			{
 				"cell_type": "code",
@@ -99,9 +99,9 @@
 					"## new curated database\r\n",
 					"curated_db_migration_name: str = 'odw_curated_migration_db'\r\n",
 					"curated_table_migration_name: str = 'nsip_project'\r\n",
-					"primary_key: str = 'caseId'"
+					"primary_key: str = 'caseReference'"
 				],
-				"execution_count": 212
+				"execution_count": 60
 			},
 			{
 				"cell_type": "code",
@@ -120,7 +120,7 @@
 					"storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\r\n",
 					"path_to_orchestration_file: str = \"abfss://odw-config@\"+storage_account+\"orchestration/orchestration.json\""
 				],
-				"execution_count": 213
+				"execution_count": 61
 			},
 			{
 				"cell_type": "code",
@@ -208,7 +208,7 @@
 					"\t\t\"isMaterialChange\"\r\n",
 					"\t]"
 				],
-				"execution_count": 214
+				"execution_count": 62
 			},
 			{
 				"cell_type": "code",
@@ -226,7 +226,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 215
+				"execution_count": 63
 			},
 			{
 				"cell_type": "code",
@@ -247,7 +247,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\r\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 216
+				"execution_count": 64
 			},
 			{
 				"cell_type": "markdown",
@@ -282,7 +282,7 @@
 					"hrm_schema_correct: bool = test_compare_schemas(sb_hrm_schema, sb_hrm_table_schema)\r\n",
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")"
 				],
-				"execution_count": 217
+				"execution_count": 65
 			},
 			{
 				"cell_type": "markdown",
@@ -321,7 +321,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\r\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 218
+				"execution_count": 66
 			},
 			{
 				"cell_type": "code",
@@ -353,7 +353,7 @@
 					"    hrm.caseId Is null\r\n",
 					"LIMIT 1"
 				],
-				"execution_count": 219
+				"execution_count": 67
 			},
 			{
 				"cell_type": "markdown",
@@ -386,7 +386,7 @@
 					"harmonised_final_count, curated_count, counts_match = test_curated_row_count(hrm_table_final, curated_table_name)\r\n",
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": 220
+				"execution_count": 68
 			},
 			{
 				"cell_type": "markdown",
@@ -420,7 +420,7 @@
 					"harmonised_count, curated_count, counts_match = test_counts_hrm_cur(hrm_db_name, hrm_table_final, curated_db_migration_name, curated_table_migration_name, primary_key)\r\n",
 					"print(f\"Harmonised Count: {harmonised_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": 11
+				"execution_count": 69
 			},
 			{
 				"cell_type": "markdown",
@@ -452,7 +452,7 @@
 					"no_horizon_records, total_curated_count, distinct_curated_count, counts_match = test_curated_unique_hzn_only(curated_db_migration_name, curated_table_migration_name, primary_key)\r\n",
 					"print(f\"There is no other records than Horizon: {no_horizon_records:}\\nCurated Count: {total_curated_count: ,}\\n Distinct Curated Count: {distinct_curated_count:,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": 12
+				"execution_count": 70
 			},
 			{
 				"cell_type": "markdown",
@@ -484,7 +484,7 @@
 					"result = test_hrm_to_curated_no_dropping_primary_ids_only_records(hrm_db_name, hrm_table_final, curated_db_migration_name, curated_table_migration_name, primary_key)\n",
 					"print(f\"Horizon to curated no caseids are dropped: {result}\")"
 				],
-				"execution_count": 13
+				"execution_count": 71
 			},
 			{
 				"cell_type": "markdown",
@@ -521,7 +521,7 @@
 					"%%sql\r\n",
 					"SELECT * FROM odw_standardised_db.sb_nsip_project"
 				],
-				"execution_count": 14
+				"execution_count": 72
 			},
 			{
 				"cell_type": "code",
@@ -545,7 +545,7 @@
 					"SELECT * FROM odw_standardised_db.sb_nsip_project \r\n",
 					"WHERE caseid = 100000913 order by ingested_datetime desc"
 				],
-				"execution_count": 224
+				"execution_count": 73
 			},
 			{
 				"cell_type": "code",
@@ -569,7 +569,7 @@
 					"SELECT * FROM odw_harmonised_db.sb_nsip_project WHERE caseid = 100000913 \r\n",
 					"Order by IngestionDate desc"
 				],
-				"execution_count": 16
+				"execution_count": 74
 			},
 			{
 				"cell_type": "markdown",
@@ -618,7 +618,7 @@
 					"ORDER BY\r\n",
 					"    2 DESC"
 				],
-				"execution_count": 17
+				"execution_count": 75
 			},
 			{
 				"cell_type": "code",
@@ -642,7 +642,7 @@
 					"SELECT * FROM \r\n",
 					"    odw_standardised_db.horizon_nsip_data"
 				],
-				"execution_count": 18
+				"execution_count": 76
 			},
 			{
 				"cell_type": "markdown",
@@ -748,7 +748,7 @@
 					"WHERE\r\n",
 					"     horizoncasenumber = '3222228'"
 				],
-				"execution_count": 19
+				"execution_count": 77
 			},
 			{
 				"cell_type": "code",
@@ -846,7 +846,7 @@
 					"order BY\r\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 20
+				"execution_count": 78
 			},
 			{
 				"cell_type": "markdown",
@@ -892,7 +892,7 @@
 					"ORDER BY\r\n",
 					"    2 desc"
 				],
-				"execution_count": 231
+				"execution_count": 79
 			},
 			{
 				"cell_type": "code",
@@ -925,7 +925,7 @@
 					"ORDER BY\r\n",
 					"    2 desc"
 				],
-				"execution_count": 232
+				"execution_count": 80
 			},
 			{
 				"cell_type": "code",
@@ -955,7 +955,7 @@
 					"order BY\r\n",
 					"    ingestiondate DESC"
 				],
-				"execution_count": 233
+				"execution_count": 81
 			},
 			{
 				"cell_type": "markdown",
@@ -996,7 +996,7 @@
 					"WHERE\r\n",
 					"    caseid = '100000913'"
 				],
-				"execution_count": 238
+				"execution_count": 82
 			},
 			{
 				"cell_type": "markdown",
@@ -1047,7 +1047,7 @@
 					"where caseid in (3148455,3217867) and LOWER(SourceSystem) ='horizon'\r\n",
 					"order by caseid"
 				],
-				"execution_count": null
+				"execution_count": 83
 			},
 			{
 				"cell_type": "markdown",
@@ -1084,7 +1084,7 @@
 					"select * from odw_harmonised_db.nsip_project tbl_1\r\n",
 					"where LOWER(SourceSystem)='horizon'  and IngestionDate = (select max(IngestionDate) from odw_harmonised_db.nsip_project tbl_2  WHERE tbl_1.caseid = tbl_2.caseid group by caseid) and caseid in (3148455,3217867)"
 				],
-				"execution_count": null
+				"execution_count": 84
 			},
 			{
 				"cell_type": "markdown",
@@ -1123,7 +1123,7 @@
 					"GROUP BY caseid\r\n",
 					"HAVING COUNT(*) > 1;"
 				],
-				"execution_count": null
+				"execution_count": 85
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "18758b67-4100-48e0-b1a8-22a4f971e57e"
+				"spark.autotune.trackingId": "078bd093-5892-42c7-ba96-bbc20139f1a8"
 			}
 		},
 		"metadata": {
@@ -99,7 +99,7 @@
 					"## new curated database\r\n",
 					"curated_db_migration_name: str = 'odw_curated_migration_db'\r\n",
 					"curated_table_migration_name: str = 'nsip_project'\r\n",
-					"primary_key: str = 'caseId'"
+					"primary_key: str = 'caseId' # or caseReference?"
 				],
 				"execution_count": 60
 			},

--- a/workspace/notebook/py_unit_tests_relevant_representation.json
+++ b/workspace/notebook/py_unit_tests_relevant_representation.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6b560a5a-f8c0-4cc4-85d1-4a4a6053a16f"
+				"spark.autotune.trackingId": "114e45fa-37d9-4637-9405-36148c25c5e5"
 			}
 		},
 		"metadata": {
@@ -59,7 +59,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 19
+				"execution_count": 41
 			},
 			{
 				"cell_type": "code",
@@ -90,7 +90,7 @@
 					"curated_migration_db_name: str = 'odw_curated_migration_db'\n",
 					"curated_migration_table_name: str = 'nsip_representation'"
 				],
-				"execution_count": 20
+				"execution_count": 42
 			},
 			{
 				"cell_type": "code",
@@ -109,7 +109,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 21
+				"execution_count": 43
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 					"\t\t\"attachmentIds\"\n",
 					"\t]"
 				],
-				"execution_count": 22
+				"execution_count": 44
 			},
 			{
 				"cell_type": "code",
@@ -164,7 +164,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 23
+				"execution_count": 45
 			},
 			{
 				"cell_type": "code",
@@ -185,7 +185,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 24
+				"execution_count": 46
 			},
 			{
 				"cell_type": "markdown",
@@ -219,7 +219,7 @@
 					"hrm_schema_correct: bool = test_compare_schemas(sb_hrm_schema, sb_hrm_table_schema)\n",
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")"
 				],
-				"execution_count": 25
+				"execution_count": 47
 			},
 			{
 				"cell_type": "markdown",
@@ -258,7 +258,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 26
+				"execution_count": 48
 			},
 			{
 				"cell_type": "markdown",
@@ -291,7 +291,7 @@
 					"harmonised_final_count, curated_count, counts_match = test_curated_row_count(hrm_table_final, curated_table_name, data_model_columns)\n",
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")"
 				],
-				"execution_count": 27
+				"execution_count": 49
 			},
 			{
 				"cell_type": "markdown",
@@ -330,7 +330,7 @@
 					"exitCode += int(not cur_migrated_schema_correct)\n",
 					"print(f\"Curated Migration schema correct: {cur_migrated_schema_correct}\\nTable: {curated_migration_db_name}.{curated_migration_table_name}\\nDifferences shown above (if any)\")"
 				],
-				"execution_count": 28
+				"execution_count": 50
 			},
 			{
 				"cell_type": "markdown",
@@ -364,7 +364,7 @@
 					"print(f\"Horizon to Curared - Counts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 29
+				"execution_count": 51
 			},
 			{
 				"cell_type": "markdown",
@@ -398,7 +398,7 @@
 					"print(f\"Horizon to Curared - No rows dropped: {rows_dropped}\")\n",
 					"exitCode += int(not rows_dropped)"
 				],
-				"execution_count": 30
+				"execution_count": 52
 			},
 			{
 				"cell_type": "markdown",
@@ -432,7 +432,7 @@
 					"exitCode += int(not no_horizon_records)\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 31
+				"execution_count": 53
 			},
 			{
 				"cell_type": "markdown",
@@ -476,7 +476,7 @@
 					"else:\n",
 					"    print('FAIL: dangling caseReference found')"
 				],
-				"execution_count": 32
+				"execution_count": 54
 			},
 			{
 				"cell_type": "markdown",
@@ -517,7 +517,7 @@
 					"else:\n",
 					"    print('FAIL: NULL representedId found')"
 				],
-				"execution_count": 33
+				"execution_count": 55
 			},
 			{
 				"cell_type": "markdown",
@@ -572,7 +572,7 @@
 					"    print('FAIL: Expected count of representations match')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 34
+				"execution_count": 56
 			},
 			{
 				"cell_type": "code",
@@ -590,7 +590,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 35
+				"execution_count": 57
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "12647e1e-b6a0-4c22-88c1-fb533f180167"
+				"spark.autotune.trackingId": "be1f498a-a9e5-4628-8432-8f2536de2de7"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e34e17d4-4f70-4793-93c3-31ed55c17ff7"
+				"spark.autotune.trackingId": "058c8448-9179-4273-ae5c-f29599f1ad4f"
 			}
 		},
 		"metadata": {
@@ -73,7 +73,7 @@
 					"from pyspark.sql import functions as F\n",
 					""
 				],
-				"execution_count": 57
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -92,7 +92,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 58
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,31 @@
 					"service_user_appeal_table: str = 'appeal_service_user'\n",
 					"service_user_migration_table: str = 'service_user'"
 				],
-				"execution_count": 59
+				"execution_count": 4
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					},
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"select * from odw_standardised_db.sb_service_user where id not in (select id from odw_harmonised_db.sb_service_user )\n",
+					"and message_id is  null"
+				],
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -163,7 +187,7 @@
 					"\t\"sourceSystem\",\n",
 					"\t\"sourceSuid\"]"
 				],
-				"execution_count": 60
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -181,7 +205,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 5
+				"execution_count": 25
 			},
 			{
 				"cell_type": "code",
@@ -209,7 +233,7 @@
 					"curated_migration_schema = create_spark_schema(curated_migration_db_name, entity_name)\n",
 					"curated_migration_table_schema = spark.table(f\"{curated_migration_db_name}.{service_user_migration_table}\").schema"
 				],
-				"execution_count": 61
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -256,7 +280,7 @@
 					"print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_migration_schema_correct)"
 				],
-				"execution_count": 72
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -296,7 +320,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 63
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -315,9 +339,10 @@
 					"if test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name, 'id'):\n",
 					"   pass\n",
 					"else:\n",
-					"    exitCode += 1"
+					"   print('Failed: test_sb_std_to_sb_hrm_no_dropping_records')\n",
+					"   exitCode += 1"
 				],
-				"execution_count": 64
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -336,9 +361,23 @@
 					"if test_sb_hrm_to_hrm_final_no_dropping_records(hrm_table_name, hrm_table_final, 'id'):\n",
 					"    pass\n",
 					"else:\n",
+					"    print('Failed: test_sb_hrm_to_hrm_final_no_dropping_records')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 65
+				"execution_count": 27
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"#### The following test is not a valid one since `service_user_appeal_table` only filters out Appellants from all Service Users from the harmonised table"
+				]
 			},
 			{
 				"cell_type": "code",
@@ -354,12 +393,13 @@
 					}
 				},
 				"source": [
-					"if test_hrm_to_curated_no_dropping_records(hrm_table_final, service_user_appeal_table, 'id'):\n",
-					"    pass\n",
-					"else:\n",
-					"    exitCode += 1"
+					"# if test_hrm_to_curated_no_dropping_records(hrm_table_final, service_user_appeal_table, 'id'):\n",
+					"#     pass\n",
+					"# else:\n",
+					"#     print('Failed: test_hrm_to_curated_no_dropping_records')\n",
+					"#     exitCode += 1"
 				],
-				"execution_count": 66
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -378,9 +418,10 @@
 					"if test_curated_unique_hzn_only(curated_db_name, service_user_appeal_table, 'id'):\n",
 					"    pass\n",
 					"else:\n",
+					"    print('Failed: test_curated_unique_hzn_only')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 67
+				"execution_count": 21
 			},
 			{
 				"cell_type": "markdown",
@@ -441,7 +482,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 68
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -476,7 +517,7 @@
 					"    print('FAIL: Each project has an applicant')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 69
+				"execution_count": 15
 			},
 			{
 				"cell_type": "markdown",
@@ -524,7 +565,7 @@
 					"    print('FAIL: Expected count of representations match')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 70
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -542,7 +583,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 71
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "058c8448-9179-4273-ae5c-f29599f1ad4f"
+				"spark.autotune.trackingId": "e0be5ab3-e855-4e8b-9658-0245a5b16757"
 			}
 		},
 		"metadata": {
@@ -73,7 +73,7 @@
 					"from pyspark.sql import functions as F\n",
 					""
 				],
-				"execution_count": 2
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
@@ -92,7 +92,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 3
+				"execution_count": 32
 			},
 			{
 				"cell_type": "code",
@@ -123,31 +123,7 @@
 					"service_user_appeal_table: str = 'appeal_service_user'\n",
 					"service_user_migration_table: str = 'service_user'"
 				],
-				"execution_count": 4
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"microsoft": {
-						"language": "sparksql"
-					},
-					"collapsed": false
-				},
-				"source": [
-					"%%sql\n",
-					"select * from odw_standardised_db.sb_service_user where id not in (select id from odw_harmonised_db.sb_service_user )\n",
-					"and message_id is  null"
-				],
-				"execution_count": 24
+				"execution_count": 33
 			},
 			{
 				"cell_type": "code",
@@ -187,7 +163,7 @@
 					"\t\"sourceSystem\",\n",
 					"\t\"sourceSuid\"]"
 				],
-				"execution_count": 5
+				"execution_count": 34
 			},
 			{
 				"cell_type": "code",
@@ -205,7 +181,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 25
+				"execution_count": 35
 			},
 			{
 				"cell_type": "code",
@@ -233,7 +209,7 @@
 					"curated_migration_schema = create_spark_schema(curated_migration_db_name, entity_name)\n",
 					"curated_migration_table_schema = spark.table(f\"{curated_migration_db_name}.{service_user_migration_table}\").schema"
 				],
-				"execution_count": 7
+				"execution_count": 36
 			},
 			{
 				"cell_type": "markdown",
@@ -280,7 +256,7 @@
 					"print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_migration_schema_correct)"
 				],
-				"execution_count": 8
+				"execution_count": 37
 			},
 			{
 				"cell_type": "markdown",
@@ -320,7 +296,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 9
+				"execution_count": 38
 			},
 			{
 				"cell_type": "code",
@@ -342,7 +318,7 @@
 					"   print('Failed: test_sb_std_to_sb_hrm_no_dropping_records')\n",
 					"   exitCode += 1"
 				],
-				"execution_count": 26
+				"execution_count": 39
 			},
 			{
 				"cell_type": "code",
@@ -364,7 +340,7 @@
 					"    print('Failed: test_sb_hrm_to_hrm_final_no_dropping_records')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 27
+				"execution_count": 40
 			},
 			{
 				"cell_type": "markdown",
@@ -399,7 +375,7 @@
 					"#     print('Failed: test_hrm_to_curated_no_dropping_records')\n",
 					"#     exitCode += 1"
 				],
-				"execution_count": 30
+				"execution_count": 41
 			},
 			{
 				"cell_type": "code",
@@ -421,7 +397,7 @@
 					"    print('Failed: test_curated_unique_hzn_only')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 21
+				"execution_count": 42
 			},
 			{
 				"cell_type": "markdown",
@@ -482,7 +458,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 14
+				"execution_count": 43
 			},
 			{
 				"cell_type": "code",
@@ -517,7 +493,7 @@
 					"    print('FAIL: Each project has an applicant')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 15
+				"execution_count": 44
 			},
 			{
 				"cell_type": "markdown",
@@ -565,7 +541,7 @@
 					"    print('FAIL: Expected count of representations match')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 16
+				"execution_count": 45
 			},
 			{
 				"cell_type": "code",
@@ -583,7 +559,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 17
+				"execution_count": 46
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e0be5ab3-e855-4e8b-9658-0245a5b16757"
+				"spark.autotune.trackingId": "12647e1e-b6a0-4c22-88c1-fb533f180167"
 			}
 		},
 		"metadata": {
@@ -73,7 +73,7 @@
 					"from pyspark.sql import functions as F\n",
 					""
 				],
-				"execution_count": 31
+				"execution_count": 49
 			},
 			{
 				"cell_type": "code",
@@ -92,7 +92,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 32
+				"execution_count": 50
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"service_user_appeal_table: str = 'appeal_service_user'\n",
 					"service_user_migration_table: str = 'service_user'"
 				],
-				"execution_count": 33
+				"execution_count": 51
 			},
 			{
 				"cell_type": "code",
@@ -163,7 +163,7 @@
 					"\t\"sourceSystem\",\n",
 					"\t\"sourceSuid\"]"
 				],
-				"execution_count": 34
+				"execution_count": 52
 			},
 			{
 				"cell_type": "code",
@@ -181,7 +181,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 35
+				"execution_count": 53
 			},
 			{
 				"cell_type": "code",
@@ -209,7 +209,7 @@
 					"curated_migration_schema = create_spark_schema(curated_migration_db_name, entity_name)\n",
 					"curated_migration_table_schema = spark.table(f\"{curated_migration_db_name}.{service_user_migration_table}\").schema"
 				],
-				"execution_count": 36
+				"execution_count": 54
 			},
 			{
 				"cell_type": "markdown",
@@ -251,12 +251,11 @@
 					"exitCode += int(not cur_schema_correct)\n",
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{service_user_appeal_table}\\nDifferences shown above (if any)\")\n",
 					"\n",
-					"#test currently fails; ticket created THEODW-1459\n",
 					"cur_migration_schema_correct: bool = test_compare_schemas(curated_migration_schema, curated_migration_table_schema)\n",
 					"print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_migration_schema_correct)"
 				],
-				"execution_count": 37
+				"execution_count": 55
 			},
 			{
 				"cell_type": "markdown",
@@ -296,7 +295,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 38
+				"execution_count": 56
 			},
 			{
 				"cell_type": "code",
@@ -318,7 +317,7 @@
 					"   print('Failed: test_sb_std_to_sb_hrm_no_dropping_records')\n",
 					"   exitCode += 1"
 				],
-				"execution_count": 39
+				"execution_count": 57
 			},
 			{
 				"cell_type": "code",
@@ -340,7 +339,7 @@
 					"    print('Failed: test_sb_hrm_to_hrm_final_no_dropping_records')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 40
+				"execution_count": 58
 			},
 			{
 				"cell_type": "markdown",
@@ -375,7 +374,7 @@
 					"#     print('Failed: test_hrm_to_curated_no_dropping_records')\n",
 					"#     exitCode += 1"
 				],
-				"execution_count": 41
+				"execution_count": 59
 			},
 			{
 				"cell_type": "code",
@@ -397,7 +396,7 @@
 					"    print('Failed: test_curated_unique_hzn_only')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 42
+				"execution_count": 60
 			},
 			{
 				"cell_type": "markdown",
@@ -458,7 +457,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 43
+				"execution_count": 61
 			},
 			{
 				"cell_type": "code",
@@ -493,7 +492,7 @@
 					"    print('FAIL: Each project has an applicant')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 44
+				"execution_count": 62
 			},
 			{
 				"cell_type": "markdown",
@@ -541,7 +540,7 @@
 					"    print('FAIL: Expected count of representations match')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 45
+				"execution_count": 63
 			},
 			{
 				"cell_type": "code",
@@ -559,7 +558,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 46
+				"execution_count": 64
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/service_user_migration.json
+++ b/workspace/notebook/service_user_migration.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "68e53b51-4874-4712-8f99-7e3781df561b"
+				"spark.autotune.trackingId": "ccdde5c3-1913-4484-af9d-c50cadb60869"
 			}
 		},
 		"metadata": {
@@ -106,7 +106,7 @@
 					"\r\n",
 					"    SELECT id, MAX(IngestionDate) AS latest_date\r\n",
 					"    FROM odw_harmonised_db.service_user\r\n",
-					"    WHERE LOWER(sourceSystem) = 'horizon'\r\n",
+					"    WHERE LOWER(ODTSourceSystem) = 'horizon'\r\n",
 					"    GROUP BY id\r\n",
 					"    \r\n",
 					") latest ON SU.id = latest.id AND SU.IngestionDate = latest.latest_date   \r\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
