### PR TITLE
Feat/odw 1528 change data source for reference id field on representation entity

### DIFF
--- a/workspace/notebook/nsip_representation.json
+++ b/workspace/notebook/nsip_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "94ce30f2-cf2e-4b03-81cd-c05e079b0946"
+				"spark.autotune.trackingId": "006a3077-8399-49a1-9a06-b6a5504c25d7"
 			}
 		},
 		"metadata": {
@@ -68,7 +68,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 1
+				"execution_count": 6
 			},
 			{
 				"cell_type": "markdown",
@@ -117,7 +117,7 @@
 					"SELECT DISTINCT\r\n",
 					"\r\n",
 					"    RR.representationId\r\n",
-					"    ,RR.referenceId\r\n",
+					"    ,RR.webreference referenceId\r\n",
 					"    ,RR.examinationLibraryRef\r\n",
 					"    ,RR.caseRef\r\n",
 					"    ,RR.caseId\r\n",
@@ -189,7 +189,7 @@
 					"    AND RR.caseRef IS NOT NULL\r\n",
 					""
 				],
-				"execution_count": 32
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -220,7 +220,7 @@
 				"source": [
 					"logInfo(f\"Writing odw_curated_db.nsip_representation\")"
 				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -241,7 +241,7 @@
 					"view_df = spark.sql('SELECT * FROM odw_curated_db.vw_nsip_representation')\r\n",
 					"view_df.write.mode('overwrite').saveAsTable('odw_curated_db.nsip_representation')"
 				],
-				"execution_count": 33
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 				"source": [
 					"logInfo(f\"Written odw_curated_db.nsip_representation\")"
 				],
-				"execution_count": null
+				"execution_count": 10
 			}
 		]
 	}

--- a/workspace/notebook/nsip_representation.json
+++ b/workspace/notebook/nsip_representation.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "006a3077-8399-49a1-9a06-b6a5504c25d7"
+				"spark.autotune.trackingId": "324e9e25-996a-4b30-9f1a-050a7a09964d"
 			}
 		},
 		"metadata": {
@@ -117,7 +117,7 @@
 					"SELECT DISTINCT\r\n",
 					"\r\n",
 					"    RR.representationId\r\n",
-					"    ,RR.webreference referenceId\r\n",
+					"    ,RR.webreference As referenceId\r\n",
 					"    ,RR.examinationLibraryRef\r\n",
 					"    ,RR.caseRef\r\n",
 					"    ,RR.caseId\r\n",

--- a/workspace/notebook/nsip_representation_migration.json
+++ b/workspace/notebook/nsip_representation_migration.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fd290110-76d6-4738-a243-7bd733dc0462"
+				"spark.autotune.trackingId": "c7415b36-0f24-4576-82e3-276d2a7441c4"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"SELECT DISTINCT\n",
 					"\n",
 					"    RR.representationId\n",
-					"    ,RR.referenceId\n",
+					"    ,,RR.webreference referenceId\n",
 					"    ,RR.examinationLibraryRef\n",
 					"    ,RR.caseRef\n",
 					"    ,RR.caseId\n",
@@ -160,7 +160,7 @@
 					"    AND NP.caseReference IS NOT NULL\n",
 					""
 				],
-				"execution_count": 1
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -192,7 +192,7 @@
 					"data = spark.sql(\"SELECT * FROM vw_nsip_representation\")\n",
 					"data.write.mode(\"overwrite\").saveAsTable(\"odw_curated_migration_db.nsip_representation\")"
 				],
-				"execution_count": 3
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/nsip_representation_migration.json
+++ b/workspace/notebook/nsip_representation_migration.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c7415b36-0f24-4576-82e3-276d2a7441c4"
+				"spark.autotune.trackingId": "3d525f7a-457a-4393-993e-62fb4d4d00b7"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"SELECT DISTINCT\n",
 					"\n",
 					"    RR.representationId\n",
-					"    ,,RR.webreference referenceId\n",
+					"    ,,RR.webreference As referenceId\n",
 					"    ,RR.examinationLibraryRef\n",
 					"    ,RR.caseRef\n",
 					"    ,RR.caseId\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
