### PR TITLE
Updating notebook: py_unit_tests_appeals_events

### DIFF
--- a/workspace/notebook/py_unit_tests_appeals_events.json
+++ b/workspace/notebook/py_unit_tests_appeals_events.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e411e11e-d206-4f36-8f25-954c29becccf"
+				"spark.autotune.trackingId": "3889a82c-ceb4-48a0-8667-e30fd38b3d62"
 			}
 		},
 		"metadata": {
@@ -280,7 +280,6 @@
 				"source": [
 					"standardised_count, harmonised_count, counts_match = test_std_same_rows_hrm(std_table_name, hrm_table_name)\r\n",
 					"print(f\"Standardised Count: {standardised_count: ,}\\nHarmonised Count: {harmonised_count: ,}\\nCounts match: {counts_match}\")\r\n",
-					"exitCode += int(not counts_match)\r\n",
 					"\r\n",
 					"if standardised_count > harmonised_count:\r\n",
 					"    exitCode += 1\r\n",


### PR DESCRIPTION
Removed the extra exitCode increment to stop the failing test counting itself twice