### PR TITLE
Feat/theodw 1500 entraid unit test

### DIFF
--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "605a35f7-3c32-4ee1-ba7a-4f9fb06a7e00"
+				"spark.autotune.trackingId": "07ca2dbd-a0b5-4949-856d-b703488fd3ea"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "07d8edbd-f590-44c0-a46f-f9350a1bca21"
+				"spark.autotune.trackingId": "605a35f7-3c32-4ee1-ba7a-4f9fb06a7e00"
 			}
 		},
 		"metadata": {
@@ -172,11 +172,12 @@
 					"    StructField(\"ODTSourceSystem\", StringType(), True),\r\n",
 					"    StructField(\"SourceSystemID\", StringType(), True),\r\n",
 					"    StructField(\"IngestionDate\", StringType(), True),\r\n",
-					"    StructField(\"message_id\", StringType(), True),\r\n",
 					"    StructField(\"ValidTo\", StringType(), True),\r\n",
 					"    StructField(\"RowID\", StringType(), True),\r\n",
 					"    StructField(\"IsActive\", StringType(), True)\r\n",
-					"])"
+					"])\r\n",
+					"if is_servicebus_schema:\r\n",
+					"    harmonised_fields = StructType(harmonised_fields.fields + [StructField(\"message_id\", StringType(), True)])"
 				],
 				"execution_count": 25
 			},

--- a/workspace/notebook/py_unit_tests_entraid.json
+++ b/workspace/notebook/py_unit_tests_entraid.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d085972d-33e1-44ea-a442-4c2d56ed65e9"
+				"spark.autotune.trackingId": "5b3d41bc-5c7a-4e30-af88-0efad20a4c6f"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 100
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -95,7 +95,7 @@
 					"hrm_table_name: str = 'entraid'\n",
 					"curated_table_name: str = 'entraid'"
 				],
-				"execution_count": 101
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -114,7 +114,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 102
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -132,7 +132,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 103
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name, None, False)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 104
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -190,7 +190,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 105
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -232,7 +232,7 @@
 					"    \"\"\")\r\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 106
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -253,7 +253,7 @@
 					"else:\r\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 107
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -287,115 +287,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 108
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def show_differences_between_tables(hrm_table: str, curated_table: str, primary_key: str) -> DataFrame:\r\n",
-					"    differences_df: DataFrame = spark.sql(f\"\"\"\r\n",
-					"    SELECT *\r\n",
-					"    FROM {hrm_db_name}.{hrm_table} hrm\r\n",
-					"    FULL OUTER JOIN {curated_db_name}.{curated_table} curated\r\n",
-					"    ON hrm.{primary_key} = curated.{primary_key}\r\n",
-					"    WHERE hrm.{primary_key} IS NULL OR curated.{primary_key} IS NULL\r\n",
-					"    \"\"\")\r\n",
-					"    return differences_df\r\n",
-					"\r\n",
-					"differences_df = show_differences_between_tables(hrm_table_name, curated_table_name, 'Id')\r\n",
-					"differences_df.show()"
-				],
-				"execution_count": 109
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def show_records_in_hrm_not_in_curated(hrm_table: str, curated_table: str, primary_key: str) -> DataFrame:\r\n",
-					"    # List of common columns\r\n",
-					"    common_columns = [\"employeeId\", \"id\", \"givenName\", \"surname\", \"userPrincipalName\"]\r\n",
-					"\r\n",
-					"    # Records in harmonised table but not in curated table\r\n",
-					"    hrm_not_in_curated_df: DataFrame = spark.sql(f\"\"\"\r\n",
-					"    SELECT {', '.join([f'hrm.{col}' for col in common_columns])}\r\n",
-					"    FROM {hrm_db_name}.{hrm_table} hrm\r\n",
-					"    LEFT JOIN {curated_db_name}.{curated_table} curated\r\n",
-					"    ON hrm.{primary_key} = curated.{primary_key}\r\n",
-					"    WHERE curated.{primary_key} IS NULL\r\n",
-					"    \"\"\")\r\n",
-					"\r\n",
-					"    return hrm_not_in_curated_df\r\n",
-					"\r\n",
-					"differences_df = show_records_in_hrm_not_in_curated(hrm_table_name, curated_table_name, 'Id')\r\n",
-					"differences_df.show()"
-				],
-				"execution_count": 110
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"def show_differences_between_tables(hrm_table: str, curated_table: str, primary_key: str) -> DataFrame:\r\n",
-					"    # List of common columns\r\n",
-					"    common_columns = [\"employeeId\", \"id\", \"givenName\", \"surname\", \"userPrincipalName\"]\r\n",
-					"\r\n",
-					"    # Records in harmonised table but not in curated table\r\n",
-					"    hrm_not_in_curated_df: DataFrame = spark.sql(f\"\"\"\r\n",
-					"    SELECT {', '.join([f'hrm.{col}' for col in common_columns])}\r\n",
-					"    FROM {hrm_db_name}.{hrm_table} hrm\r\n",
-					"    LEFT JOIN {curated_db_name}.{curated_table} curated\r\n",
-					"    ON hrm.{primary_key} = curated.{primary_key}\r\n",
-					"    WHERE curated.{primary_key} IS NULL\r\n",
-					"    \"\"\")\r\n",
-					"\r\n",
-					"    # Records in curated table but not in harmonised table\r\n",
-					"    curated_not_in_hrm_df: DataFrame = spark.sql(f\"\"\"\r\n",
-					"    SELECT {', '.join([f'curated.{col}' for col in common_columns])}\r\n",
-					"    FROM {curated_db_name}.{curated_table} curated\r\n",
-					"    LEFT JOIN {hrm_db_name}.{hrm_table} hrm\r\n",
-					"    ON curated.{primary_key} = hrm.{primary_key}\r\n",
-					"    WHERE hrm.{primary_key} IS NULL\r\n",
-					"    \"\"\")\r\n",
-					"\r\n",
-					"    # Union the two DataFrames to get all differing records\r\n",
-					"    differences_df: DataFrame = hrm_not_in_curated_df.union(curated_not_in_hrm_df)\r\n",
-					"    return differences_df\r\n",
-					"\r\n",
-					"differences_df = show_differences_between_tables(hrm_table_name, curated_table_name, 'Id')\r\n",
-					"differences_df.show()"
-				],
-				"execution_count": 111
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -429,7 +321,7 @@
 					"print(f\"Is Curated Data Valid: {is_valid_data}\")\n",
 					"exitCode += int(not is_valid_data)"
 				],
-				"execution_count": 112
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -447,7 +339,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 113
+				"execution_count": 14
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_entraid.json
+++ b/workspace/notebook/py_unit_tests_entraid.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c77222e6-9f4a-491b-b836-127552c645c2"
+				"spark.autotune.trackingId": "1be01104-3ec5-4009-b209-80049209e04c"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 1
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -95,7 +95,7 @@
 					"hrm_table_name: str = 'entraid'\n",
 					"curated_table_name: str = 'entraid'"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -114,7 +114,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 3
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -132,7 +132,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 4
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name, None, False)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 5
+				"execution_count": 13
 			},
 			{
 				"cell_type": "markdown",
@@ -190,7 +190,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 6
+				"execution_count": 14
 			},
 			{
 				"cell_type": "markdown",
@@ -220,12 +220,61 @@
 					}
 				},
 				"source": [
+					"def entraid_test_sb_std_to_sb_hrm_no_dropping_records(sb_std_table: str, sb_hrm_table: str, primary_key: str) -> bool:\r\n",
+					"    df: DataFrame = spark.sql(f\"\"\"\r\n",
+					"    select {primary_key}\r\n",
+					"    from {std_db_name}.{sb_std_table}\r\n",
+					"    where {primary_key} not in\r\n",
+					"    (\r\n",
+					"        select {primary_key}\r\n",
+					"        from {hrm_db_name}.{sb_hrm_table}\r\n",
+					"    )\r\n",
+					"    \"\"\")\r\n",
+					"    return df.count() == 0"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if entraid_test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name, 'Id'):\r\n",
+					"   print(\"Test passed: No records were dropped.\")\r\n",
+					"else:\r\n",
+					"    exitCode += 1"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
 					"if test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name, 'Id'):\r\n",
 					"   print(\"Test passed: No records were dropped.\")\r\n",
 					"else:\r\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 16
+				"execution_count": 15
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_entraid.json
+++ b/workspace/notebook/py_unit_tests_entraid.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "09ba2184-9b29-4e01-a7a9-d4dac982efec"
+				"spark.autotune.trackingId": "d085972d-33e1-44ea-a442-4c2d56ed65e9"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 74
+				"execution_count": 100
 			},
 			{
 				"cell_type": "code",
@@ -95,7 +95,7 @@
 					"hrm_table_name: str = 'entraid'\n",
 					"curated_table_name: str = 'entraid'"
 				],
-				"execution_count": 75
+				"execution_count": 101
 			},
 			{
 				"cell_type": "code",
@@ -114,7 +114,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 76
+				"execution_count": 102
 			},
 			{
 				"cell_type": "code",
@@ -132,7 +132,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 77
+				"execution_count": 103
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name, None, False)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 78
+				"execution_count": 104
 			},
 			{
 				"cell_type": "markdown",
@@ -190,7 +190,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 79
+				"execution_count": 105
 			},
 			{
 				"cell_type": "markdown",
@@ -232,7 +232,7 @@
 					"    \"\"\")\r\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": 80
+				"execution_count": 106
 			},
 			{
 				"cell_type": "code",
@@ -253,7 +253,7 @@
 					"else:\r\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 81
+				"execution_count": 107
 			},
 			{
 				"cell_type": "markdown",
@@ -287,7 +287,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 82
+				"execution_count": 108
 			},
 			{
 				"cell_type": "code",
@@ -316,7 +316,7 @@
 					"differences_df = show_differences_between_tables(hrm_table_name, curated_table_name, 'Id')\r\n",
 					"differences_df.show()"
 				],
-				"execution_count": 95
+				"execution_count": 109
 			},
 			{
 				"cell_type": "code",
@@ -350,7 +350,7 @@
 					"differences_df = show_records_in_hrm_not_in_curated(hrm_table_name, curated_table_name, 'Id')\r\n",
 					"differences_df.show()"
 				],
-				"execution_count": 99
+				"execution_count": 110
 			},
 			{
 				"cell_type": "code",
@@ -395,7 +395,7 @@
 					"differences_df = show_differences_between_tables(hrm_table_name, curated_table_name, 'Id')\r\n",
 					"differences_df.show()"
 				],
-				"execution_count": 97
+				"execution_count": 111
 			},
 			{
 				"cell_type": "markdown",
@@ -429,7 +429,7 @@
 					"print(f\"Is Curated Data Valid: {is_valid_data}\")\n",
 					"exitCode += int(not is_valid_data)"
 				],
-				"execution_count": null
+				"execution_count": 112
 			},
 			{
 				"cell_type": "code",
@@ -447,7 +447,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": null
+				"execution_count": 113
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_entraid.json
+++ b/workspace/notebook/py_unit_tests_entraid.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8dd78af9-9493-4c13-888f-2000bd8b0f61"
+				"spark.autotune.trackingId": "2f327661-003f-4f86-a977-b981c7ae51e0"
 			}
 		},
 		"metadata": {
@@ -93,7 +93,9 @@
 					"\n",
 					"std_table_name: str = 'entraid'\n",
 					"hrm_table_name: str = 'entraid'\n",
-					"curated_table_name: str = 'entraid'"
+					"curated_table_name: str = 'entraid'\n",
+					"\n",
+					"primary_key: str = 'Id'"
 				],
 				"execution_count": 2
 			},
@@ -220,15 +222,15 @@
 					}
 				},
 				"source": [
-					"def entraid_test_sb_std_to_sb_hrm_no_dropping_records(sb_std_table: str, sb_hrm_table: str, primary_key: str) -> bool:\r\n",
+					"def entraid_test_std_to_hrm_no_dropping_records() -> bool:\r\n",
 					"    df: DataFrame = spark.sql(f\"\"\"\r\n",
-					"    select {primary_key}\r\n",
-					"    from {std_db_name}.{sb_std_table}\r\n",
-					"    where {primary_key} not in\r\n",
-					"    (\r\n",
-					"        select {primary_key}\r\n",
-					"        from {hrm_db_name}.{sb_hrm_table}\r\n",
-					"    )\r\n",
+					"        SELECT {primary_key}\r\n",
+					"        FROM {std_db_name}.{std_table_name}\r\n",
+					"        WHERE {primary_key} NOT IN\r\n",
+					"        (\r\n",
+					"            SELECT {primary_key}\r\n",
+					"            FROM {hrm_db_name}.{hrm_table_name}\r\n",
+					"        )\r\n",
 					"    \"\"\")\r\n",
 					"    return df.count() == 0"
 				],
@@ -248,7 +250,7 @@
 					}
 				},
 				"source": [
-					"if entraid_test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name, 'Id'):\r\n",
+					"if entraid_test_std_to_hrm_no_dropping_records():\r\n",
 					"   print(\"Test passed: No records were dropped.\")\r\n",
 					"else:\r\n",
 					"    exitCode += 1"

--- a/workspace/notebook/py_unit_tests_entraid.json
+++ b/workspace/notebook/py_unit_tests_entraid.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1be01104-3ec5-4009-b209-80049209e04c"
+				"spark.autotune.trackingId": "09ba2184-9b29-4e01-a7a9-d4dac982efec"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import pprint"
 				],
-				"execution_count": 27
+				"execution_count": 74
 			},
 			{
 				"cell_type": "code",
@@ -95,7 +95,7 @@
 					"hrm_table_name: str = 'entraid'\n",
 					"curated_table_name: str = 'entraid'"
 				],
-				"execution_count": null
+				"execution_count": 75
 			},
 			{
 				"cell_type": "code",
@@ -114,7 +114,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": null
+				"execution_count": 76
 			},
 			{
 				"cell_type": "code",
@@ -132,7 +132,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": null
+				"execution_count": 77
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"sb_hrm_schema = create_spark_schema(hrm_db_name, entity_name, None, False)\n",
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema"
 				],
-				"execution_count": 13
+				"execution_count": 78
 			},
 			{
 				"cell_type": "markdown",
@@ -190,7 +190,7 @@
 					"print(f\"Service bus harmonised schema correct: {hrm_schema_correct}\\nTable: {hrm_db_name}.{hrm_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not hrm_schema_correct)"
 				],
-				"execution_count": 14
+				"execution_count": 79
 			},
 			{
 				"cell_type": "markdown",
@@ -232,7 +232,7 @@
 					"    \"\"\")\r\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 80
 			},
 			{
 				"cell_type": "code",
@@ -253,28 +253,7 @@
 					"else:\r\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"if test_sb_std_to_sb_hrm_no_dropping_records(std_table_name, hrm_table_name, 'Id'):\r\n",
-					"   print(\"Test passed: No records were dropped.\")\r\n",
-					"else:\r\n",
-					"    exitCode += 1"
-				],
-				"execution_count": 15
+				"execution_count": 81
 			},
 			{
 				"cell_type": "markdown",
@@ -308,7 +287,115 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": null
+				"execution_count": 82
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def show_differences_between_tables(hrm_table: str, curated_table: str, primary_key: str) -> DataFrame:\r\n",
+					"    differences_df: DataFrame = spark.sql(f\"\"\"\r\n",
+					"    SELECT *\r\n",
+					"    FROM {hrm_db_name}.{hrm_table} hrm\r\n",
+					"    FULL OUTER JOIN {curated_db_name}.{curated_table} curated\r\n",
+					"    ON hrm.{primary_key} = curated.{primary_key}\r\n",
+					"    WHERE hrm.{primary_key} IS NULL OR curated.{primary_key} IS NULL\r\n",
+					"    \"\"\")\r\n",
+					"    return differences_df\r\n",
+					"\r\n",
+					"differences_df = show_differences_between_tables(hrm_table_name, curated_table_name, 'Id')\r\n",
+					"differences_df.show()"
+				],
+				"execution_count": 95
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def show_records_in_hrm_not_in_curated(hrm_table: str, curated_table: str, primary_key: str) -> DataFrame:\r\n",
+					"    # List of common columns\r\n",
+					"    common_columns = [\"employeeId\", \"id\", \"givenName\", \"surname\", \"userPrincipalName\"]\r\n",
+					"\r\n",
+					"    # Records in harmonised table but not in curated table\r\n",
+					"    hrm_not_in_curated_df: DataFrame = spark.sql(f\"\"\"\r\n",
+					"    SELECT {', '.join([f'hrm.{col}' for col in common_columns])}\r\n",
+					"    FROM {hrm_db_name}.{hrm_table} hrm\r\n",
+					"    LEFT JOIN {curated_db_name}.{curated_table} curated\r\n",
+					"    ON hrm.{primary_key} = curated.{primary_key}\r\n",
+					"    WHERE curated.{primary_key} IS NULL\r\n",
+					"    \"\"\")\r\n",
+					"\r\n",
+					"    return hrm_not_in_curated_df\r\n",
+					"\r\n",
+					"differences_df = show_records_in_hrm_not_in_curated(hrm_table_name, curated_table_name, 'Id')\r\n",
+					"differences_df.show()"
+				],
+				"execution_count": 99
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def show_differences_between_tables(hrm_table: str, curated_table: str, primary_key: str) -> DataFrame:\r\n",
+					"    # List of common columns\r\n",
+					"    common_columns = [\"employeeId\", \"id\", \"givenName\", \"surname\", \"userPrincipalName\"]\r\n",
+					"\r\n",
+					"    # Records in harmonised table but not in curated table\r\n",
+					"    hrm_not_in_curated_df: DataFrame = spark.sql(f\"\"\"\r\n",
+					"    SELECT {', '.join([f'hrm.{col}' for col in common_columns])}\r\n",
+					"    FROM {hrm_db_name}.{hrm_table} hrm\r\n",
+					"    LEFT JOIN {curated_db_name}.{curated_table} curated\r\n",
+					"    ON hrm.{primary_key} = curated.{primary_key}\r\n",
+					"    WHERE curated.{primary_key} IS NULL\r\n",
+					"    \"\"\")\r\n",
+					"\r\n",
+					"    # Records in curated table but not in harmonised table\r\n",
+					"    curated_not_in_hrm_df: DataFrame = spark.sql(f\"\"\"\r\n",
+					"    SELECT {', '.join([f'curated.{col}' for col in common_columns])}\r\n",
+					"    FROM {curated_db_name}.{curated_table} curated\r\n",
+					"    LEFT JOIN {hrm_db_name}.{hrm_table} hrm\r\n",
+					"    ON curated.{primary_key} = hrm.{primary_key}\r\n",
+					"    WHERE hrm.{primary_key} IS NULL\r\n",
+					"    \"\"\")\r\n",
+					"\r\n",
+					"    # Union the two DataFrames to get all differing records\r\n",
+					"    differences_df: DataFrame = hrm_not_in_curated_df.union(curated_not_in_hrm_df)\r\n",
+					"    return differences_df\r\n",
+					"\r\n",
+					"differences_df = show_differences_between_tables(hrm_table_name, curated_table_name, 'Id')\r\n",
+					"differences_df.show()"
+				],
+				"execution_count": 97
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_entraid.json
+++ b/workspace/notebook/py_unit_tests_entraid.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5b3d41bc-5c7a-4e30-af88-0efad20a4c6f"
+				"spark.autotune.trackingId": "8dd78af9-9493-4c13-888f-2000bd8b0f61"
 			}
 		},
 		"metadata": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
