### PR TITLE
Theodw 1549 etl file ingestion logging - Part 1

### DIFF
--- a/workspace/dataset/NSIP_ReleventRepresentation.json
+++ b/workspace/dataset/NSIP_ReleventRepresentation.json
@@ -17,7 +17,7 @@
 			"location": {
 				"type": "AzureBlobFSLocation",
 				"fileName": {
-					"value": "@dataset().FileName",
+					"value": "@concat(dataset().FileName, '_', formatDateTime(utcnow(), 'yyyyMMddHHmmss'))",
 					"type": "Expression"
 				},
 				"folderPath": {

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3f9c0601-11fd-4d5a-be52-64a3efdb9b57"
+				"spark.autotune.trackingId": "084224c8-2256-4a58-a8e6-54de87a2a04d"
 			}
 		},
 		"metadata": {
@@ -70,7 +70,27 @@
 					"import warnings\n",
 					"warnings.filterwarnings(\"ignore\", message=\"iteritems is deprecated\")"
 				],
-				"execution_count": 1
+				"execution_count": 12
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Import Packages\n",
+					"from pandas import DataFrame\n",
+					"from datetime import datetime"
+				],
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -88,7 +108,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 2
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -106,7 +126,7 @@
 				"source": [
 					"%run  /0-odw-source-to-raw/Fileshare/SAP_HR/py_0_source_to_raw_hr_functions"
 				],
-				"execution_count": 3
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -124,7 +144,7 @@
 				"source": [
 					"%run /utils/py_mount_storage"
 				],
-				"execution_count": 4
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -193,7 +213,7 @@
 					"        raise TypeError(\"Header row should be an integer value\")\n",
 					""
 				],
-				"execution_count": 5
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -288,7 +308,7 @@
 					"    logInfo(f\"Written to {targetpath}\")\n",
 					""
 				],
-				"execution_count": 6
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -328,7 +348,7 @@
 					"        deltaTable = DeltaTable.convertToDelta(spark, f\"parquet.`{target_delta_folder}`\") \n",
 					"        logInfo(f\"Converted to {target_delta_folder}\")"
 				],
-				"execution_count": 7
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -367,7 +387,7 @@
 					"    spark.sql(f\"CREATE TABLE {db_name}.{delta_lake_table_name} USING DELTA LOCATION '{target_delta_folder}'\")\n",
 					"    logInfo(f\"Created delta table {db_name}.{delta_lake_table_name}\")"
 				],
-				"execution_count": 8
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -409,7 +429,44 @@
 					"\n",
 					"    return filtered_paths"
 				],
-				"execution_count": null
+				"execution_count": 21
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"@logging_to_appins\n",
+					"def get_max_file_date(df: DataFrame) -> datetime:\n",
+					"    \"\"\"\n",
+					"    Gets the maximum date from a file path field in a DataFrame.\n",
+					"    E.g. if the input_file field contained paths such as this:\n",
+					"    abfss://odw-raw@pinsstodwdevuks9h80mb.dfs.core.windows.net/ServiceBus/appeal-has/2024-12-02/appeal-has_2024-12-02T16:54:35.214679+0000.json\n",
+					"    It extracts the date from the string for each row and gets the maximum date.\n",
+					"\n",
+					"    Args:\n",
+					"        df: a spark DataFrame\n",
+					"\n",
+					"    Returns:\n",
+					"        formatted_timestamp: a string of the maximum file date\n",
+					"    \"\"\"\n",
+					"    date_pattern: str = r'(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}\\+\\d{4})'\n",
+					"    df: DataFrame = df.withColumn(\"file_date\", regexp_extract(df[\"input_file\"], date_pattern, 1))\n",
+					"    df: DataFrame = df.withColumn(\"file_date\", df[\"file_date\"].cast(TimestampType()))\n",
+					"    max_timestamp: list = df.agg(max(\"file_date\")).collect()[0][0]\n",
+					"    formatted_timestamp: str = max_timestamp.strftime(\"%Y-%m-%dT%H:%M:%S.%f\")+\"+0000\"\n",
+					"    return formatted_timestamp"
+				],
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -578,7 +635,7 @@
 					"    return (ingestion_failure, rows_raw)\n",
 					""
 				],
-				"execution_count": 9
+				"execution_count": 22
 			}
 		]
 	}

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b5e292e0-2125-42bb-b2c7-8541e107705a"
+				"spark.autotune.trackingId": "b587b66b-974e-4114-b586-f04cd85865a3"
 			}
 		},
 		"metadata": {
@@ -410,7 +410,7 @@
 					"\n",
 					"    standardised_container = \"abfss://odw-standardised@\"+storage_account\n",
 					"    standardised_path = definition['Standardised_Path'] + \"/\"\n",
-					"    standardised_table_name = definition['Standardised_Table_Name']\n",
+					"    standardised_table_name = definition['zzz_test_{definition['Standardised_Table_Name']}\"\n",
 					"\n",
 					"    if 'Standardised_Table_Definition' in definition:\n",
 					"        standardised_table_loc = \"abfss://odw-config@\"+storage_account + definition['Standardised_Table_Definition']\n",
@@ -490,7 +490,9 @@
 					"    sparkDF = sparkDF.withColumn(\"ingested_datetime\",lit(datetime.now()))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_from\",lit(expected_from))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_to\",lit(expected_to))\n",
-					"    \n",
+					"    ## add extra log columns here\n",
+					"\n",
+					"\n",
 					"    ### change any array field to string\n",
 					"    schema = json.loads(standardised_table_def_json)\n",
 					"    for field in schema['fields']:\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e9d3796a-affc-4601-85f0-1bd52badbc77"
+				"spark.autotune.trackingId": "3f9c0601-11fd-4d5a-be52-64a3efdb9b57"
 			}
 		},
 		"metadata": {
@@ -532,7 +532,7 @@
 					"    sparkDF = sparkDF.withColumn(\"ingested_datetime\",lit(datetime.now()))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_from\",lit(expected_from))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_to\",lit(expected_to))\n",
-					"    sparkDF = sparkDF.withColumn(\"file_name\", lit(filename)) \n",
+					"    sparkDF = sparkDF.withColumn(\"raw_file_name\", lit(filename)) \n",
 					"\n",
 					"\n",
 					"    ### change any array field to string\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b587b66b-974e-4114-b586-f04cd85865a3"
+				"spark.autotune.trackingId": "e9d3796a-affc-4601-85f0-1bd52badbc77"
 			}
 		},
 		"metadata": {
@@ -384,6 +384,48 @@
 				},
 				"source": [
 					"@logging_to_appins\n",
+					"def extract_and_filter_paths(files: list, filter_date: str):\n",
+					"    \"\"\"\n",
+					"    Takes a list of file paths and filters them to return the file paths greater than the filter_date\n",
+					"    \n",
+					"    Args:\n",
+					"        files: a list of file paths\n",
+					"        filter_date: a date to filter on\n",
+					"\n",
+					"    Returns:\n",
+					"        filtered_paths: a list of file paths greater than a given date\n",
+					"    \"\"\"\n",
+					"    timestamp_pattern: str = re.compile(r\"(\\d{4}-\\d{2}-\\d{2}T\\d{2}[:_]\\d{2}[:_]\\d{2}[.\\d]*[+-]\\d{4})\")\n",
+					"    filter_datetime: datetime = datetime.strptime(filter_date, \"%Y-%m-%dT%H:%M:%S.%f%z\")\n",
+					"    filtered_paths: list = []\n",
+					"\n",
+					"    for file in files:\n",
+					"        match = timestamp_pattern.search(file)\n",
+					"        if match:\n",
+					"            timestamp_str = match.group(1).replace('_', ':')\n",
+					"            file_datetime = datetime.strptime(timestamp_str, \"%Y-%m-%dT%H:%M:%S.%f%z\")\n",
+					"            if file_datetime > filter_datetime:\n",
+					"                filtered_paths.append(file)\n",
+					"\n",
+					"    return filtered_paths"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"@logging_to_appins\n",
 					"def ingest_adhoc(storage_account, \n",
 					"                    definition,\n",
 					"                    folder_path, \n",
@@ -490,7 +532,7 @@
 					"    sparkDF = sparkDF.withColumn(\"ingested_datetime\",lit(datetime.now()))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_from\",lit(expected_from))\n",
 					"    sparkDF = sparkDF.withColumn(\"expected_to\",lit(expected_to))\n",
-					"    ## add extra log columns here\n",
+					"    sparkDF = sparkDF.withColumn(\"file_name\", lit(filename)) \n",
 					"\n",
 					"\n",
 					"    ### change any array field to string\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "084224c8-2256-4a58-a8e6-54de87a2a04d"
+				"spark.autotune.trackingId": "af8b1c6f-ea8a-4b72-81d6-828cff631d4b"
 			}
 		},
 		"metadata": {
@@ -509,7 +509,7 @@
 					"\n",
 					"    standardised_container = \"abfss://odw-standardised@\"+storage_account\n",
 					"    standardised_path = definition['Standardised_Path'] + \"/\"\n",
-					"    standardised_table_name = definition['zzz_test_{definition['Standardised_Table_Name']}\"\n",
+					"    standardised_table_name = f\"zzz_test_{definition['Standardised_Table_Name']}\"\n",
 					"\n",
 					"    if 'Standardised_Table_Definition' in definition:\n",
 					"        standardised_table_loc = \"abfss://odw-config@\"+storage_account + definition['Standardised_Table_Definition']\n",
@@ -635,7 +635,7 @@
 					"    return (ingestion_failure, rows_raw)\n",
 					""
 				],
-				"execution_count": 22
+				"execution_count": 1
 			}
 		]
 	}

--- a/workspace/notebook/py_raw_to_std.json
+++ b/workspace/notebook/py_raw_to_std.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d7a10613-307b-4550-9f3b-1a842dadab42"
+				"spark.autotune.trackingId": "f2fdc388-45d8-41b3-881d-69887e620574"
 			}
 		},
 		"metadata": {
@@ -293,6 +293,24 @@
 					""
 				],
 				"execution_count": 13
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					""
+				],
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -2,7 +2,7 @@
 	"name": "py_raw_to_std_revised",
 	"properties": {
 		"folder": {
-			"name": "service-bus"
+			"name": "1-odw-raw-to-standardised"
 		},
 		"nbformat": 4,
 		"nbformat_minor": 2,
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "46dfd3e9-a302-4675-bcde-240bb5b9b514"
+				"spark.autotune.trackingId": "3750e110-c357-4ddf-b266-ebc038aea4e1"
 			}
 		},
 		"metadata": {
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.4",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
@@ -90,7 +90,7 @@
 					"    }\n",
 					"}"
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -108,7 +108,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -124,8 +124,7 @@
 					}
 				},
 				"source": [
-					"entity_name = \"horizon-appeals-document-metadata\"\n",
-					""
+					"entity_name = \"horizon-appeals-document-metadata\""
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5ec1ef18-2847-46b1-a0d5-134e13d5fc17"
+				"spark.autotune.trackingId": "41444344-1b3b-4423-b89c-e3f8834446b5"
 			}
 		},
 		"metadata": {
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
@@ -111,24 +111,6 @@
 				"execution_count": 9
 			},
 			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"entity_name = \"horizon-appeals-document-metadata\""
-				],
-				"execution_count": null
-			},
-			{
 				"cell_type": "markdown",
 				"metadata": {
 					"nteract": {
@@ -184,24 +166,6 @@
 					}
 				},
 				"source": [
-					"raw_container"
-				],
-				"execution_count": 11
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
 					"%run \"1-odw-raw-to-standardised/Fileshare/SAP_HR/py_1_raw_to_standardised_hr_functions\""
 				],
 				"execution_count": 12
@@ -239,6 +203,7 @@
 					"    import pandas as pd\n",
 					"    from pyspark.sql.functions import col, lit\n",
 					"    from pyspark.sql.types import StructType\n",
+					"    import re\n",
 					"    \n",
 					"    ingestion_failure = False\n",
 					"    spark = SparkSession.builder.getOrCreate()\n",
@@ -335,7 +300,7 @@
 					"\n",
 					"    # Write to Delta table\n",
 					"    logInfo(f\"Writing data to odw_standardised_db.{standardised_table_name}\")\n",
-					"    sparkDF.write.option(\"mergeSchema\", \"true\").format(\"delta\").mode(\"append\").saveAsTable(f\"odw_standardised_db.{standardised_table_name}\")\n",
+					"    sparkDF.write.option(\"mergeSchema\", \"true\").format(\"delta\").mode(\"append\").saveAsTable(f\"odw_standardised_db.{standardised_table_name}_test\")\n",
 					"\n",
 					"    # Validate rows written\n",
 					"    rows_new = spark.read.format(\"delta\").load(standardised_table_location) \\\n",
@@ -350,7 +315,7 @@
 					"    return ingestion_failure, sparkDF.count()\n",
 					""
 				],
-				"execution_count": 13
+				"execution_count": 43
 			},
 			{
 				"cell_type": "markdown",
@@ -387,7 +352,7 @@
 					"delete_existing_table=False\n",
 					"dataAttribute = \"\""
 				],
-				"execution_count": 37
+				"execution_count": 45
 			},
 			{
 				"cell_type": "markdown",
@@ -455,33 +420,33 @@
 					"                        and (not source_frequency_folder or d['Source_Frequency_Folder'] == source_frequency_folder) \n",
 					"                        and file.name.startswith(d['Source_Filename_Start'])), None)\n",
 					"    \n",
-					"#     if definition:\n",
-					"#         expected_from = date_folder - timedelta(days=1)\n",
-					"#         expected_from = datetime.combine(expected_from, datetime.min.time())\n",
-					"#         expected_to = expected_from + timedelta(days=definition['Expected_Within_Weekdays']) \n",
+					"    if definition:\n",
+					"        expected_from = date_folder - timedelta(days=1)\n",
+					"        expected_from = datetime.combine(expected_from, datetime.min.time())\n",
+					"        expected_to = expected_from + timedelta(days=definition['Expected_Within_Weekdays']) \n",
 					"\n",
-					"#         if delete_existing_table:\n",
-					"#             logInfo(f\"Deleting existing table if exists odw_standardised_db.{definition['Standardised_Table_Name']}\")\n",
-					"#             mssparkutils.notebook.run('/utils/py_delete_table', 300, arguments={'db_name': 'odw_standardised_db', 'table_name': definition['Standardised_Table_Name']})\n",
+					"        if delete_existing_table:\n",
+					"            logInfo(f\"Deleting existing table if exists odw_standardised_db.{definition['Standardised_Table_Name']}\")\n",
+					"            mssparkutils.notebook.run('/utils/py_delete_table', 300, arguments={'db_name': 'odw_standardised_db', 'table_name': definition['Standardised_Table_Name']})\n",
 					"\n",
-					"#         logInfo(f\"Ingesting {file.name}\")\n",
-					"#         (ingestion_failure, row_count) = ingest_adhoc2(storage_account, definition, source_path, file.name, expected_from, expected_to, isMultiLine, dataAttribute)\n",
-					"#         logInfo(f\"Ingested {row_count} rows\")\n",
+					"        logInfo(f\"Ingesting {file.name}\")\n",
+					"        (ingestion_failure, row_count) = ingest_adhoc2(storage_account, definition, source_path, file.name, expected_from, expected_to, isMultiLine, dataAttribute)\n",
+					"        logInfo(f\"Ingested {row_count} rows\")\n",
 					"\n",
-					"#         if ingestion_failure:\n",
-					"#             print(f\"Errors reported during Ingestion!!\")\n",
-					"#             raise RuntimeError(\"Ingestion Failure\")\n",
-					"#         else:\n",
-					"#             print(f\"No Errors reported during Ingestion\")\n",
+					"        if ingestion_failure:\n",
+					"            print(f\"Errors reported during Ingestion!!\")\n",
+					"            raise RuntimeError(\"Ingestion Failure\")\n",
+					"        else:\n",
+					"            print(f\"No Errors reported during Ingestion\")\n",
 					"\n",
-					"#     else:\n",
-					"#         if specific_file != '':\n",
-					"#             raise ValueError(f\"No definition found for {specific_file}\")\n",
-					"#         else:\n",
-					"#             logError(\"No definition found\")\n",
+					"    else:\n",
+					"        if specific_file != '':\n",
+					"            raise ValueError(f\"No definition found for {specific_file}\")\n",
+					"        else:\n",
+					"            logError(\"No definition found\")\n",
 					""
 				],
-				"execution_count": 38
+				"execution_count": 46
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f70b7ccf-3e13-4c52-a7a9-6651948d88a9"
+				"spark.autotune.trackingId": "3be83a2f-2065-4273-b32c-078d40e8f52c"
 			}
 		},
 		"metadata": {
@@ -114,7 +114,7 @@
 					}
 				},
 				"source": [
-					"entity_name = \"stef_test\"\n",
+					"entity_name = \"appeals-document\"\n",
 					""
 				],
 				"execution_count": null

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -7,7 +7,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3be83a2f-2065-4273-b32c-078d40e8f52c"
+				"spark.autotune.trackingId": "bbd7f8d8-8f71-48e6-bc33-c7ab14e13ef5"
 			}
 		},
 		"metadata": {
@@ -34,10 +34,10 @@
 				"name": "python"
 			},
 			"a365ComputeOptions": {
-				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
-				"name": "pinssynspodw",
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
+				"name": "pinssynspodwpr",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodwpr",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
@@ -157,9 +157,9 @@
 					}
 				},
 				"source": [
-					"%run service-bus/py_spark_df_ingestion_functions"
+					"%run \"1-odw-raw-to-standardised/Fileshare/SAP_HR/py_1_raw_to_standardised_hr_functions\""
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -1,5 +1,5 @@
 {
-	"name": "py_sb_raw_to_std",
+	"name": "py_raw_to_std_revised",
 	"properties": {
 		"folder": {
 			"name": "service-bus"
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bd56b2e5-3015-487d-9aa1-6dcbced1b4a0"
+				"spark.autotune.trackingId": "f70b7ccf-3e13-4c52-a7a9-6651948d88a9"
 			}
 		},
 		"metadata": {
@@ -52,6 +52,22 @@
 		},
 		"cells": [
 			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"## Prerequisites\n",
+					"1. Make sure the new raw file's entry has been added to the Orchestration i.e `/infrastructure/configuration/data-lake/orchestration/orchestration.json`\n",
+					"2. Make sure the standardised table's schema is present on the path specified in the entry added in step 1.\n",
+					"3. Only if the raw file is huge (several GBs), the spark pool might need some upscaling. Hence the following cell"
+				]
+			},
+			{
 				"cell_type": "code",
 				"metadata": {
 					"jupyter": {
@@ -67,28 +83,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 2
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"tags": [
-						"parameters"
-					]
-				},
-				"source": [
-					""
-				],
-				"execution_count": 3
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -103,7 +98,26 @@
 					"from pyspark.sql.functions import *\n",
 					"import re"
 				],
-				"execution_count": 4
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"entity_name = \"stef_test\"\n",
+					""
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -127,7 +141,7 @@
 					"schema = mssparkutils.notebook.run(\"/py_create_spark_schema\", 30, {\"db_name\": 'odw_standardised_db', \"entity_name\": entity_name})\n",
 					"spark_schema = StructType.fromJson(json.loads(schema)) if schema != '' else ''"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -145,7 +159,7 @@
 				"source": [
 					"%run service-bus/py_spark_df_ingestion_functions"
 				],
-				"execution_count": 6
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +192,7 @@
 					"\r\n",
 					"    return max_value"
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +230,7 @@
 					"    formatted_timestamp: str = max_timestamp.strftime(\"%Y-%m-%dT%H:%M:%S.%f\")+\"+0000\"\r\n",
 					"    return formatted_timestamp"
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +273,7 @@
 					"    \r\n",
 					"    return files"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -299,7 +313,7 @@
 					"\r\n",
 					"    return missing_files"
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +355,7 @@
 					"\r\n",
 					"    return filtered_paths"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -384,7 +398,7 @@
 					"\n",
 					"    return df"
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -419,7 +433,7 @@
 					"    return df\r\n",
 					""
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -451,7 +465,7 @@
 					"    .saveAsTable(table_name)\r\n",
 					""
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -482,7 +496,7 @@
 					"    \"\"\"\r\n",
 					"    return new_table_row_count == expected_new_count"
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -540,7 +554,7 @@
 					"    except Exception as e:\r\n",
 					"        logError(f\"Error getting list of missing files:\\n{e}\")"
 				],
-				"execution_count": 16
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -585,7 +599,7 @@
 					"except Exception as e:\r\n",
 					"    logError(f\"Error deduping and generating counts:\\n{e}\")"
 				],
-				"execution_count": 17
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -623,7 +637,7 @@
 					"except Exception as e:\n",
 					"    logError(f\"Error appending rows:\\n{e}\")"
 				],
-				"execution_count": 18
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -659,7 +673,7 @@
 					"else:\r\n",
 					"    logInfo(\"Rows appended successfully.\")"
 				],
-				"execution_count": 19
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bbd7f8d8-8f71-48e6-bc33-c7ab14e13ef5"
+				"spark.autotune.trackingId": "f4a43937-63b3-4db9-833b-5032696aaf95"
 			}
 		},
 		"metadata": {
@@ -83,7 +83,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 1
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -98,7 +98,7 @@
 					"from pyspark.sql.functions import *\n",
 					"import re"
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -117,7 +117,51 @@
 					"entity_name = \"appeals-document\"\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 9
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"#####"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
+				],
+				"execution_count": 35
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Initialise the parameters"
+				]
 			},
 			{
 				"cell_type": "code",
@@ -135,13 +179,14 @@
 				"source": [
 					"spark: SparkSession = SparkSession.builder.getOrCreate()\n",
 					"storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
-					"table_name: str = f\"odw_standardised_db.sb_{entity_name.replace('-', '_')}\"\n",
-					"date_folder = datetime.now().date().strftime('%Y-%m-%d') if date_folder == '' else date_folder\n",
-					"source_path: str = f\"abfss://odw-raw@{storage_account}ServiceBus/{entity_name}/\"\n",
+					"table_name: str = f\"odw_standardised_db.{entity_name.replace('-', '_')}\"\n",
+					"date_folder = datetime.now().date().strftime('%Y-%m-%d')\n",
+					"# if date_folder == '' else date_folder\n",
+					"source_path: str = f\"abfss://odw-raw@{storage_account}test_stef/{entity_name}/\"\n",
 					"schema = mssparkutils.notebook.run(\"/py_create_spark_schema\", 30, {\"db_name\": 'odw_standardised_db', \"entity_name\": entity_name})\n",
 					"spark_schema = StructType.fromJson(json.loads(schema)) if schema != '' else ''"
 				],
-				"execution_count": null
+				"execution_count": 37
 			},
 			{
 				"cell_type": "code",
@@ -159,7 +204,7 @@
 				"source": [
 					"%run \"1-odw-raw-to-standardised/Fileshare/SAP_HR/py_1_raw_to_standardised_hr_functions\""
 				],
-				"execution_count": 4
+				"execution_count": 38
 			},
 			{
 				"cell_type": "code",
@@ -181,7 +226,7 @@
 					"    Gets the maximum value from a given table column\r\n",
 					"\r\n",
 					"    Args:\r\n",
-					"        table_name: the name of the table, e.g. sb_appeal_has\r\n",
+					"        table_name: the name of the table, e.g. appeal_has\r\n",
 					"        column_name: the name of the table column, e.g. ingested_datetime\r\n",
 					"\r\n",
 					"    Returns:\r\n",
@@ -192,7 +237,7 @@
 					"\r\n",
 					"    return max_value"
 				],
-				"execution_count": null
+				"execution_count": 39
 			},
 			{
 				"cell_type": "code",
@@ -230,7 +275,7 @@
 					"    formatted_timestamp: str = max_timestamp.strftime(\"%Y-%m-%dT%H:%M:%S.%f\")+\"+0000\"\r\n",
 					"    return formatted_timestamp"
 				],
-				"execution_count": null
+				"execution_count": 40
 			},
 			{
 				"cell_type": "code",
@@ -273,7 +318,7 @@
 					"    \r\n",
 					"    return files"
 				],
-				"execution_count": null
+				"execution_count": 41
 			},
 			{
 				"cell_type": "code",
@@ -299,7 +344,7 @@
 					"    Compares the two sets to give the missing files not yet loaded to the table.\r\n",
 					"\r\n",
 					"    Args:\r\n",
-					"        table_name: the name of the table, e.g. sb_appeal_has\r\n",
+					"        table_name: the name of the table, e.g. appeal_has\r\n",
 					"        source_path: the folder path to start from, \r\n",
 					"        e.g. abfss://odw-raw@pinsstodwdevuks9h80mb.dfs.core.windows.net/ServiceBus/appeal-has/\r\n",
 					"\r\n",
@@ -313,7 +358,7 @@
 					"\r\n",
 					"    return missing_files"
 				],
-				"execution_count": null
+				"execution_count": 42
 			},
 			{
 				"cell_type": "code",
@@ -355,7 +400,7 @@
 					"\r\n",
 					"    return filtered_paths"
 				],
-				"execution_count": null
+				"execution_count": 43
 			},
 			{
 				"cell_type": "code",
@@ -398,7 +443,7 @@
 					"\n",
 					"    return df"
 				],
-				"execution_count": null
+				"execution_count": 44
 			},
 			{
 				"cell_type": "code",
@@ -433,7 +478,7 @@
 					"    return df\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 45
 			},
 			{
 				"cell_type": "code",
@@ -465,7 +510,7 @@
 					"    .saveAsTable(table_name)\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 46
 			},
 			{
 				"cell_type": "code",
@@ -496,7 +541,7 @@
 					"    \"\"\"\r\n",
 					"    return new_table_row_count == expected_new_count"
 				],
-				"execution_count": null
+				"execution_count": 47
 			},
 			{
 				"cell_type": "markdown",
@@ -554,7 +599,7 @@
 					"    except Exception as e:\r\n",
 					"        logError(f\"Error getting list of missing files:\\n{e}\")"
 				],
-				"execution_count": null
+				"execution_count": 48
 			},
 			{
 				"cell_type": "markdown",
@@ -599,7 +644,7 @@
 					"except Exception as e:\r\n",
 					"    logError(f\"Error deduping and generating counts:\\n{e}\")"
 				],
-				"execution_count": null
+				"execution_count": 49
 			},
 			{
 				"cell_type": "markdown",
@@ -637,7 +682,7 @@
 					"except Exception as e:\n",
 					"    logError(f\"Error appending rows:\\n{e}\")"
 				],
-				"execution_count": null
+				"execution_count": 50
 			},
 			{
 				"cell_type": "markdown",
@@ -673,7 +718,7 @@
 					"else:\r\n",
 					"    logInfo(\"Rows appended successfully.\")"
 				],
-				"execution_count": null
+				"execution_count": 51
 			}
 		]
 	}

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3750e110-c357-4ddf-b266-ebc038aea4e1"
+				"spark.autotune.trackingId": "5ec1ef18-2847-46b1-a0d5-134e13d5fc17"
 			}
 		},
 		"metadata": {
@@ -90,7 +90,7 @@
 					"    }\n",
 					"}"
 				],
-				"execution_count": 4
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -108,7 +108,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 5
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -168,7 +168,7 @@
 					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"raw_container = \"abfss://odw-raw@\" + storage_account"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -186,7 +186,7 @@
 				"source": [
 					"raw_container"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -204,7 +204,153 @@
 				"source": [
 					"%run \"1-odw-raw-to-standardised/Fileshare/SAP_HR/py_1_raw_to_standardised_hr_functions\""
 				],
-				"execution_count": null
+				"execution_count": 12
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# Rewriting ingest_adhoc function\n",
+					"\n",
+					"@logging_to_appins\n",
+					"def ingest_adhoc2(storage_account, \n",
+					"                    definition,\n",
+					"                    folder_path, \n",
+					"                    filename, \n",
+					"                    expected_from, \n",
+					"                    expected_to, \n",
+					"                    isMultilineJSON=False, \n",
+					"                    dataAttribute=None):\n",
+					"\n",
+					"    from pyspark.sql import SparkSession\n",
+					"    from notebookutils import mssparkutils\n",
+					"    import json\n",
+					"    from datetime import datetime\n",
+					"    import pandas as pd\n",
+					"    from pyspark.sql.functions import col, lit\n",
+					"    from pyspark.sql.types import StructType\n",
+					"    \n",
+					"    ingestion_failure = False\n",
+					"    spark = SparkSession.builder.getOrCreate()\n",
+					"    spark.conf.set(\"spark.databricks.delta.schema.autoMerge.enabled\", \"true\")\n",
+					"\n",
+					"    standardised_container = f\"abfss://odw-standardised@{storage_account}\"\n",
+					"    standardised_path = definition['Standardised_Path'] + \"/\"\n",
+					"    standardised_table_name = definition['Standardised_Table_Name']\n",
+					"    \n",
+					"    # Load standardised table schema\n",
+					"    if 'Standardised_Table_Definition' in definition:\n",
+					"        standardised_table_loc = f\"abfss://odw-config@{storage_account}{definition['Standardised_Table_Definition']}\"\n",
+					"        standardised_table_def_json = spark.read.text(standardised_table_loc, wholetext=True).first().value\n",
+					"    else:\n",
+					"        standardised_table_def_json = mssparkutils.notebook.run('/py_get_schema_from_url', 30, \n",
+					"                                                                {'db_name': 'odw_standardised_db', \n",
+					"                                                                 'entity_name': definition['Source_Frequency_Folder']})\n",
+					"\n",
+					"    # Create table if not exists\n",
+					"    if not any([table.name == standardised_table_name for table in spark.catalog.listTables('odw_standardised_db')]):\n",
+					"        create_table_from_schema(standardised_table_def_json, \"odw_standardised_db\", standardised_table_name, \n",
+					"                                 standardised_container, standardised_path + standardised_table_name)   \n",
+					"\n",
+					"    # Ensure table is in Delta format\n",
+					"    table_metadata = spark.sql(f\"DESCRIBE EXTENDED odw_standardised_db.{standardised_table_name}\")\n",
+					"    data_format = table_metadata.filter(table_metadata.col_name == \"Provider\").collect()[0].data_type\n",
+					"\n",
+					"    if data_format == \"parquet\":\n",
+					"        spark.sql(f\"CONVERT TO DELTA odw_standardised_db.{standardised_table_name}\")\n",
+					"\n",
+					"    # Get table location\n",
+					"    try:\n",
+					"        standardised_table_location = spark.sql(f\"DESCRIBE FORMATTED odw_standardised_db.{standardised_table_name}\") \\\n",
+					"                    .filter(\"col_name = 'Location'\") \\\n",
+					"                    .select(\"data_type\") \\\n",
+					"                    .collect()[0][0]\n",
+					"    except:\n",
+					"        standardised_table_location = standardised_container + standardised_path + standardised_table_name\n",
+					"\n",
+					"    # Load existing standardised table\n",
+					"    standardised_table_df = spark.read.format(\"delta\").load(standardised_table_location)\n",
+					"\n",
+					"    # Check if the same expected_from and expected_to already exist\n",
+					"    rows = standardised_table_df.filter((col(\"expected_from\") == expected_from) & (col(\"expected_to\") == expected_to)).count()\n",
+					"\n",
+					"    logInfo(f\"Reading {filename}\")\n",
+					"\n",
+					"    # Read file\n",
+					"    file_path = f\"{folder_path}/{filename}\"\n",
+					"    if filename.lower().endswith(\".xlsx\"):\n",
+					"        sheet_name = definition.get('Source_Sheet_Name', 0)\n",
+					"        df = pd.read_excel(file_path, dtype=str, sheet_name=sheet_name, na_filter=False)\n",
+					"        sparkDF = spark.createDataFrame(df)\n",
+					"    elif filename.lower().endswith('.csv'):\n",
+					"        sparkDF = spark.read.options(quote='\"', escape='\\\\', encoding='utf8', header=True, multiLine=True, \n",
+					"                                     columnNameOfCorruptRecord='corrupted_records', mode=\"PERMISSIVE\").csv(file_path)\n",
+					"        if \"corrupted_records\" in sparkDF.columns:\n",
+					"            logError(f\"Corrupted Records detected from CSV ingestion in {filename}\")\n",
+					"            ingestion_failure = True\n",
+					"    elif filename.lower().endswith('.json'):\n",
+					"        if isMultilineJSON:\n",
+					"            logInfo(\"Reading multiline JSON\")\n",
+					"            sparkDF = spark.read.option(\"multiline\", \"true\").json(file_path)\n",
+					"            if dataAttribute:\n",
+					"                sparkDF = sparkDF.select(dataAttribute).rdd.flatMap(lambda row: row[dataAttribute]).toDF()\n",
+					"        else:\n",
+					"            sparkDF = spark.read.json(file_path)\n",
+					"    else:\n",
+					"        raise RuntimeError(f\"Unsupported file type for {filename}\")\n",
+					"\n",
+					"    # Drop unnamed columns (headerless)\n",
+					"    sparkDF = sparkDF.select([col for col in sparkDF.columns if not col.startswith('Unnamed')])\n",
+					"\n",
+					"    # Add metadata columns\n",
+					"    sparkDF = sparkDF.withColumn(\"ingested_datetime\", lit(datetime.now()))\n",
+					"    sparkDF = sparkDF.withColumn(\"expected_from\", lit(expected_from))\n",
+					"    sparkDF = sparkDF.withColumn(\"expected_to\", lit(expected_to))\n",
+					"    sparkDF = sparkDF.withColumn(\"file_name\", lit(filename))\n",
+					"\n",
+					"    # Ensure schema consistency\n",
+					"    schema = StructType.fromJson(json.loads(standardised_table_def_json))\n",
+					"    for field in schema.fields:\n",
+					"        if field.dataType.simpleString() == 'array':\n",
+					"            sparkDF = sparkDF.withColumn(field.name, col(field.name).cast(\"string\"))\n",
+					"\n",
+					"    # Rename columns for Delta compatibility\n",
+					"    new_columns = {c: re.sub(r'[^0-9a-zA-Z]+', '_', c).lower().rstrip('_') for c in sparkDF.columns}\n",
+					"    sparkDF = sparkDF.toDF(*[new_columns[c] for c in sparkDF.columns])\n",
+					"\n",
+					"    # Cast fields to match schema\n",
+					"    for field in schema.fields:\n",
+					"        if field.name in sparkDF.columns:\n",
+					"            sparkDF = sparkDF.withColumn(field.name, col(field.name).cast(field.dataType))\n",
+					"\n",
+					"    # Write to Delta table\n",
+					"    logInfo(f\"Writing data to odw_standardised_db.{standardised_table_name}\")\n",
+					"    sparkDF.write.option(\"mergeSchema\", \"true\").format(\"delta\").mode(\"append\").saveAsTable(f\"odw_standardised_db.{standardised_table_name}\")\n",
+					"\n",
+					"    # Validate rows written\n",
+					"    rows_new = spark.read.format(\"delta\").load(standardised_table_location) \\\n",
+					"        .filter((col(\"expected_from\") == expected_from) & (col(\"expected_to\") == expected_to)).count()\n",
+					"\n",
+					"    if rows_new >= sparkDF.count():\n",
+					"        logInfo(\"All rows successfully written\")\n",
+					"    else:\n",
+					"        logError(f\"Row count mismatch: Expected {sparkDF.count()}, Written {rows_new}\")\n",
+					"        ingestion_failure = True\n",
+					"\n",
+					"    return ingestion_failure, sparkDF.count()\n",
+					""
+				],
+				"execution_count": 13
 			},
 			{
 				"cell_type": "markdown",
@@ -233,15 +379,122 @@
 					}
 				},
 				"source": [
-					"date_folder=''\n",
-					"source_folder=''\n",
+					"date_folder='2025-02-04'\n",
+					"source_folder='stef_test'\n",
 					"source_frequency_folder=''\n",
 					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
 					"isMultiLine = True\n",
 					"delete_existing_table=False\n",
 					"dataAttribute = \"\""
 				],
-				"execution_count": null
+				"execution_count": 37
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"### Ingest the data from the raw/source into the standardised table. \n",
+					"If the table doesn't already exist, this will create the table first and ingest the data."
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"if date_folder == '':\n",
+					"    date_folder = datetime.now().date()\n",
+					"else:\n",
+					"    date_folder = datetime.strptime(date_folder, \"%Y-%m-%d\")\n",
+					"\n",
+					"date_folder_str = date_folder.strftime('%Y-%m-%d')\n",
+					"source_folder_path = source_folder if not source_frequency_folder else f\"{source_folder}/{source_frequency_folder}\"\n",
+					"\n",
+					"# READ ORCHESTRATION DATA\n",
+					"path_to_orchestration_file = \"abfss://odw-config@\"+storage_account+\"orchestration/orchestration.json\"\n",
+					"df = spark.read.option(\"multiline\",\"true\").json(path_to_orchestration_file)\n",
+					"definitions = json.loads(df.toJSON().first())['definitions']\n",
+					"\n",
+					"source_path = f\"{raw_container}{source_folder_path}/{date_folder_str}\"\n",
+					"\n",
+					"try:\n",
+					"    logInfo(f\"Reading from {source_path}\")\n",
+					"    files = mssparkutils.fs.ls(source_path)\n",
+					"except Exception as e:\n",
+					"    logError(f\"Raw file not found at {source_path}\")\n",
+					"    logException(e)\n",
+					"    mssparkutils.notebook.exit(f\"Raw file not found at {source_path}\")\n",
+					"\n",
+					"\n",
+					"for file in files:\n",
+					"\n",
+					"    # ignore json raw files if source is service bus\n",
+					"    if source_folder == 'ServiceBus' and file.name.endswith('.json'):\n",
+					"        continue\n",
+					"\n",
+					"    # ignore files other than specified file \n",
+					"    if specific_file != '' and not file.name.startswith(specific_file + '.'):\n",
+					"        continue\n",
+					"        \n",
+					"    definition = next((d for d in definitions if (specific_file == '' or d['Source_Filename_Start'] == specific_file) \n",
+					"                        and (not source_frequency_folder or d['Source_Frequency_Folder'] == source_frequency_folder) \n",
+					"                        and file.name.startswith(d['Source_Filename_Start'])), None)\n",
+					"    \n",
+					"#     if definition:\n",
+					"#         expected_from = date_folder - timedelta(days=1)\n",
+					"#         expected_from = datetime.combine(expected_from, datetime.min.time())\n",
+					"#         expected_to = expected_from + timedelta(days=definition['Expected_Within_Weekdays']) \n",
+					"\n",
+					"#         if delete_existing_table:\n",
+					"#             logInfo(f\"Deleting existing table if exists odw_standardised_db.{definition['Standardised_Table_Name']}\")\n",
+					"#             mssparkutils.notebook.run('/utils/py_delete_table', 300, arguments={'db_name': 'odw_standardised_db', 'table_name': definition['Standardised_Table_Name']})\n",
+					"\n",
+					"#         logInfo(f\"Ingesting {file.name}\")\n",
+					"#         (ingestion_failure, row_count) = ingest_adhoc2(storage_account, definition, source_path, file.name, expected_from, expected_to, isMultiLine, dataAttribute)\n",
+					"#         logInfo(f\"Ingested {row_count} rows\")\n",
+					"\n",
+					"#         if ingestion_failure:\n",
+					"#             print(f\"Errors reported during Ingestion!!\")\n",
+					"#             raise RuntimeError(\"Ingestion Failure\")\n",
+					"#         else:\n",
+					"#             print(f\"No Errors reported during Ingestion\")\n",
+					"\n",
+					"#     else:\n",
+					"#         if specific_file != '':\n",
+					"#             raise ValueError(f\"No definition found for {specific_file}\")\n",
+					"#         else:\n",
+					"#             logError(\"No definition found\")\n",
+					""
+				],
+				"execution_count": 38
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Extra functions"
+				]
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_raw_to_std_revised.json
+++ b/workspace/notebook/py_raw_to_std_revised.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f4a43937-63b3-4db9-833b-5032696aaf95"
+				"spark.autotune.trackingId": "46dfd3e9-a302-4675-bcde-240bb5b9b514"
 			}
 		},
 		"metadata": {
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
@@ -81,24 +81,95 @@
 					}
 				},
 				"source": [
-					"%run utils/py_logging_decorator"
+					"%%configure -f\n",
+					"{\n",
+					"    \"conf\": {\n",
+					"        \"spark.kryoserializer.buffer.max\": \"2047m\",\n",
+					"        \"spark.driver.maxResultSize\": \"10g\",\n",
+					"        \"spark.rpc.message.maxSize\": \"1280\"\n",
+					"    }\n",
+					"}"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"%run utils/py_logging_decorator"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"entity_name = \"horizon-appeals-document-metadata\"\n",
+					""
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"### Get the Storage Account"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
 				"source": [
 					"from pyspark.sql import SparkSession\n",
 					"from notebookutils import mssparkutils\n",
 					"import json\n",
-					"from datetime import datetime, date\n",
-					"from pyspark.sql.functions import current_timestamp, expr, to_timestamp, lit, input_file_name\n",
-					"from pyspark.sql import DataFrame\n",
-					"from pyspark.sql.types import StructType,TimestampType\n",
-					"from pyspark.sql.functions import *\n",
-					"import re"
+					"import calendar\n",
+					"from datetime import datetime, timedelta, date\n",
+					"import pandas as pd\n",
+					"import os\n",
+					"\n",
+					"spark = SparkSession.builder.getOrCreate()\n",
+					"\n",
+					"storage_account=mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
+					"raw_container = \"abfss://odw-raw@\" + storage_account"
 				],
-				"execution_count": 6
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -114,79 +185,9 @@
 					}
 				},
 				"source": [
-					"entity_name = \"appeals-document\"\n",
-					""
+					"raw_container"
 				],
-				"execution_count": 9
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"#####"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
-				],
-				"execution_count": 35
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"##### Initialise the parameters"
-				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"spark: SparkSession = SparkSession.builder.getOrCreate()\n",
-					"storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
-					"table_name: str = f\"odw_standardised_db.{entity_name.replace('-', '_')}\"\n",
-					"date_folder = datetime.now().date().strftime('%Y-%m-%d')\n",
-					"# if date_folder == '' else date_folder\n",
-					"source_path: str = f\"abfss://odw-raw@{storage_account}test_stef/{entity_name}/\"\n",
-					"schema = mssparkutils.notebook.run(\"/py_create_spark_schema\", 30, {\"db_name\": 'odw_standardised_db', \"entity_name\": entity_name})\n",
-					"spark_schema = StructType.fromJson(json.loads(schema)) if schema != '' else ''"
-				],
-				"execution_count": 37
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -204,7 +205,44 @@
 				"source": [
 					"%run \"1-odw-raw-to-standardised/Fileshare/SAP_HR/py_1_raw_to_standardised_hr_functions\""
 				],
-				"execution_count": 38
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"### Initialise the parameters"
+				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"date_folder=''\n",
+					"source_folder=''\n",
+					"source_frequency_folder=''\n",
+					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
+					"isMultiLine = True\n",
+					"delete_existing_table=False\n",
+					"dataAttribute = \"\""
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -237,7 +275,7 @@
 					"\r\n",
 					"    return max_value"
 				],
-				"execution_count": 39
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -275,7 +313,7 @@
 					"    formatted_timestamp: str = max_timestamp.strftime(\"%Y-%m-%dT%H:%M:%S.%f\")+\"+0000\"\r\n",
 					"    return formatted_timestamp"
 				],
-				"execution_count": 40
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -318,7 +356,7 @@
 					"    \r\n",
 					"    return files"
 				],
-				"execution_count": 41
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -358,7 +396,7 @@
 					"\r\n",
 					"    return missing_files"
 				],
-				"execution_count": 42
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -400,7 +438,7 @@
 					"\r\n",
 					"    return filtered_paths"
 				],
-				"execution_count": 43
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -443,7 +481,7 @@
 					"\n",
 					"    return df"
 				],
-				"execution_count": 44
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -478,7 +516,7 @@
 					"    return df\r\n",
 					""
 				],
-				"execution_count": 45
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -510,7 +548,7 @@
 					"    .saveAsTable(table_name)\r\n",
 					""
 				],
-				"execution_count": 46
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -541,7 +579,7 @@
 					"    \"\"\"\r\n",
 					"    return new_table_row_count == expected_new_count"
 				],
-				"execution_count": 47
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -599,7 +637,7 @@
 					"    except Exception as e:\r\n",
 					"        logError(f\"Error getting list of missing files:\\n{e}\")"
 				],
-				"execution_count": 48
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -644,7 +682,7 @@
 					"except Exception as e:\r\n",
 					"    logError(f\"Error deduping and generating counts:\\n{e}\")"
 				],
-				"execution_count": 49
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -682,7 +720,7 @@
 					"except Exception as e:\n",
 					"    logError(f\"Error appending rows:\\n{e}\")"
 				],
-				"execution_count": 50
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -718,7 +756,7 @@
 					"else:\r\n",
 					"    logInfo(\"Rows appended successfully.\")"
 				],
-				"execution_count": 51
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/pipeline/0_Raw_Horizon_NSIP_Relevant_Reps.json
+++ b/workspace/pipeline/0_Raw_Horizon_NSIP_Relevant_Reps.json
@@ -657,7 +657,7 @@
 						"type": "DatasetReference",
 						"parameters": {
 							"FileName": {
-								"value": "@concat('NSIPReleventRepresentation_', formatDateTime(utcNow(), 'yyyy-MM-ddTHH:mm:ss.ffffff'), '+0000.csv')\n",
+								"value": "NSIPReleventRepresentation.csv",
 								"type": "Expression"
 							}
 						}

--- a/workspace/pipeline/0_Raw_Horizon_NSIP_Relevant_Reps.json
+++ b/workspace/pipeline/0_Raw_Horizon_NSIP_Relevant_Reps.json
@@ -656,7 +656,10 @@
 						"referenceName": "NSIP_ReleventRepresentation",
 						"type": "DatasetReference",
 						"parameters": {
-							"FileName": "NSIPReleventRepresentation.csv"
+							"FileName": {
+								"value": "@concat('NSIPReleventRepresentation_', formatDateTime(utcNow(), 'yyyy-MM-ddTHH:mm:ss.ffffff'), '+0000.csv')\n",
+								"type": "Expression"
+							}
 						}
 					}
 				]


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ X] No

 2. Have any new tables been created in Standardised?

  	- [ X] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ X] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [X ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
