### PR TITLE
Feat/theodw 1562 upgrade spark pools to 3 4

### DIFF
--- a/data-models/appeals_representation.md
+++ b/data-models/appeals_representation.md
@@ -1,0 +1,37 @@
+#### ODW Data Model
+ 
+##### entity: appeals-representation
+ 
+Data model for appeals-representation entity showing data flow from source to curated.
+ 
+```mermaid
+ 
+classDiagram
+    direction LR
+ 
+    namespace Sources {
+        class appeals_representation {
+            representationId: int
+        }
+    }
+    namespace Standardised {
+        class sb_appeals_representation_std {
+            representationId: int
+        }
+    }
+ 
+    namespace Harmonised {
+        class sb_appeals_representation_hrm {
+            representationId: int
+        }
+    }
+ 
+    namespace Curated {
+        class appeals_representation_cu {
+            representationId: int
+        }
+    }
+ 
+appeals_representation --> sb_appeals_representation_std
+sb_appeals_representation_std --> sb_appeals_representation_hrm
+sb_appeals_representation_hrm --> appeals_representation_cu

--- a/functions/config.yaml
+++ b/functions/config.yaml
@@ -79,3 +79,7 @@ global:
     appeal-s78:
       topic: "appeal-s78"
       subscription: "appeal-s78-odw-sub"
+
+    appeal-representation:
+      topic: "appeal-representation"
+      subscription: "appeal-representation-odw-sub"

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -763,6 +763,56 @@ def appeals78(req: func.HttpRequest) -> func.HttpResponse:
         )
     
 
+@_app.function_name("appealrepresentation")
+@_app.route(route="appealrepresentation", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
+def appealrepresentation(req: func.HttpRequest) -> func.HttpResponse:
+    """
+    Azure Function endpoint for handling HTTP requests.
+
+    Args:
+        req: An instance of `func.HttpRequest` representing the HTTP request.
+
+    Returns:
+        An instance of `func.HttpResponse` representing the HTTP response.
+    """
+
+    _SCHEMA = _SCHEMAS["appeal-representation.schema.json"]
+    _TOPIC = config["global"]["entities"]["appeal-representation"]["topic"]
+    _SUBSCRIPTION = config["global"]["entities"]["appeal-representation"]["subscription"]
+
+    try:
+        _data = get_messages_and_validate(
+            namespace=_NAMESPACE_APPEALS,
+            credential=_CREDENTIAL,
+            topic=_TOPIC,
+            subscription=_SUBSCRIPTION,
+            max_message_count=_MAX_MESSAGE_COUNT,
+            max_wait_time=_MAX_WAIT_TIME,
+            schema=_SCHEMA,
+        )
+        _message_count = send_to_storage(
+            account_url=_STORAGE,
+            credential=_CREDENTIAL,
+            container=_CONTAINER,
+            entity="appeal-representation",
+            data=_data,
+        )
+
+        response = json.dumps({"message" : f"{_SUCCESS_RESPONSE} - {_message_count} messages sent to storage", "count": _message_count})
+
+        return func.HttpResponse(
+            response,
+            status_code=200
+        )
+
+    except Exception as e:
+        return (
+            func.HttpResponse(f"Validation error: {str(e)}", status_code=500)
+            if f"{_VALIDATION_ERROR}" in str(e)
+            else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
+        )
+
+
 @_app.function_name(name="getDaRT")
 @_app.route(route="getDaRT", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
 @_app.sql_input(arg_name="dart",

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -209,7 +209,7 @@ spark_pool_max_node_count  = 12
 spark_pool_min_node_count  = 3
 spark_pool_node_size       = "Small"
 spark_pool_timeout_minutes = 60
-spark_pool_version         = "3.3"
+spark_pool_version         = "3.4"
 
 spark_pool_preview_enabled = true
 spark_pool_preview_version = "3.3"

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -209,7 +209,7 @@ spark_pool_max_node_count  = 12
 spark_pool_min_node_count  = 3
 spark_pool_node_size       = "Small"
 spark_pool_timeout_minutes = 60
-spark_pool_version         = "3.4"
+spark_pool_version         = "3.3"
 
 spark_pool_preview_enabled = true
 spark_pool_preview_version = "3.3"

--- a/infrastructure/terraform.tfvars
+++ b/infrastructure/terraform.tfvars
@@ -21,5 +21,9 @@ odt_appeals_back_office_sb_topic_subscriptions = [
   {
     subscription_name = "appeal-service-user-odw-sub"
     topic_name        = "appeal-service-user"
+  },
+  {
+    subscription_name = "appeal-representation-odw-sub"
+    topic_name        = "appeal-representation"
   }
 ]

--- a/workspace/notebook/Bug_1378_review.json
+++ b/workspace/notebook/Bug_1378_review.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Calendar.json
+++ b/workspace/notebook/Calendar.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Dev test.json
+++ b/workspace/notebook/Dev test.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Developer_QA.json
+++ b/workspace/notebook/Developer_QA.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Entraid_curated_mipins.json
+++ b/workspace/notebook/Entraid_curated_mipins.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_Employee_HR_Hierarchy_Dim.json
+++ b/workspace/notebook/HIST_Employee_HR_Hierarchy_Dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_HR_record_fact.json
+++ b/workspace/notebook/HIST_HR_record_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_OrganisationUnit_Dim.json
+++ b/workspace/notebook/HIST_OrganisationUnit_Dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_PINS_location_dim.json
+++ b/workspace/notebook/HIST_PINS_location_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_contract_dim.json
+++ b/workspace/notebook/HIST_contract_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_costcentre_dim.json
+++ b/workspace/notebook/HIST_costcentre_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_employee_dim.json
+++ b/workspace/notebook/HIST_employee_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_employee_fact.json
+++ b/workspace/notebook/HIST_employee_fact.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_employeegroup_dim.json
+++ b/workspace/notebook/HIST_employeegroup_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_initial_run_views.json
+++ b/workspace/notebook/HIST_initial_run_views.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_payband_dim.json
+++ b/workspace/notebook/HIST_payband_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_payrollarea_dim.json
+++ b/workspace/notebook/HIST_payrollarea_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_personnelarea_dim.json
+++ b/workspace/notebook/HIST_personnelarea_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_personnelsubarea_dim.json
+++ b/workspace/notebook/HIST_personnelsubarea_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_position_dim.json
+++ b/workspace/notebook/HIST_position_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/HIST_sap_hr_master.json
+++ b/workspace/notebook/HIST_sap_hr_master.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Horizon_appeal_event_harmonised.json
+++ b/workspace/notebook/Horizon_appeal_event_harmonised.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Leavers not in SAPHR.json
+++ b/workspace/notebook/Leavers not in SAPHR.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/MiPINS_query.json
+++ b/workspace/notebook/MiPINS_query.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Remove curated tables ahead of service userrebuild.json
+++ b/workspace/notebook/Remove curated tables ahead of service userrebuild.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Schema_changes.json
+++ b/workspace/notebook/Schema_changes.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/THEODW-1461-message_id.json
+++ b/workspace/notebook/THEODW-1461-message_id.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/THEODW-992-WelshFields-alter-table.json
+++ b/workspace/notebook/THEODW-992-WelshFields-alter-table.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Theodw_1485_appeal_s78_add_in_config_Copy1.json
+++ b/workspace/notebook/Theodw_1485_appeal_s78_add_in_config_Copy1.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/Theodw_1485_appeal_s78_check_in_config.json
+++ b/workspace/notebook/Theodw_1485_appeal_s78_check_in_config.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/adding_zendesk_to_service_user.json
+++ b/workspace/notebook/adding_zendesk_to_service_user.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/aie_document_data.json
+++ b/workspace/notebook/aie_document_data.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeal_document.json
+++ b/workspace/notebook/appeal_document.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeal_event.json
+++ b/workspace/notebook/appeal_event.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeal_s78.json
+++ b/workspace/notebook/appeal_s78.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeal_service_user.json
+++ b/workspace/notebook/appeal_service_user.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeal_service_user_curated_mipins.json
+++ b/workspace/notebook/appeal_service_user_curated_mipins.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeals_document_metadata.json
+++ b/workspace/notebook/appeals_document_metadata.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeals_event.json
+++ b/workspace/notebook/appeals_event.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeals_folder.json
+++ b/workspace/notebook/appeals_folder.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeals_folder_curated.json
+++ b/workspace/notebook/appeals_folder_curated.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeals_has.json
+++ b/workspace/notebook/appeals_has.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/appeals_has_curated_mipins.json
+++ b/workspace/notebook/appeals_has_curated_mipins.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework-views.json
+++ b/workspace/notebook/casework-views.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_additional_fields_dim.json
+++ b/workspace/notebook/casework_additional_fields_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_advert_details_dim.json
+++ b/workspace/notebook/casework_advert_details_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_all_appeals_additional_data_dim.json
+++ b/workspace/notebook/casework_all_appeals_additional_data_dim.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_all_appeals_dim.json
+++ b/workspace/notebook/casework_all_appeals_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_application_sub_type_case_name_dim.json
+++ b/workspace/notebook/casework_application_sub_type_case_name_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_case_dates_dim.json
+++ b/workspace/notebook/casework_case_dates_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_case_fact_legacy.json
+++ b/workspace/notebook/casework_case_fact_legacy.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_case_full_list.json
+++ b/workspace/notebook/casework_case_full_list.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_case_info_dim.json
+++ b/workspace/notebook/casework_case_info_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_case_involvement_dim.json
+++ b/workspace/notebook/casework_case_involvement_dim.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_case_involvement_dim_legacy.json
+++ b/workspace/notebook/casework_case_involvement_dim_legacy.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_case_officer_additional_details_dim.json
+++ b/workspace/notebook/casework_case_officer_additional_details_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_common_land_dim.json
+++ b/workspace/notebook/casework_common_land_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_contact_information_dim.json
+++ b/workspace/notebook/casework_contact_information_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_contact_information_dim_legacy.json
+++ b/workspace/notebook/casework_contact_information_dim_legacy.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_contacts_organisation_dim.json
+++ b/workspace/notebook/casework_contacts_organisation_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_decision_issue_dim.json
+++ b/workspace/notebook/casework_decision_issue_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_enforcement_grounds_dim.json
+++ b/workspace/notebook/casework_enforcement_grounds_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_event_dim.json
+++ b/workspace/notebook/casework_event_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_event_fact.json
+++ b/workspace/notebook/casework_event_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/casework_hedgerow_dim.json
+++ b/workspace/notebook/casework_hedgerow_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/casework_high_hedges_dim.json
+++ b/workspace/notebook/casework_high_hedges_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/casework_inspector_cases_dim.json
+++ b/workspace/notebook/casework_inspector_cases_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_legacy_rights_of_way_dim.json
+++ b/workspace/notebook/casework_legacy_rights_of_way_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_local_planning_authority_dim.json
+++ b/workspace/notebook/casework_local_planning_authority_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_local_planning_authority_fact.json
+++ b/workspace/notebook/casework_local_planning_authority_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/casework_local_plans_dim.json
+++ b/workspace/notebook/casework_local_plans_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_lpa_resposibility_dim.json
+++ b/workspace/notebook/casework_lpa_resposibility_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 16,
 				"memory": 112,

--- a/workspace/notebook/casework_master.json
+++ b/workspace/notebook/casework_master.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_nsip_advice_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_advice_dim_legacy.json
@@ -44,7 +44,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_nsip_data_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_data_dim_legacy.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_nsip_examination_timetable_dim_legacy.json
+++ b/workspace/notebook/casework_nsip_examination_timetable_dim_legacy.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_nsip_redactions_dim.json
+++ b/workspace/notebook/casework_nsip_redactions_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_nsip_relevant_representation_dim.json
+++ b/workspace/notebook/casework_nsip_relevant_representation_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_nsip_service_user_dim.json
+++ b/workspace/notebook/casework_nsip_service_user_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_picaso_dim.json
+++ b/workspace/notebook/casework_picaso_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_special_circumstance_dim.json
+++ b/workspace/notebook/casework_special_circumstance_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialism_dim.json
+++ b/workspace/notebook/casework_specialism_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_case_dates_dim.json
+++ b/workspace/notebook/casework_specialist_case_dates_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_case_string_dim.json
+++ b/workspace/notebook/casework_specialist_case_string_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_coastal_access_dim.json
+++ b/workspace/notebook/casework_specialist_coastal_access_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_environment_dim.json
+++ b/workspace/notebook/casework_specialist_environment_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_high_court_dim.json
+++ b/workspace/notebook/casework_specialist_high_court_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_modifications_dim.json
+++ b/workspace/notebook/casework_specialist_modifications_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_purchase_notice_dim.json
+++ b/workspace/notebook/casework_specialist_purchase_notice_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_specialist_recharge_dim.json
+++ b/workspace/notebook/casework_specialist_recharge_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/casework_tpo_dim.json
+++ b/workspace/notebook/casework_tpo_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_case_casemarking_bridge.json
+++ b/workspace/notebook/checkmark_case_casemarking_bridge.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_case_fact.json
+++ b/workspace/notebook/checkmark_case_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_case_reading_case_bridge.json
+++ b/workspace/notebook/checkmark_case_reading_case_bridge.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_casemarking_dim.json
+++ b/workspace/notebook/checkmark_casemarking_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_casemarking_fact.json
+++ b/workspace/notebook/checkmark_casemarking_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_comment_state_reference_dim.json
+++ b/workspace/notebook/checkmark_comment_state_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_comment_type_reference_dim.json
+++ b/workspace/notebook/checkmark_comment_type_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_comments_case_bridge.json
+++ b/workspace/notebook/checkmark_comments_case_bridge.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_comments_dim.json
+++ b/workspace/notebook/checkmark_comments_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_comments_fact.json
+++ b/workspace/notebook/checkmark_comments_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_complexity_reference_dim.json
+++ b/workspace/notebook/checkmark_complexity_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_conditions_reference_dim.json
+++ b/workspace/notebook/checkmark_conditions_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_coverage_reference_dim.json
+++ b/workspace/notebook/checkmark_coverage_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_documents_dim.json
+++ b/workspace/notebook/checkmark_documents_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_grounds_reference_dim.json
+++ b/workspace/notebook/checkmark_grounds_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_inspector_manager_dim.json
+++ b/workspace/notebook/checkmark_inspector_manager_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_inspector_manager_fact.json
+++ b/workspace/notebook/checkmark_inspector_manager_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_inspector_manager_reading_case_bridge.json
+++ b/workspace/notebook/checkmark_inspector_manager_reading_case_bridge.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_invalid_nullity_reference_dim.json
+++ b/workspace/notebook/checkmark_invalid_nullity_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_level_reference_dim.json
+++ b/workspace/notebook/checkmark_level_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_manager_type_reference_dim.json
+++ b/workspace/notebook/checkmark_manager_type_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_nsi_dim.json
+++ b/workspace/notebook/checkmark_nsi_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_outcome_reference_dim.json
+++ b/workspace/notebook/checkmark_outcome_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_presentation_accuracy_detail_reference_dim.json
+++ b/workspace/notebook/checkmark_presentation_accuracy_detail_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_procedure_reference_dim.json
+++ b/workspace/notebook/checkmark_procedure_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_reading_case.json
+++ b/workspace/notebook/checkmark_reading_case.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_reading_case_bridge.json
+++ b/workspace/notebook/checkmark_reading_case_bridge.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_reading_case_fact.json
+++ b/workspace/notebook/checkmark_reading_case_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_reading_status_reference_dim.json
+++ b/workspace/notebook/checkmark_reading_status_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_reading_type_reference_dim.json
+++ b/workspace/notebook/checkmark_reading_type_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_source_reference_dim.json
+++ b/workspace/notebook/checkmark_source_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/checkmark_structure_reasoning_detail_reference_dim.json
+++ b/workspace/notebook/checkmark_structure_reasoning_detail_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/create_table_from_schema.json
+++ b/workspace/notebook/create_table_from_schema.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/dart_api.json
+++ b/workspace/notebook/dart_api.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/data-checks.json
+++ b/workspace/notebook/data-checks.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/data_validation_testing.json
+++ b/workspace/notebook/data_validation_testing.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/data_validation_wip.json
+++ b/workspace/notebook/data_validation_wip.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/delete-hr-harmonised.json
+++ b/workspace/notebook/delete-hr-harmonised.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/document_case_reference_dim.json
+++ b/workspace/notebook/document_case_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/document_case_type_dim.json
+++ b/workspace/notebook/document_case_type_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/document_meta_data.json
+++ b/workspace/notebook/document_meta_data.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/document_tree_dim.json
+++ b/workspace/notebook/document_tree_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/employee-publish.json
+++ b/workspace/notebook/employee-publish.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/employee.json
+++ b/workspace/notebook/employee.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/entraid-post-deployment-notebook.json
+++ b/workspace/notebook/entraid-post-deployment-notebook.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/entraid.json
+++ b/workspace/notebook/entraid.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/entraid_cu.json
+++ b/workspace/notebook/entraid_cu.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/examination_timetable.json
+++ b/workspace/notebook/examination_timetable.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/gather_data_quality_reports.json
+++ b/workspace/notebook/gather_data_quality_reports.json
@@ -41,7 +41,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/high_court_dim.json
+++ b/workspace/notebook/high_court_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/horizon_folder.json
+++ b/workspace/notebook/horizon_folder.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_absence_dim.json
+++ b/workspace/notebook/hr_absence_dim.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_contract_dim.json
+++ b/workspace/notebook/hr_contract_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_costcenter_dim.json
+++ b/workspace/notebook/hr_costcenter_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_disability_dim.json
+++ b/workspace/notebook/hr_disability_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_diversity_dim.json
+++ b/workspace/notebook/hr_diversity_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_employee_dim.json
+++ b/workspace/notebook/hr_employee_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_employee_dim_for_leavers.json
+++ b/workspace/notebook/hr_employee_dim_for_leavers.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_employee_fact.json
+++ b/workspace/notebook/hr_employee_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/hr_employee_fact_for_leavers.json
+++ b/workspace/notebook/hr_employee_fact_for_leavers.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_employee_hr_hierarchy_dim.json
+++ b/workspace/notebook/hr_employee_hr_hierarchy_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_employee_leavers_dim.json
+++ b/workspace/notebook/hr_employee_leavers_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_employeegroup_dim.json
+++ b/workspace/notebook/hr_employeegroup_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_leave_entitlement_dim.json
+++ b/workspace/notebook/hr_leave_entitlement_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_organisation_unit_dim.json
+++ b/workspace/notebook/hr_organisation_unit_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_payband_dim.json
+++ b/workspace/notebook/hr_payband_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_payroll_area_dim.json
+++ b/workspace/notebook/hr_payroll_area_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_personnel_area_dim.json
+++ b/workspace/notebook/hr_personnel_area_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_personnel_sub_area_dim.json
+++ b/workspace/notebook/hr_personnel_sub_area_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_pins_location_dim.json
+++ b/workspace/notebook/hr_pins_location_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_position_dim.json
+++ b/workspace/notebook/hr_position_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_record_fact.json
+++ b/workspace/notebook/hr_record_fact.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/hr_record_fact_for_leavers.json
+++ b/workspace/notebook/hr_record_fact_for_leavers.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_religion_dim.json
+++ b/workspace/notebook/hr_religion_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_secure_info_fact.json
+++ b/workspace/notebook/hr_secure_info_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_specialism_dim.json
+++ b/workspace/notebook/hr_specialism_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_sxo_dim.json
+++ b/workspace/notebook/hr_sxo_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/hr_work_schedule_dim.json
+++ b/workspace/notebook/hr_work_schedule_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims-master.json
+++ b/workspace/notebook/ims-master.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims-master_historic.json
+++ b/workspace/notebook/ims-master_historic.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_attribute_dim.json
+++ b/workspace/notebook/ims_attribute_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_attribute_dim_historic.json
+++ b/workspace/notebook/ims_attribute_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_dataflow_dim.json
+++ b/workspace/notebook/ims_dataflow_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_dataflow_dim_historic.json
+++ b/workspace/notebook/ims_dataflow_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/ims_dpia_dim.json
+++ b/workspace/notebook/ims_dpia_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_dpia_dim_historic.json
+++ b/workspace/notebook/ims_dpia_dim_historic.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/ims_dsa_dim.json
+++ b/workspace/notebook/ims_dsa_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_dsa_dim_historic.json
+++ b/workspace/notebook/ims_dsa_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/ims_entity_dim.json
+++ b/workspace/notebook/ims_entity_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_entity_dim_historic.json
+++ b/workspace/notebook/ims_entity_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/ims_information_asset_dim.json
+++ b/workspace/notebook/ims_information_asset_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_information_asset_dim_historic.json
+++ b/workspace/notebook/ims_information_asset_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/ims_integration_dim.json
+++ b/workspace/notebook/ims_integration_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_integration_dim_historic.json
+++ b/workspace/notebook/ims_integration_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 16,
 				"memory": 112

--- a/workspace/notebook/ims_masterdata_map_dim.json
+++ b/workspace/notebook/ims_masterdata_map_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_masterdata_map_dim_historic.json
+++ b/workspace/notebook/ims_masterdata_map_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/ims_ropa_dim.json
+++ b/workspace/notebook/ims_ropa_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/ims_ropa_dim_historic.json
+++ b/workspace/notebook/ims_ropa_dim_historic.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/lake database query.json
+++ b/workspace/notebook/lake database query.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/leave.json
+++ b/workspace/notebook/leave.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/legacy_folder_data.json
+++ b/workspace/notebook/legacy_folder_data.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/legacy_mrw_tables.json
+++ b/workspace/notebook/legacy_mrw_tables.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/listed_building.json
+++ b/workspace/notebook/listed_building.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/listed_building_dim.json
+++ b/workspace/notebook/listed_building_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/listed_building_outline_dim.json
+++ b/workspace/notebook/listed_building_outline_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/main_sourcesystem_fact.json
+++ b/workspace/notebook/main_sourcesystem_fact.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/master.json
+++ b/workspace/notebook/master.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_high_court.json
+++ b/workspace/notebook/mipins_high_court.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/mipins_hr_contract.json
+++ b/workspace/notebook/mipins_hr_contract.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_hr_cost_centre.json
+++ b/workspace/notebook/mipins_hr_cost_centre.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/mipins_hr_employee_leavers.json
+++ b/workspace/notebook/mipins_hr_employee_leavers.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_hr_fact_sickness.json
+++ b/workspace/notebook/mipins_hr_fact_sickness.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_hr_measures.json
+++ b/workspace/notebook/mipins_hr_measures.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/mipins_hr_measures_NEW.json
+++ b/workspace/notebook/mipins_hr_measures_NEW.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_hr_measures_new_data_lookup.json
+++ b/workspace/notebook/mipins_hr_measures_new_data_lookup.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_hr_measures_old_data_ingestion.json
+++ b/workspace/notebook/mipins_hr_measures_old_data_ingestion.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_hr_organisation_unit.json
+++ b/workspace/notebook/mipins_hr_organisation_unit.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/mipins_hr_personnel_area.json
+++ b/workspace/notebook/mipins_hr_personnel_area.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/mipins_hr_personnel_sub_area.json
+++ b/workspace/notebook/mipins_hr_personnel_sub_area.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/mipins_hr_protected_data.json
+++ b/workspace/notebook/mipins_hr_protected_data.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_ims_masterdatamap.json
+++ b/workspace/notebook/mipins_ims_masterdatamap.json
@@ -40,7 +40,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/mipins_views.json
+++ b/workspace/notebook/mipins_views.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/mipins_vw_fact_absence_all.json
+++ b/workspace/notebook/mipins_vw_fact_absence_all.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip-project-subscribe.json
+++ b/workspace/notebook/nsip-project-subscribe.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_applicant_service_user.json
+++ b/workspace/notebook/nsip_applicant_service_user.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_data.json
+++ b/workspace/notebook/nsip_data.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_document.json
+++ b/workspace/notebook/nsip_document.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_document_migration.json
+++ b/workspace/notebook/nsip_document_migration.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_exam_timetable_migration.json
+++ b/workspace/notebook/nsip_exam_timetable_migration.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_project_migration.json
+++ b/workspace/notebook/nsip_project_migration.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_representation.json
+++ b/workspace/notebook/nsip_representation.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_representation_migration.json
+++ b/workspace/notebook/nsip_representation_migration.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_s51_advice.json
+++ b/workspace/notebook/nsip_s51_advice.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_s51_advice_migration.json
+++ b/workspace/notebook/nsip_s51_advice_migration.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/nsip_subscription.json
+++ b/workspace/notebook/nsip_subscription.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/outstanding_files_add_entry.json
+++ b/workspace/notebook/outstanding_files_add_entry.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/pins_inspectors.json
+++ b/workspace/notebook/pins_inspectors.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/pins_inspectors_create_data_structures.json
+++ b/workspace/notebook/pins_inspectors_create_data_structures.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/pins_inspectors_curated.json
+++ b/workspace/notebook/pins_inspectors_curated.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/pins_lpa.json
+++ b/workspace/notebook/pins_lpa.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/pins_lpa_create_data_structures.json
+++ b/workspace/notebook/pins_lpa_create_data_structures.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/pins_lpa_curated.json
+++ b/workspace/notebook/pins_lpa_curated.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/pln_1335_alter_table_scripts.json
+++ b/workspace/notebook/pln_1335_alter_table_scripts.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_0_create_config_tables.json
+++ b/workspace/notebook/py_0_create_config_tables.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_0_log_copy_activity_output.json
+++ b/workspace/notebook/py_0_log_copy_activity_output.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_0_log_notebook_output.json
+++ b/workspace/notebook/py_0_log_notebook_output.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_0_source_to_raw_hr_functions.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_functions.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_0_source_to_raw_hr_main.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_main.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_0_source_to_raw_hr_tests.json
+++ b/workspace/notebook/py_0_source_to_raw_hr_tests.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_1_initial_run_raw_to_standardised_scheduling.json
+++ b/workspace/notebook/py_1_initial_run_raw_to_standardised_scheduling.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_1_raw_to_standardised_hr_main.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_main.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_1_raw_to_standardised_hr_tests.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_tests.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_1_raw_to_standardised_scheduling.json
+++ b/workspace/notebook/py_1_raw_to_standardised_scheduling.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_4_curated_tables.json
+++ b/workspace/notebook/py_4_curated_tables.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/py_HIST_all_hist_dates.json
+++ b/workspace/notebook/py_HIST_all_hist_dates.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_amend_tables.json
+++ b/workspace/notebook/py_amend_tables.json
@@ -45,7 +45,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_backfill_input_files.json
+++ b/workspace/notebook/py_backfill_input_files.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_casework_raw_to_std.json
+++ b/workspace/notebook/py_casework_raw_to_std.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/py_change_table.json
+++ b/workspace/notebook/py_change_table.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_convert_json_to_csv_ims.json
+++ b/workspace/notebook/py_convert_json_to_csv_ims.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_convert_json_to_csv_listed_buildings.json
+++ b/workspace/notebook/py_convert_json_to_csv_listed_buildings.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_create_curated_table.json
+++ b/workspace/notebook/py_create_curated_table.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_create_lake_databases.json
+++ b/workspace/notebook/py_create_lake_databases.json
@@ -44,7 +44,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_create_random_test_data.json
+++ b/workspace/notebook/py_create_random_test_data.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_create_schema_from_raw.json
+++ b/workspace/notebook/py_create_schema_from_raw.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_create_tables_new.json
+++ b/workspace/notebook/py_create_tables_new.json
@@ -44,7 +44,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_create_views_SAP_HR.json
+++ b/workspace/notebook/py_create_views_SAP_HR.json
@@ -41,7 +41,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_daily_files_into_date_folders.json
+++ b/workspace/notebook/py_daily_files_into_date_folders.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_delete_outstanding_files_entry.json
+++ b/workspace/notebook/py_delete_outstanding_files_entry.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_delete_rows_raw_to_std_outstanding_files.json
+++ b/workspace/notebook/py_delete_rows_raw_to_std_outstanding_files.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_delete_table.json
+++ b/workspace/notebook/py_delete_table.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_delete_table_contents.json
+++ b/workspace/notebook/py_delete_table_contents.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_delete_view.json
+++ b/workspace/notebook/py_delete_view.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_delta_table_cleanup.json
+++ b/workspace/notebook/py_delta_table_cleanup.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_deployment_create_logging_db.json
+++ b/workspace/notebook/py_deployment_create_logging_db.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_deployment_manage_main_config.json
+++ b/workspace/notebook/py_deployment_manage_main_config.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_deployment_manage_main_config.json
+++ b/workspace/notebook/py_deployment_manage_main_config.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2f23f3ba-91e1-435e-94c1-6f85f5f60033"
+				"spark.autotune.trackingId": "23dd9a98-b7ee-4a28-a904-15eef2cb1b39"
 			}
 		},
 		"metadata": {
@@ -268,6 +268,13 @@
 					"    ,'Listed Buildings' AS System_name\n",
 					"    ,'Listed Buildings' AS Object\n",
 					"    ,'listed-buildings' AS entity_name\n",
+					"    ,TRUE AS is_enabled\n",
+					"UNION ALL\n",
+					"SELECT\n",
+					"    27 AS System_key\n",
+					"    ,'Service bus' AS System_name\n",
+					"    ,'Appeal Representation' AS Object\n",
+					"    ,'appeal-representation' AS entity_name\n",
 					"    ,TRUE AS is_enabled"
 				],
 				"execution_count": 1

--- a/workspace/notebook/py_employee_harmonised_layer2_transform.json
+++ b/workspace/notebook/py_employee_harmonised_layer2_transform.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_fail_activity_logging.json
+++ b/workspace/notebook/py_fail_activity_logging.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_generate_schema_script.json
+++ b/workspace/notebook/py_generate_schema_script.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_get_delta_table_changes.json
+++ b/workspace/notebook/py_get_delta_table_changes.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_get_orchestration_entry.json
+++ b/workspace/notebook/py_get_orchestration_entry.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_get_schema_from_url.json
+++ b/workspace/notebook/py_get_schema_from_url.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_harmonised_and_hr_measures_monthly.json
+++ b/workspace/notebook/py_harmonised_and_hr_measures_monthly.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_horizon_harmonised_aie_document.json
+++ b/workspace/notebook/py_horizon_harmonised_aie_document.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_hr_monthly_raw_to_std.json
+++ b/workspace/notebook/py_hr_monthly_raw_to_std.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_inspector_address_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_inspector_address_harmonised_layer1_transform.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_inspector_harmonised_to_curated_load.json
+++ b/workspace/notebook/py_inspector_harmonised_to_curated_load.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_inspector_raw_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_inspector_raw_harmonised_layer1_transform.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_list_notebooks.json
+++ b/workspace/notebook/py_list_notebooks.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_load_listed_buildings_to_harmonised.json
+++ b/workspace/notebook/py_load_listed_buildings_to_harmonised.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_load_listed_buildings_to_standardised.json
+++ b/workspace/notebook/py_load_listed_buildings_to_standardised.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_load_standardised_to_harmonised.json
+++ b/workspace/notebook/py_load_standardised_to_harmonised.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_logging_decorator.json
+++ b/workspace/notebook/py_logging_decorator.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_mount_storage.json
+++ b/workspace/notebook/py_mount_storage.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_odw_curated_table_creation.json
+++ b/workspace/notebook/py_odw_curated_table_creation.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_odw_harmonised_table_creation.json
+++ b/workspace/notebook/py_odw_harmonised_table_creation.json
@@ -44,7 +44,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_populate_HR_dimension_tables.json
+++ b/workspace/notebook/py_populate_HR_dimension_tables.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_populate_HR_dimension_tables_protected_data.json
+++ b/workspace/notebook/py_populate_HR_dimension_tables_protected_data.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_process_raw_to_curated_table_for_reports.json
+++ b/workspace/notebook/py_process_raw_to_curated_table_for_reports.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_process_raw_to_standardised_delta_table.json
+++ b/workspace/notebook/py_process_raw_to_standardised_delta_table.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_process_raw_to_standardised_validate.json
+++ b/workspace/notebook/py_process_raw_to_standardised_validate.json
@@ -44,7 +44,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_raw_to_std.json
+++ b/workspace/notebook/py_raw_to_std.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_reload_from_raw_nsip_project.json
+++ b/workspace/notebook/py_reload_from_raw_nsip_project.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_reload_from_raw_nsip_representation.json
+++ b/workspace/notebook/py_reload_from_raw_nsip_representation.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_reload_hr_leavers.json
+++ b/workspace/notebook/py_reload_hr_leavers.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_reload_hr_record_fact.json
+++ b/workspace/notebook/py_reload_hr_record_fact.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -4,7 +4,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {
@@ -31,10 +31,10 @@
 				"name": "python"
 			},
 			"a365ComputeOptions": {
-				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
-				"name": "pinssynspodw",
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
+				"name": "pinssynspodwpr",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodwpr",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.4",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -4,7 +4,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodwpr",
+			"referenceName": "pinssynspodw",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {
@@ -31,15 +31,15 @@
 				"name": "python"
 			},
 			"a365ComputeOptions": {
-				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
-				"name": "pinssynspodwpr",
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodwpr",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -17,7 +17,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1086d633-d0c9-4e2a-a04f-8983169d7fb3"
+				"spark.autotune.trackingId": "29006e2a-d12a-4502-a978-07b58ce68e42"
 			}
 		},
 		"metadata": {
@@ -61,6 +61,24 @@
 					"##### Example of using the tenacity library for retry logic\r\n",
 					"url: https://tenacity.readthedocs.io/en/latest/"
 				]
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(\"Hello\")"
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -4,7 +4,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodwpr",
+			"referenceName": "pinssynspodw",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {
@@ -31,15 +31,15 @@
 				"name": "python"
 			},
 			"a365ComputeOptions": {
-				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
-				"name": "pinssynspodwpr",
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodwpr",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.4",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -32,14 +32,14 @@
 			},
 			"a365ComputeOptions": {
 				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
-				"name": "pinssynspodw",
+				"name": "pinssynspodwpr",
 				"type": "Spark",
 				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.4",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -4,7 +4,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {
@@ -31,10 +31,10 @@
 				"name": "python"
 			},
 			"a365ComputeOptions": {
-				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
-				"name": "pinssynspodw",
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
+				"name": "pinssynspodwpr",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2020-12-01/sparkPools/pinssynspodw",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2020-12-01/sparkPools/pinssynspodwpr",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -34,7 +34,7 @@
 				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
 				"name": "pinssynspodw",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2020-12-01/sparkPools/pinssynspodw",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -17,7 +17,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "29006e2a-d12a-4502-a978-07b58ce68e42"
+				"spark.autotune.trackingId": "99e34ad3-1dc4-4cf9-9efc-91566a843c7a"
 			}
 		},
 		"metadata": {
@@ -61,24 +61,6 @@
 					"##### Example of using the tenacity library for retry logic\r\n",
 					"url: https://tenacity.readthedocs.io/en/latest/"
 				]
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(\"Hello\")"
-				],
-				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -4,7 +4,7 @@
 		"nbformat": 4,
 		"nbformat_minor": 2,
 		"bigDataPool": {
-			"referenceName": "pinssynspodw",
+			"referenceName": "pinssynspodwpr",
 			"type": "BigDataPoolReference"
 		},
 		"sessionProperties": {
@@ -31,10 +31,10 @@
 				"name": "python"
 			},
 			"a365ComputeOptions": {
-				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
 				"name": "pinssynspodwpr",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodwpr",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"

--- a/workspace/notebook/py_retry_logic.json
+++ b/workspace/notebook/py_retry_logic.json
@@ -34,12 +34,12 @@
 				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodwpr",
 				"name": "pinssynspodwpr",
 				"type": "Spark",
-				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2020-12-01/sparkPools/pinssynspodwpr",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodwpr",
 				"auth": {
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.4",
+				"sparkVersion": "3.3",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sap_hr_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_sap_hr_harmonised_layer1_transform.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_appeal_document.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_appeal_document.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_appeal_event.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_appeal_event.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_appeal_s78.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_appeal_s78.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_exam_timetable.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_exam_timetable.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_project.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_project.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_representation.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_representation.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_s51_advice.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_s51_advice.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_horizon_harmonised_service_user.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_service_user.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_raw_to_std.json
+++ b/workspace/notebook/py_sb_raw_to_std.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_reload_from_raw_storage.json
+++ b/workspace/notebook/py_sb_reload_from_raw_storage.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_std_to_hrm.json
+++ b/workspace/notebook/py_sb_std_to_hrm.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_sb_to_raw.json
+++ b/workspace/notebook/py_sb_to_raw.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_service_bus_json_to_csv.json
+++ b/workspace/notebook/py_service_bus_json_to_csv.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_standardised_to_harmonised_data_conversions.json
+++ b/workspace/notebook/py_standardised_to_harmonised_data_conversions.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_std_to_hrm.json
+++ b/workspace/notebook/py_std_to_hrm.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_temp_syn_employee_to_curated.json
+++ b/workspace/notebook/py_temp_syn_employee_to_curated.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_testing_change_table_schema.json
+++ b/workspace/notebook/py_testing_change_table_schema.json
@@ -39,7 +39,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_appeal_s78.json
+++ b/workspace/notebook/py_unit_tests_appeal_s78.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_appeals_events.json
+++ b/workspace/notebook/py_unit_tests_appeals_events.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_appeals_representation.json
+++ b/workspace/notebook/py_unit_tests_appeals_representation.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_entraid.json
+++ b/workspace/notebook/py_unit_tests_entraid.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_functions.json
+++ b/workspace/notebook/py_unit_tests_functions.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_getDaRTfunction.json
+++ b/workspace/notebook/py_unit_tests_getDaRTfunction.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_gettimesheetsfunction.json
+++ b/workspace/notebook/py_unit_tests_gettimesheetsfunction.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_has_appeals.json
+++ b/workspace/notebook/py_unit_tests_has_appeals.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_listed_buildings.json
+++ b/workspace/notebook/py_unit_tests_listed_buildings.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_nsip_document.json
+++ b/workspace/notebook/py_unit_tests_nsip_document.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_nsip_exam_timetable.json
+++ b/workspace/notebook/py_unit_tests_nsip_exam_timetable.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_nsip_project.json
+++ b/workspace/notebook/py_unit_tests_nsip_project.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_nsip_s51_advice.json
+++ b/workspace/notebook/py_unit_tests_nsip_s51_advice.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_relevant_representation.json
+++ b/workspace/notebook/py_unit_tests_relevant_representation.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_s62a_view_cases.json
+++ b/workspace/notebook/py_unit_tests_s62a_view_cases.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_util_partition__document_metadata_rollback.json
+++ b/workspace/notebook/py_util_partition__document_metadata_rollback.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_util_partition_document_metadata.json
+++ b/workspace/notebook/py_util_partition_document_metadata.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_appeal_event.json
+++ b/workspace/notebook/py_utils_curated_validate_appeal_event.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_examination_timetable.json
+++ b/workspace/notebook/py_utils_curated_validate_examination_timetable.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_functions.json
+++ b/workspace/notebook/py_utils_curated_validate_functions.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_general.json
+++ b/workspace/notebook/py_utils_curated_validate_general.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_legacy_folder_data.json
+++ b/workspace/notebook/py_utils_curated_validate_legacy_folder_data.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_master.json
+++ b/workspace/notebook/py_utils_curated_validate_master.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_nsip_document.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_document.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_nsip_project.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_project.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_nsip_project_update.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_project_update.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_nsip_representation.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_representation.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_nsip_s51_advice.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_s51_advice.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_nsip_subscription.json
+++ b/workspace/notebook/py_utils_curated_validate_nsip_subscription.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_service_user.json
+++ b/workspace/notebook/py_utils_curated_validate_service_user.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_curated_validate_table.json
+++ b/workspace/notebook/py_utils_curated_validate_table.json
@@ -47,7 +47,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_data_validation_final.json
+++ b/workspace/notebook/py_utils_data_validation_final.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_data_validation_functions.json
+++ b/workspace/notebook/py_utils_data_validation_functions.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_function_metadata.json
+++ b/workspace/notebook/py_utils_get_function_metadata.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_key_vault_secret.json
+++ b/workspace/notebook/py_utils_get_key_vault_secret.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_keyvault.json
+++ b/workspace/notebook/py_utils_get_keyvault.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_pipeline_config.json
+++ b/workspace/notebook/py_utils_get_pipeline_config.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_service_bus_config.json
+++ b/workspace/notebook/py_utils_get_service_bus_config.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_service_bus_feeds.json
+++ b/workspace/notebook/py_utils_get_service_bus_feeds.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_standardised_column_names.json
+++ b/workspace/notebook/py_utils_get_standardised_column_names.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_get_storage_account.json
+++ b/workspace/notebook/py_utils_get_storage_account.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_log_stage.json
+++ b/workspace/notebook/py_utils_log_stage.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_random_sleep.json
+++ b/workspace/notebook/py_utils_random_sleep.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_utils_read_log.json
+++ b/workspace/notebook/py_utils_read_log.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_versions.json
+++ b/workspace/notebook/py_versions.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_vw_SAP_HR_email_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_vw_SAP_HR_email_harmonised_layer1_transform.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_vw_SAP_HR_email_weekly_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_vw_SAP_HR_email_weekly_harmonised_layer1_transform.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/py_vw_SAP_PINS_email_harmonised_layer1_transform.json
+++ b/workspace/notebook/py_vw_SAP_PINS_email_harmonised_layer1_transform.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/rebuild_tables.json
+++ b/workspace/notebook/rebuild_tables.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/remove_input_file_column_from_hrm.json
+++ b/workspace/notebook/remove_input_file_column_from_hrm.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/s62a.json
+++ b/workspace/notebook/s62a.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/s62a_view_case_basic_data_dim.json
+++ b/workspace/notebook/s62a_view_case_basic_data_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/s62a_view_case_dates_dim.json
+++ b/workspace/notebook/s62a_view_case_dates_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/s62a_view_case_extended_data_dim.json
+++ b/workspace/notebook/s62a_view_case_extended_data_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/s62a_view_case_officers_dim.json
+++ b/workspace/notebook/s62a_view_case_officers_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/s62a_view_cases_dim.json
+++ b/workspace/notebook/s62a_view_cases_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/sample_to_call_listed_buiding_API.json
+++ b/workspace/notebook/sample_to_call_listed_buiding_API.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/sap-hr-master.json
+++ b/workspace/notebook/sap-hr-master.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/sap-hr-master_full_reload.json
+++ b/workspace/notebook/sap-hr-master_full_reload.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/sap-hr-views-historic.json
+++ b/workspace/notebook/sap-hr-views-historic.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/sap-hr-views-leavers.json
+++ b/workspace/notebook/sap-hr-views-leavers.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/sap-hr-views-saphr.json
+++ b/workspace/notebook/sap-hr-views-saphr.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/sap-hr-views.json
+++ b/workspace/notebook/sap-hr-views.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/service-user-publish-legacy-code.json
+++ b/workspace/notebook/service-user-publish-legacy-code.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/service-user-publish.json
+++ b/workspace/notebook/service-user-publish.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28

--- a/workspace/notebook/service_user.json
+++ b/workspace/notebook/service_user.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/service_user_migration.json
+++ b/workspace/notebook/service_user_migration.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/service_user_zendesk_dim.json
+++ b/workspace/notebook/service_user_zendesk_dim.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 8,
 				"memory": 56,

--- a/workspace/notebook/servicebus_horizon_merge_arrays_example.json
+++ b/workspace/notebook/servicebus_horizon_merge_arrays_example.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/template_notebook.json
+++ b/workspace/notebook/template_notebook.json
@@ -44,7 +44,7 @@
 					"authResource": "https://dev.azuresynapse.net",
 					"authHeader": null
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/timesheets_master.json
+++ b/workspace/notebook/timesheets_master.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/timesheets_minutes_dim.json
+++ b/workspace/notebook/timesheets_minutes_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/timesheets_record_fact.json
+++ b/workspace/notebook/timesheets_record_fact.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/timesheets_segment_type_reference_dim.json
+++ b/workspace/notebook/timesheets_segment_type_reference_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/timesheets_work_segment_dim.json
+++ b/workspace/notebook/timesheets_work_segment_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/timesheets_work_segment_lock_dim.json
+++ b/workspace/notebook/timesheets_work_segment_lock_dim.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk-subscribe.json
+++ b/workspace/notebook/zendesk-subscribe.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_get_created_tickets.json
+++ b/workspace/notebook/zendesk_get_created_tickets.json
@@ -44,7 +44,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_harmonised_export.json
+++ b/workspace/notebook/zendesk_harmonised_export.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_historical.json
+++ b/workspace/notebook/zendesk_historical.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_raw_inspect.json
+++ b/workspace/notebook/zendesk_raw_inspect.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_raw_to_standerdised.json
+++ b/workspace/notebook/zendesk_raw_to_standerdised.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_read_me.json
+++ b/workspace/notebook/zendesk_read_me.json
@@ -40,7 +40,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_schema_validation.json
+++ b/workspace/notebook/zendesk_schema_validation.json
@@ -43,7 +43,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/notebook/zendesk_standardised_and_harmonised.json
+++ b/workspace/notebook/zendesk_standardised_and_harmonised.json
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,

--- a/workspace/pipeline/0_pln_source_to_raw_fileshare_copy_activity.json
+++ b/workspace/pipeline/0_pln_source_to_raw_fileshare_copy_activity.json
@@ -29,23 +29,39 @@
 							"userProperties": [],
 							"typeProperties": {
 								"source": {
-									"type": "BinarySource",
-									"storeSettings": {
-										"type": "AzureFileStorageReadSettings",
-										"recursive": true
-									},
-									"formatSettings": {
-										"type": "BinaryReadSettings"
-									}
+									"type": "AzureSqlSource",
+									"queryTimeout": "02:00:00",
+									"partitionOption": "None"
 								},
 								"sink": {
-									"type": "BinarySink",
-									"storeSettings": {
-										"type": "AzureBlobFSWriteSettings"
-									}
+									"type": "AzureSqlSink",
+									"preCopyScript": "p table if exists [odw].[nsip_project_curated_mipins]",
+									"writeBehavior": "insert",
+									"sqlWriterUseTableLock": false,
+									"disableMetricsCollection": false
 								},
-								"enableStaging": false
-							}
+								"enableStaging": false,
+								"translator": {
+									"type": "TabularTranslator",
+									"typeConversion": true,
+									"typeConversionSettings": {
+										"allowDataTruncation": true,
+										"treatBooleanAsNumber": false
+									}
+								}
+							},
+							"inputs": [
+								{
+									"referenceName": "NSIPProject",
+									"type": "DatasetReference"
+								}
+							],
+							"outputs": [
+								{
+									"referenceName": "nsip_project_curated_mipins",
+									"type": "DatasetReference"
+								}
+							]
 						},
 						{
 							"name": "Copy_Outcome_Logging_and_Log_Table_Update",

--- a/workspace/pipeline/Rel_7_0_2.json
+++ b/workspace/pipeline/Rel_7_0_2.json
@@ -1,0 +1,104 @@
+{
+	"name": "Rel_7_0_2",
+	"properties": {
+		"activities": [
+			{
+				"name": "create_standardise_table_schema",
+				"description": "",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_standardised_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "appeal-representation",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "create_curated_table_schema",
+				"description": "",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_curated_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "appeal-representation",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "create_hormonised_table_schema_copy2",
+				"description": "",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_harmonised_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "appeal-representation",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			}
+		],
+		"folder": {
+			"name": "Releases/7.0.2"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_SAPHR_SharepointData.json
+++ b/workspace/pipeline/pln_SAPHR_SharepointData.json
@@ -31,14 +31,9 @@
 			{
 				"name": "Copy data1",
 				"type": "Copy",
-				"dependsOn": [
-					{
-						"activity": "Get Token SAPHR Sharepoint",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
+				"state": "Inactive",
+				"onInactiveMarkAs": "Succeeded",
+				"dependsOn": [],
 				"policy": {
 					"timeout": "0.12:00:00",
 					"retry": 0,
@@ -70,12 +65,6 @@
 					},
 					"enableStaging": false
 				},
-				"inputs": [
-					{
-						"referenceName": "SAPHRSharepoinrdata",
-						"type": "DatasetReference"
-					}
-				],
 				"outputs": [
 					{
 						"referenceName": "a_saphr_DS_data_binary_sink",
@@ -98,10 +87,6 @@
 				},
 				"userProperties": [],
 				"typeProperties": {
-					"dataset": {
-						"referenceName": "Binary1",
-						"type": "DatasetReference"
-					},
 					"fieldList": [],
 					"storeSettings": {
 						"type": "HttpReadSettings",
@@ -116,6 +101,8 @@
 			{
 				"name": "Get Token SAPHR Sharepoint",
 				"type": "WebActivity",
+				"state": "Inactive",
+				"onInactiveMarkAs": "Succeeded",
 				"dependsOn": [],
 				"policy": {
 					"timeout": "0.12:00:00",

--- a/workspace/pipeline/pln_application_run_stage_service_bus.json
+++ b/workspace/pipeline/pln_application_run_stage_service_bus.json
@@ -25,6 +25,9 @@
 							"name": "Src to raw",
 							"type": "ExecutePipeline",
 							"dependsOn": [],
+							"policy": {
+								"secureInput": false
+							},
 							"userProperties": [],
 							"typeProperties": {
 								"pipeline": {
@@ -602,53 +605,6 @@
 				}
 			},
 			{
-				"name": "Project update - hrm to cur",
-				"type": "IfCondition",
-				"dependsOn": [
-					{
-						"activity": "Run standard to Harmonised",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"expression": {
-						"value": "@and(equals(variables('Stage'), 'Hrm to Cur'), equals(variables('Pipeline'), 'pln_service_bus_nsip_project_update'))",
-						"type": "Expression"
-					},
-					"ifTrueActivities": [
-						{
-							"name": "nisp_project_update",
-							"type": "SynapseNotebook",
-							"dependsOn": [],
-							"policy": {
-								"timeout": "0.12:00:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"notebook": {
-									"referenceName": "nsip_project_update",
-									"type": "NotebookReference"
-								},
-								"snapshot": true,
-								"conf": {
-									"spark.dynamicAllocation.enabled": null,
-									"spark.dynamicAllocation.minExecutors": null,
-									"spark.dynamicAllocation.maxExecutors": null
-								},
-								"numExecutors": null
-							}
-						}
-					]
-				}
-			},
-			{
 				"name": "project - hrm to cur",
 				"type": "IfCondition",
 				"dependsOn": [
@@ -730,7 +686,13 @@
 									"referenceName": "nsip_applicant_service_user",
 									"type": "NotebookReference"
 								},
-								"snapshot": true
+								"snapshot": true,
+								"conf": {
+									"spark.dynamicAllocation.enabled": null,
+									"spark.dynamicAllocation.minExecutors": null,
+									"spark.dynamicAllocation.maxExecutors": null
+								},
+								"numExecutors": null
 							}
 						}
 					]

--- a/workspace/pipeline/pln_service_bus_nsip_project_update.json
+++ b/workspace/pipeline/pln_service_bus_nsip_project_update.json
@@ -7,6 +7,9 @@
 				"description": "Triggers Function App to read messages from Service Bus and write to odw-raw",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
+				"policy": {
+					"secureInput": false
+				},
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
@@ -167,39 +170,6 @@
 										},
 										"type": "string"
 									}
-								},
-								"snapshot": true,
-								"conf": {
-									"spark.dynamicAllocation.enabled": null,
-									"spark.dynamicAllocation.minExecutors": null,
-									"spark.dynamicAllocation.maxExecutors": null
-								},
-								"numExecutors": null
-							}
-						},
-						{
-							"name": "Hrm to Cur",
-							"type": "SynapseNotebook",
-							"dependsOn": [
-								{
-									"activity": "Std to Hrm",
-									"dependencyConditions": [
-										"Succeeded"
-									]
-								}
-							],
-							"policy": {
-								"timeout": "0.12:00:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"notebook": {
-									"referenceName": "nsip_project_update",
-									"type": "NotebookReference"
 								},
 								"snapshot": true,
 								"conf": {

--- a/workspace/template-parameters-definition.json
+++ b/workspace/template-parameters-definition.json
@@ -30,6 +30,15 @@
         "properties": {
             "bigDataPool": {
                 "referenceName": "="
+            },
+
+            "metadata": {
+                "a365ComputeOptions": {
+                    "id": "=",
+                    "name": "=",
+                    "endpoint": "=",
+                    "sparkVersion": "="
+                }
             }
         }
     },


### PR DESCRIPTION
Added metadata block to notebook parameters in config file.
Upgraded all notebooks to spark pool version 3.4. Weirdly this isn't actually needed it seems. With the json still at 3.3 the notebooks still run OK on a 3.4 spark pool. However, for consistency and to avoid confusion I think updating the spark pool in the notebook json files is the sensible option. Tested 3 notebooks and all run OK on 3.4.
Any issues, forward fix by reverting as it's a simple change.
