### PR TITLE
Updating notebook: py_unit_tests_service_user

### DIFF
--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fb5c43bd-8797-43ce-8da0-81a596cf4538"
+				"spark.autotune.trackingId": "1688f2f5-9026-4b33-a931-891061d9ee4f"
 			}
 		},
 		"metadata": {
@@ -252,6 +252,7 @@
 					"exitCode += int(not cur_schema_correct)\n",
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{service_user_appeal_table}\\nDifferences shown above (if any)\")\n",
 					"\n",
+					"# --COMMENTED OUT TO PREVENT FAILURE, AS ITS DEFINITIONS HAVE BEEN COMMENTED IN THE PREVIOUS CELL.\n",
 					"# cur_migration_schema_correct: bool = test_compare_schemas(curated_migration_schema, curated_migration_table_schema)\n",
 					"# print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
 					"# exitCode += int(not cur_migration_schema_correct)"

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "dc5c4e9b-b1ae-4008-a30c-448c1c480a24"
+				"spark.autotune.trackingId": "9cd21132-8680-4979-a379-ba4c9ab0dd03"
 			}
 		},
 		"metadata": {
@@ -204,11 +204,7 @@
 					"sb_hrm_table_schema = spark.table(f\"{hrm_db_name}.{hrm_table_name}\").schema\n",
 					"\n",
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
-					"curated_table_schema = spark.table(f\"{curated_db_name}.{service_user_appeal_table}\").schema\n",
-					"\n",
-					"# this will fail because of an extra column (contactMethod) required by ODT https://pins-ds.atlassian.net/browse/THEODW-1494\n",
-					"# curated_migration_schema = create_spark_schema(curated_migration_db_name, entity_name)\n",
-					"# curated_migration_table_schema = spark.table(f\"{curated_migration_db_name}.{service_user_migration_table}\").schema"
+					"curated_table_schema = spark.table(f\"{curated_db_name}.{service_user_appeal_table}\").schema"
 				],
 				"execution_count": 35
 			},
@@ -222,7 +218,9 @@
 					}
 				},
 				"source": [
-					"##### Compare schemas"
+					"##### Compare schemas\n",
+					"\n",
+					"NOTE: Schema comparison unit test for the odw_curated_migration_db.service_user is not included because of an extra column  (contactMethod) required by ODT https://pins-ds.atlassian.net/browse/THEODW-1494"
 				]
 			},
 			{
@@ -250,12 +248,7 @@
 					"\n",
 					"cur_schema_correct: bool = test_compare_schemas(curated_schema, curated_table_schema)\n",
 					"exitCode += int(not cur_schema_correct)\n",
-					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{service_user_appeal_table}\\nDifferences shown above (if any)\")\n",
-					"\n",
-					"# -- COMMENTED OUT TO PREVENT TEST FAILURE, AS ITS DEFINITIONS HAVE BEEN COMMENTED IN THE PREVIOUS CELL.\n",
-					"# cur_migration_schema_correct: bool = test_compare_schemas(curated_migration_schema, curated_migration_table_schema)\n",
-					"# print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
-					"# exitCode += int(not cur_migration_schema_correct)"
+					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{service_user_appeal_table}\\nDifferences shown above (if any)\")"
 				],
 				"execution_count": 36
 			},

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "19cb282c-a1b9-4bea-9ca7-924713b06f6c"
+				"spark.autotune.trackingId": "fb5c43bd-8797-43ce-8da0-81a596cf4538"
 			}
 		},
 		"metadata": {
@@ -73,7 +73,7 @@
 					"from pyspark.sql import functions as F\n",
 					""
 				],
-				"execution_count": 49
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -92,7 +92,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 50
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"service_user_appeal_table: str = 'appeal_service_user'\n",
 					"service_user_migration_table: str = 'service_user'"
 				],
-				"execution_count": 51
+				"execution_count": 32
 			},
 			{
 				"cell_type": "code",
@@ -163,7 +163,7 @@
 					"\t\"sourceSystem\",\n",
 					"\t\"sourceSuid\"]"
 				],
-				"execution_count": 52
+				"execution_count": 33
 			},
 			{
 				"cell_type": "code",
@@ -181,7 +181,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 53
+				"execution_count": 34
 			},
 			{
 				"cell_type": "code",
@@ -210,7 +210,7 @@
 					"# curated_migration_schema = create_spark_schema(curated_migration_db_name, entity_name)\n",
 					"# curated_migration_table_schema = spark.table(f\"{curated_migration_db_name}.{service_user_migration_table}\").schema"
 				],
-				"execution_count": 54
+				"execution_count": 35
 			},
 			{
 				"cell_type": "markdown",
@@ -252,11 +252,11 @@
 					"exitCode += int(not cur_schema_correct)\n",
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{service_user_appeal_table}\\nDifferences shown above (if any)\")\n",
 					"\n",
-					"cur_migration_schema_correct: bool = test_compare_schemas(curated_migration_schema, curated_migration_table_schema)\n",
-					"print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
-					"exitCode += int(not cur_migration_schema_correct)"
+					"# cur_migration_schema_correct: bool = test_compare_schemas(curated_migration_schema, curated_migration_table_schema)\n",
+					"# print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
+					"# exitCode += int(not cur_migration_schema_correct)"
 				],
-				"execution_count": 55
+				"execution_count": 36
 			},
 			{
 				"cell_type": "markdown",
@@ -296,7 +296,7 @@
 					"    #this is classed as an error\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 56
+				"execution_count": 37
 			},
 			{
 				"cell_type": "code",
@@ -318,7 +318,7 @@
 					"   print('Failed: test_sb_std_to_sb_hrm_no_dropping_records')\n",
 					"   exitCode += 1"
 				],
-				"execution_count": 57
+				"execution_count": 38
 			},
 			{
 				"cell_type": "code",
@@ -340,7 +340,7 @@
 					"    print('Failed: test_sb_hrm_to_hrm_final_no_dropping_records')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 58
+				"execution_count": 39
 			},
 			{
 				"cell_type": "markdown",
@@ -375,7 +375,7 @@
 					"#     print('Failed: test_hrm_to_curated_no_dropping_records')\n",
 					"#     exitCode += 1"
 				],
-				"execution_count": 59
+				"execution_count": 40
 			},
 			{
 				"cell_type": "code",
@@ -397,7 +397,7 @@
 					"    print('Failed: test_curated_unique_hzn_only')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 60
+				"execution_count": 41
 			},
 			{
 				"cell_type": "markdown",
@@ -458,7 +458,7 @@
 					"else:\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 61
+				"execution_count": 42
 			},
 			{
 				"cell_type": "code",
@@ -493,7 +493,7 @@
 					"    print('FAIL: Each project has an applicant')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 62
+				"execution_count": 43
 			},
 			{
 				"cell_type": "markdown",
@@ -541,7 +541,7 @@
 					"    print('FAIL: Expected count of representations match')\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 63
+				"execution_count": 44
 			},
 			{
 				"cell_type": "code",
@@ -559,7 +559,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 64
+				"execution_count": 45
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_service_user.json
+++ b/workspace/notebook/py_unit_tests_service_user.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1688f2f5-9026-4b33-a931-891061d9ee4f"
+				"spark.autotune.trackingId": "dc5c4e9b-b1ae-4008-a30c-448c1c480a24"
 			}
 		},
 		"metadata": {
@@ -252,7 +252,7 @@
 					"exitCode += int(not cur_schema_correct)\n",
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{service_user_appeal_table}\\nDifferences shown above (if any)\")\n",
 					"\n",
-					"# --COMMENTED OUT TO PREVENT FAILURE, AS ITS DEFINITIONS HAVE BEEN COMMENTED IN THE PREVIOUS CELL.\n",
+					"# -- COMMENTED OUT TO PREVENT TEST FAILURE, AS ITS DEFINITIONS HAVE BEEN COMMENTED IN THE PREVIOUS CELL.\n",
 					"# cur_migration_schema_correct: bool = test_compare_schemas(curated_migration_schema, curated_migration_table_schema)\n",
 					"# print(f\"Curated migration schema correct: {cur_migration_schema_correct}\\nTable: {curated_migration_db_name}.{service_user_migration_table}\\nDifferences shown above (if any)\")\n",
 					"# exitCode += int(not cur_migration_schema_correct)"


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
