### PR TITLE
Theodw 1550

### DIFF
--- a/workspace/dataset/AIEFileDataLabs.json
+++ b/workspace/dataset/AIEFileDataLabs.json
@@ -16,7 +16,7 @@
 			"location": {
 				"type": "AzureFileStorageLocation",
 				"folderPath": {
-					"value": "@concat('ODW/AIE_1550/', dataset().env)",
+					"value": "@concat('ODW/AIE', '')",
 					"type": "Expression"
 				}
 			},

--- a/workspace/dataset/AIEFileDataLabs.json
+++ b/workspace/dataset/AIEFileDataLabs.json
@@ -15,7 +15,10 @@
 		"typeProperties": {
 			"location": {
 				"type": "AzureFileStorageLocation",
-				"folderPath": "ODW/AIE"
+				"folderPath": {
+					"value": "@concat('ODW/AIE_1550/', dataset().env)",
+					"type": "Expression"
+				}
 			},
 			"columnDelimiter": ",",
 			"rowDelimiter": "\n",

--- a/workspace/dataset/AIEFileDataLabs.json
+++ b/workspace/dataset/AIEFileDataLabs.json
@@ -5,6 +5,11 @@
 			"referenceName": "ls_datalab",
 			"type": "LinkedServiceReference"
 		},
+		"parameters": {
+			"env": {
+				"type": "string"
+			}
+		},
 		"annotations": [],
 		"type": "DelimitedText",
 		"typeProperties": {

--- a/workspace/dataset/AIEFileDataLabs.json
+++ b/workspace/dataset/AIEFileDataLabs.json
@@ -16,7 +16,7 @@
 			"location": {
 				"type": "AzureFileStorageLocation",
 				"folderPath": {
-					"value": "@concat('ODW/AIE', '')",
+					"value": "@concat('ODW/AIE_1550/', dataset().env)",
 					"type": "Expression"
 				}
 			},

--- a/workspace/dataset/AIEFileDataLabsCopier.json
+++ b/workspace/dataset/AIEFileDataLabsCopier.json
@@ -8,6 +8,9 @@
 		"parameters": {
 			"FileName": {
 				"type": "string"
+			},
+			"env": {
+				"type": "string"
 			}
 		},
 		"annotations": [],
@@ -19,7 +22,10 @@
 					"value": "@dataset().FileName",
 					"type": "Expression"
 				},
-				"folderPath": "ODW/AIE"
+				"folderPath": {
+					"value": "@concat('ODW/AIE_1550/', dataset().env)",
+					"type": "Expression"
+				}
 			},
 			"columnDelimiter": ",",
 			"rowDelimiter": "\n",

--- a/workspace/dataset/AIEFileDataLabsCopier.json
+++ b/workspace/dataset/AIEFileDataLabsCopier.json
@@ -23,7 +23,7 @@
 					"type": "Expression"
 				},
 				"folderPath": {
-					"value": "@concat('ODW/AIE', '')",
+					"value": "@concat('ODW/AIE_1550/', dataset().env)",
 					"type": "Expression"
 				}
 			},

--- a/workspace/dataset/AIEFileDataLabsCopier.json
+++ b/workspace/dataset/AIEFileDataLabsCopier.json
@@ -23,7 +23,7 @@
 					"type": "Expression"
 				},
 				"folderPath": {
-					"value": "@concat('ODW/AIE_1550/', dataset().env)",
+					"value": "@concat('ODW/AIE', '')",
 					"type": "Expression"
 				}
 			},

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -174,7 +174,7 @@
 				"typeProperties": {
 					"variableName": "env",
 					"value": {
-						"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-dev-uks'), 'Dev', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'Test', 'Prod'))",
+						"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-prod-uks'), 'Prod', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'Test', 'Dev'))",
 						"type": "Expression"
 					}
 				}

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -7,7 +7,14 @@
 				"name": "Get Metadata Of CSVs",
 				"description": "Getting the Metadata of the csv files in the AIE data labs folder",
 				"type": "GetMetadata",
-				"dependsOn": [],
+				"dependsOn": [
+					{
+						"activity": "Set Environment",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
 				"policy": {
 					"timeout": "0.12:00:00",
 					"retry": 0,
@@ -22,7 +29,7 @@
 						"type": "DatasetReference",
 						"parameters": {
 							"env": {
-								"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-dev-uks'), 'Dev', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'Test', 'Prod'))",
+								"value": "@variables('env')",
 								"type": "Expression"
 							}
 						}
@@ -119,6 +126,10 @@
 										"FileName": {
 											"value": "@item().name",
 											"type": "Expression"
+										},
+										"env": {
+											"value": "@variables('env')",
+											"type": "Expression"
 										}
 									}
 								}
@@ -150,8 +161,30 @@
 						}
 					]
 				}
+			},
+			{
+				"name": "Set Environment",
+				"type": "SetVariable",
+				"dependsOn": [],
+				"policy": {
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"variableName": "env",
+					"value": {
+						"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-dev-uks'), 'Dev', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'Test', 'Prod'))",
+						"type": "Expression"
+					}
+				}
 			}
 		],
+		"variables": {
+			"env": {
+				"type": "String"
+			}
+		},
 		"folder": {
 			"name": "aie-extracts/layers/0-raw"
 		},

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -182,14 +182,6 @@
 								"waitOnCompletion": true,
 								"parameters": {
 									"Stage": "Fail",
-									"PipelineName": {
-										"value": "@activity('Copy File').Output.pipelineName",
-										"type": "Expression"
-									},
-									"PipelineRunID": {
-										"value": "@activity('Copy File').Output.pipelineRunId",
-										"type": "Expression"
-									},
 									"StartTime": {
 										"value": "@activity('Copy File').ExecutionStartTime",
 										"type": "Expression"
@@ -257,14 +249,6 @@
 								"waitOnCompletion": true,
 								"parameters": {
 									"Stage": "Completion",
-									"PipelineName": {
-										"value": "@activity('Copy File').Output.pipelineName",
-										"type": "Expression"
-									},
-									"PipelineRunID": {
-										"value": "@activity('Copy File').Output.pipelineRunId",
-										"type": "Expression"
-									},
 									"StartTime": {
 										"value": "@activity('Copy File').ExecutionStartTime",
 										"type": "Expression"
@@ -322,6 +306,67 @@
 					"value": {
 						"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-prod-uks'), 'Prod', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'Test', 'Dev'))",
 						"type": "Expression"
+					}
+				}
+			},
+			{
+				"name": "Log AIE Extracts Failure",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "For Each AIE Document",
+						"dependencyConditions": [
+							"Failed"
+						]
+					}
+				],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_log_to_appins",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true,
+					"parameters": {
+						"Stage": "Fail",
+						"StartTime": {
+							"value": "@activity('Copy File').ExecutionStartTime",
+							"type": "Expression"
+						},
+						"EndTime": {
+							"value": "@activity('Copy File').ExecutionEndTime",
+							"type": "Expression"
+						},
+						"ErrorMessage": "Failed to copy one or more AIE extracts. See logs for individual files to see error details.",
+						"StatusMessage": "Failed",
+						"PipelineTriggeredbyPipelineName": {
+							"value": "@activity('Copy File').PipelineName",
+							"type": "Expression"
+						},
+						"PipelineTriggeredbyPipelineRunID": {
+							"value": "@activity('Copy File').PipelineRunId",
+							"type": "Expression"
+						},
+						"PipelineExecutionTimeInSec": {
+							"value": "@activity('Copy File').Duration",
+							"type": "Expression"
+						},
+						"ActivityType": {
+							"value": "@activity('Copy File').ActivityType",
+							"type": "Expression"
+						},
+						"DurationSeconds": {
+							"value": "@activity('Copy File').Duration",
+							"type": "Expression"
+						},
+						"AppInsCustomEventName": "ODW_Master_Pipeline_Logs",
+						"StatusCode": {
+							"value": "@activity('Copy File').StatusCode",
+							"type": "Expression"
+						}
 					}
 				}
 			}

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -78,7 +78,7 @@
 								}
 							],
 							"policy": {
-								"timeout": "0.12:00:00",
+								"timeout": "0.00:10:00",
 								"retry": 0,
 								"retryIntervalInSeconds": 30,
 								"secureOutput": false,
@@ -158,6 +158,81 @@
 									"type": "Expression"
 								}
 							}
+						},
+						{
+							"name": "Log to AppIns",
+							"type": "ExecutePipeline",
+							"dependsOn": [
+								{
+									"activity": "Copy File",
+									"dependencyConditions": [
+										"Failed"
+									]
+								}
+							],
+							"policy": {
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "pln_log_to_appins",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"Stage": "Fail",
+									"PipelineName": {
+										"value": "@activity('Copy File').Output.pipelineName",
+										"type": "Expression"
+									},
+									"PipelineRunID": {
+										"value": "@activity('Copy File').Output.pipelineRunId",
+										"type": "Expression"
+									},
+									"StartTime": {
+										"value": "@activity('Copy File').ExecutionStartTime",
+										"type": "Expression"
+									},
+									"EndTime": {
+										"value": "@activity('Copy File').ExecutionEndTime",
+										"type": "Expression"
+									},
+									"ErrorMessage": {
+										"value": "@activity('Copy File').Error.message",
+										"type": "Expression"
+									},
+									"StatusMessage": {
+										"value": "@activity('Copy File').Status",
+										"type": "Expression"
+									},
+									"PipelineTriggeredbyPipelineName": {
+										"value": "@activity('Copy File').PipelineName",
+										"type": "Expression"
+									},
+									"PipelineTriggeredbyPipelineRunID": {
+										"value": "@activity('Copy File').PipelineRunId",
+										"type": "Expression"
+									},
+									"PipelineExecutionTimeInSec": {
+										"value": "@activity('Copy File').Duration",
+										"type": "Expression"
+									},
+									"ActivityType": {
+										"value": "@activity('Copy File').ActivityType",
+										"type": "Expression"
+									},
+									"DurationSeconds": {
+										"value": "@activity('Copy File').Duration",
+										"type": "Expression"
+									},
+									"AppInsCustomEventName": "ODW_Master_Pipeline_Logs",
+									"StatusCode": {
+										"value": "@activity('Copy File').StatusCode",
+										"type": "Expression"
+									}
+								}
+							}
 						}
 					]
 				}
@@ -182,6 +257,9 @@
 		],
 		"variables": {
 			"env": {
+				"type": "String"
+			},
+			"app_ins_ikey": {
 				"type": "String"
 			}
 		},

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -160,7 +160,7 @@
 							}
 						},
 						{
-							"name": "Log to AppIns",
+							"name": "Log Failure",
 							"type": "ExecutePipeline",
 							"dependsOn": [
 								{
@@ -203,7 +203,78 @@
 										"type": "Expression"
 									},
 									"StatusMessage": {
-										"value": "@activity('Copy File').Status",
+										"value": "@concat('Failed to copy AIE extract: ', item().name)",
+										"type": "Expression"
+									},
+									"PipelineTriggeredbyPipelineName": {
+										"value": "@activity('Copy File').PipelineName",
+										"type": "Expression"
+									},
+									"PipelineTriggeredbyPipelineRunID": {
+										"value": "@activity('Copy File').PipelineRunId",
+										"type": "Expression"
+									},
+									"PipelineExecutionTimeInSec": {
+										"value": "@activity('Copy File').Duration",
+										"type": "Expression"
+									},
+									"ActivityType": {
+										"value": "@activity('Copy File').ActivityType",
+										"type": "Expression"
+									},
+									"DurationSeconds": {
+										"value": "@activity('Copy File').Duration",
+										"type": "Expression"
+									},
+									"AppInsCustomEventName": "ODW_Master_Pipeline_Logs",
+									"StatusCode": {
+										"value": "@activity('Copy File').StatusCode",
+										"type": "Expression"
+									}
+								}
+							}
+						},
+						{
+							"name": "Log Success",
+							"type": "ExecutePipeline",
+							"dependsOn": [
+								{
+									"activity": "Copy File",
+									"dependencyConditions": [
+										"Succeeded"
+									]
+								}
+							],
+							"policy": {
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "pln_log_to_appins",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"Stage": "Completion",
+									"PipelineName": {
+										"value": "@activity('Copy File').Output.pipelineName",
+										"type": "Expression"
+									},
+									"PipelineRunID": {
+										"value": "@activity('Copy File').Output.pipelineRunId",
+										"type": "Expression"
+									},
+									"StartTime": {
+										"value": "@activity('Copy File').ExecutionStartTime",
+										"type": "Expression"
+									},
+									"EndTime": {
+										"value": "@activity('Copy File').ExecutionEndTime",
+										"type": "Expression"
+									},
+									"StatusMessage": {
+										"value": "@concat('Copied AIE extract succesfully: ', item().name)",
 										"type": "Expression"
 									},
 									"PipelineTriggeredbyPipelineName": {

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -332,41 +332,46 @@
 					"waitOnCompletion": true,
 					"parameters": {
 						"Stage": "Fail",
+						"PipelineName": {
+							"value": "@pipeline().Pipeline",
+							"type": "Expression"
+						},
+						"PipelineRunID": {
+							"value": "@pipeline().RunId",
+							"type": "Expression"
+						},
 						"StartTime": {
-							"value": "@activity('Copy File').ExecutionStartTime",
+							"value": "@activity('Get Metadata Of CSVs').ExecutionEndTime",
 							"type": "Expression"
 						},
 						"EndTime": {
-							"value": "@activity('Copy File').ExecutionEndTime",
+							"value": "@utcNow()",
 							"type": "Expression"
 						},
 						"ErrorMessage": "Failed to copy one or more AIE extracts. See logs for individual files to see error details.",
 						"StatusMessage": "Failed",
+						"PipelineTriggerID": {
+							"value": "@pipeline().TriggerId",
+							"type": "Expression"
+						},
+						"PipelineTriggerName": {
+							"value": "@pipeline().TriggerName",
+							"type": "Expression"
+						},
+						"PipelineTriggerType": {
+							"value": "@pipeline().TriggerType",
+							"type": "Expression"
+						},
 						"PipelineTriggeredbyPipelineName": {
-							"value": "@activity('Copy File').PipelineName",
+							"value": "@pipeline()?.TriggeredByPipelineName",
 							"type": "Expression"
 						},
 						"PipelineTriggeredbyPipelineRunID": {
-							"value": "@activity('Copy File').PipelineRunId",
+							"value": "@pipeline()?.TriggeredByPipelineRunId",
 							"type": "Expression"
 						},
-						"PipelineExecutionTimeInSec": {
-							"value": "@activity('Copy File').Duration",
-							"type": "Expression"
-						},
-						"ActivityType": {
-							"value": "@activity('Copy File').ActivityType",
-							"type": "Expression"
-						},
-						"DurationSeconds": {
-							"value": "@activity('Copy File').Duration",
-							"type": "Expression"
-						},
-						"AppInsCustomEventName": "ODW_Master_Pipeline_Logs",
-						"StatusCode": {
-							"value": "@activity('Copy File').StatusCode",
-							"type": "Expression"
-						}
+						"ActivityType": "Pipeline",
+						"AppInsCustomEventName": "ODW_Master_Pipeline_Logs"
 					}
 				}
 			}

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -304,7 +304,7 @@
 				"typeProperties": {
 					"variableName": "env",
 					"value": {
-						"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-prod-uks'), 'Prod', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'Test', 'Dev'))",
+						"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-prod-uks'), 'PROD', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'TEST', 'DEV'))",
 						"type": "Expression"
 					}
 				}

--- a/workspace/pipeline/AIEData.json
+++ b/workspace/pipeline/AIEData.json
@@ -19,7 +19,13 @@
 				"typeProperties": {
 					"dataset": {
 						"referenceName": "AIEFileDataLabs",
-						"type": "DatasetReference"
+						"type": "DatasetReference",
+						"parameters": {
+							"env": {
+								"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-dev-uks'), 'Dev', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'Test', 'Prod'))",
+								"type": "Expression"
+							}
+						}
 					},
 					"fieldList": [
 						"childItems"

--- a/workspace/pipeline/pln_horizon.json
+++ b/workspace/pipeline/pln_horizon.json
@@ -2204,8 +2204,6 @@
 						{
 							"name": "AIE document metadata",
 							"type": "ExecutePipeline",
-							"state": "Inactive",
-							"onInactiveMarkAs": "Succeeded",
 							"dependsOn": [
 								{
 									"activity": "Record loading Document metadata",

--- a/workspace/pipeline/pln_log_to_appins.json
+++ b/workspace/pipeline/pln_log_to_appins.json
@@ -32,7 +32,7 @@
 						"type": "IntegrationRuntimeReference"
 					},
 					"body": {
-						"value": "@concat('{\"name\":\"AppEvents\",\"time\":\"', utcNow(), '\",\"iKey\":\"', pipeline().parameters.AppInsIKey, '\",\"data\":{\"baseType\":\"EventData\",\"baseData\":{\"name\":\"', pipeline().parameters.AppInsCustomEventName, '\",\"properties\":', variables('body'), '}}}'\n)",
+						"value": "@concat('{\"name\":\"AppEvents\",\"time\":\"', utcNow(), '\",\"iKey\":\"', variables('app_ins_ikey'), '\",\"data\":{\"baseType\":\"EventData\",\"baseData\":{\"name\":\"', pipeline().parameters.AppInsCustomEventName, '\",\"properties\":', variables('body'), '}}}'\n)",
 						"type": "Expression"
 					}
 				}
@@ -41,7 +41,14 @@
 				"name": "Compile Body",
 				"description": "Compiles the body from the params",
 				"type": "SetVariable",
-				"dependsOn": [],
+				"dependsOn": [
+					{
+						"activity": "If No iKey param",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
 				"policy": {
 					"secureOutput": false,
 					"secureInput": false
@@ -53,6 +60,107 @@
 						"value": "@concat('{\"Stage\":\"', pipeline().parameters.Stage, '\",',\n        '\"PipelineName\":\"', pipeline().parameters.PipelineName, '\",',\n        '\"PipelineRunID\":\"', pipeline().parameters.PipelineRunID, '\",',\n        '\"StartTime\":\"', pipeline().parameters.StartTime, '\",',\n        '\"EndTime\":\"', pipeline().parameters.EndTime, '\",',\n        '\"Inserts\":\"', string(pipeline().parameters.Inserts), '\",',\n        '\"Updates\":\"', string(pipeline().parameters.Updates), '\",',\n        '\"Deletes\":\"', string(pipeline().parameters.Deletes), '\",',\n        '\"ErrorMessage\":\"', uriComponentToString(replace(uriComponent(coalesce(pipeline().parameters.ErrorMessage, '')), '%0A', '')), '\",',\n        '\"StatusMessage\":\"', pipeline().parameters.StatusMessage, '\",',\n        '\"PipelineTriggerID\":\"', pipeline().parameters.PipelineTriggerID, '\",',\n        '\"PipelineTriggerName\":\"', pipeline().parameters.PipelineTriggerName, '\",',\n        '\"PipelineTriggerType\":\"', pipeline().parameters.PipelineTriggerType, '\",',\n        '\"PipelineTriggeredbyPipelineName\":\"', pipeline().parameters.PipelineTriggeredbyPipelineName, '\",',\n        '\"PipelineTriggeredbyPipelineRunID\":\"', pipeline().parameters.PipelineTriggeredbyPipelineRunID, '\",',\n        '\"PipelineExecutionTimeInSec\":\"', pipeline().parameters.PipelineExecutionTimeInSec, '\",',\n        '\"ActivityType\":\"', pipeline().parameters.ActivityType, '\",',\n        '\"StatusCode\":\"', pipeline().parameters.StatusCode, '\",',\n        '\"DurationSeconds\":\"', pipeline().parameters.DurationSeconds, '\"}')",
 						"type": "Expression"
 					}
+				}
+			},
+			{
+				"name": "If No iKey param",
+				"description": "Retrieving iKey for app ins if not provided in params",
+				"type": "IfCondition",
+				"dependsOn": [],
+				"userProperties": [],
+				"typeProperties": {
+					"expression": {
+						"value": "@empty(pipeline().parameters.AppInsIKey)",
+						"type": "Expression"
+					},
+					"ifFalseActivities": [
+						{
+							"name": "Set variable2",
+							"type": "SetVariable",
+							"dependsOn": [],
+							"policy": {
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"variableName": "app_ins_ikey",
+								"value": {
+									"value": "@pipeline().parameters.AppInsIKey",
+									"type": "Expression"
+								}
+							}
+						}
+					],
+					"ifTrueActivities": [
+						{
+							"name": "Set variable1",
+							"type": "SetVariable",
+							"dependsOn": [],
+							"policy": {
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"variableName": "app_ins_ikey",
+								"value": ""
+							}
+						},
+						{
+							"name": "Get AppIns iKey",
+							"description": "Get the application insights ikey for logging",
+							"type": "WebActivity",
+							"dependsOn": [],
+							"policy": {
+								"timeout": "0.12:00:00",
+								"retry": 0,
+								"retryIntervalInSeconds": 30,
+								"secureOutput": true,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"method": "GET",
+								"url": {
+									"value": "@concat('https://', if(equals(pipeline().DataFactory, 'pins-synw-odw-dev-uks'), 'pinskvsynwodwdevuks', if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'pinskvsynwodwtestuks', 'pinskvsynwodwproduks')), '.vault.azure.net/secrets/application-insights-connection-string?api-version=7.0')",
+									"type": "Expression"
+								},
+								"connectVia": {
+									"referenceName": "AutoResolveIntegrationRuntime",
+									"type": "IntegrationRuntimeReference"
+								},
+								"authentication": {
+									"type": "MSI",
+									"resource": "https://vault.azure.net"
+								}
+							}
+						},
+						{
+							"name": "Set AppIns iKey",
+							"type": "SetVariable",
+							"dependsOn": [
+								{
+									"activity": "Get AppIns iKey",
+									"dependencyConditions": [
+										"Succeeded"
+									]
+								}
+							],
+							"policy": {
+								"secureOutput": true,
+								"secureInput": true
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"variableName": "app_ins_ikey",
+								"value": {
+									"value": "@split(split(activity('Get AppIns iKey').output.value, ';')[0], '=')[1]",
+									"type": "Expression"
+								}
+							}
+						}
+					]
 				}
 			}
 		],
@@ -129,10 +237,7 @@
 			"body": {
 				"type": "String"
 			},
-			"notebook_err": {
-				"type": "String"
-			},
-			"apps_insights_ikey": {
+			"app_ins_ikey": {
 				"type": "String"
 			}
 		},

--- a/workspace/pipeline/pln_log_to_appins.json
+++ b/workspace/pipeline/pln_log_to_appins.json
@@ -75,7 +75,7 @@
 					},
 					"ifFalseActivities": [
 						{
-							"name": "Set variable2",
+							"name": "Set AppIns iKey2",
 							"type": "SetVariable",
 							"dependsOn": [],
 							"policy": {
@@ -93,20 +93,6 @@
 						}
 					],
 					"ifTrueActivities": [
-						{
-							"name": "Set variable1",
-							"type": "SetVariable",
-							"dependsOn": [],
-							"policy": {
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"variableName": "app_ins_ikey",
-								"value": ""
-							}
-						},
 						{
 							"name": "Get AppIns iKey",
 							"description": "Get the application insights ikey for logging",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
