### PR TITLE
Updating notebook: appeal_service_user_curated_mipins

### DIFF
--- a/workspace/notebook/appeal_service_user_curated_mipins.json
+++ b/workspace/notebook/appeal_service_user_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a4418118-4772-4a8a-9294-4cda170fbc2f"
+				"spark.autotune.trackingId": "2a3f240f-c9a0-4d87-81f9-15776368cc42"
 			}
 		},
 		"metadata": {
@@ -54,6 +54,9 @@
 			{
 				"cell_type": "code",
 				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [
@@ -85,14 +88,14 @@
 					"    ,sourceSUID\n",
 					"    ,ODTSourceSystem\n",
 					"    ,ingestionDate\n",
-					"    ,ValidTo\n",
+					"    ,NULLIF(ValidTo,'') as ValidTo\n",
 					"    ,RowID\n",
 					"    ,IsActive\n",
 					"\n",
 					"FROM\n",
 					"    odw_harmonised_db.sb_service_user\n",
 					"\n",
-					"    union all\n",
+					"    union\n",
 					"\n",
 					"    SELECT\n",
 					"    id\n",
@@ -128,7 +131,7 @@
 					"\n",
 					""
 				],
-				"execution_count": 5
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +149,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeal_service_user_curated_mipins;\")"
 				],
-				"execution_count": 6
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +201,7 @@
 					"\n",
 					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_service_user_curated_mipins\")"
 				],
-				"execution_count": 7
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -215,10 +218,10 @@
 					"collapsed": false
 				},
 				"source": [
-					"#%%sql\n",
-					"#select * from odw_curated_db.appeal_service_user_curated_mipins"
+					"#%%sql\r\n",
+					"#select * from odw_curated_db.appeal_service_user_curated_mipins WHERE caseReference='TR0510063' AND ISACTIVE='Y'"
 				],
-				"execution_count": 8
+				"execution_count": 17
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
