### PR TITLE
adding packages to spark pool

### DIFF
--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -1,6 +1,6 @@
 azure-identity==1.15.0
 azure-functions==1.20.0
-azure-servicebus==7.11.4
+azure-servicebus==7.13.0
 azure-storage-blob==12.19.0
 azure-mgmt-web==7.2.0
 azure-keyvault==4.2.0

--- a/infrastructure/configuration/spark-pool/requirements-preview.txt
+++ b/infrastructure/configuration/spark-pool/requirements-preview.txt
@@ -2,17 +2,16 @@
 # https://github.com/microsoft/synapse-spark-runtime/blob/main/Synapse/spark3.4/Official-Spark3.4-Rel-2024-10-18.0-rc.1.md
 
 # Azure Servicebus
-azure-servicebus
+azure-servicebus==7.13.0
 
 # Logging
-azure-monitor-opentelemetry
+azure-monitor-opentelemetry==1.6.4
 
 # Retry
-tenacity
+tenacity==9.0.0
 
 # Time
-croniter
-iso8601
+iso8601==2.1.0
 
 # Creating fake data
-Faker
+Faker==33.1.0

--- a/infrastructure/configuration/spark-pool/requirements-preview.txt
+++ b/infrastructure/configuration/spark-pool/requirements-preview.txt
@@ -4,6 +4,12 @@
 # Azure Servicebus
 azure-servicebus
 
+# Logging
+azure-monitor-opentelemetry
+
+# Retry
+tenacity
+
 # Time
 croniter
 iso8601

--- a/infrastructure/configuration/spark-pool/requirements.txt
+++ b/infrastructure/configuration/spark-pool/requirements.txt
@@ -2,17 +2,16 @@
 # https://github.com/microsoft/synapse-spark-runtime/blob/main/Synapse/spark3.3/Official-Spark3.3-Rel-2024-07-11.0-rc.1.md
 
 # Azure Servicebus
-azure-servicebus
+azure-servicebus==7.13.0
 
 # Logging
-azure-monitor-opentelemetry
+azure-monitor-opentelemetry==1.6.4
 
 # Retry
-tenacity
+tenacity==9.0.0
 
 # Time
-croniter
-iso8601
+iso8601==2.1.0
 
 # Creating fake data
-Faker
+Faker==33.1.0

--- a/infrastructure/configuration/spark-pool/requirements.txt
+++ b/infrastructure/configuration/spark-pool/requirements.txt
@@ -4,6 +4,12 @@
 # Azure Servicebus
 azure-servicebus
 
+# Logging
+azure-monitor-opentelemetry
+
+# Retry
+tenacity
+
 # Time
 croniter
 iso8601


### PR DESCRIPTION
Pinned versions of packages.
Removed `croniter` as it is no longer maintained. This is not used in any master pipeline code.
Updated `azure-servicebus` for function app to align with spark config.