### PR TITLE
task(infrastructure: creating a new image with python 3.13

### DIFF
--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -58,13 +58,6 @@ sudo apt install -y --no-install-recommends \
   python3-setuptools \
   python3-apt
 
-
-# python 3.13 as default and echo the result
-sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
-echo "==================== PYTHON DEFAULT VERSION ===================="
-python3 --version
-echo "================================================================"
-
 # Terraform 1.9.6
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
@@ -96,6 +89,12 @@ sudo apt-get update; \
 # PowerShell Modules
 pwsh -c "& {Install-Module -Name Az -Scope AllUsers -Repository PSGallery -Force -Verbose}"
 pwsh -c "& {Get-Module -ListAvailable}"
+
+# python 3.13 as default and echo the result
+sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
+echo "==================== PYTHON DEFAULT VERSION ===================="
+python3 --version
+echo "================================================================"
 
 # Sysprep
 /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -55,8 +55,12 @@ python3.7 -m pip install -U checkov==2.2.94
 # Python 3.13 Installation
 sudo apt install -y --no-install-recommends \
   python3.13 \
-  python3-setuptools \
-  python3-apt
+  python3-setuptools
+# set 3.13 as the default and echo the restul
+sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
+echo "==================== PYTHON DEFAULT VERSION ===================="
+python3 --version
+echo "================================================================"
 
 # Terraform 1.9.6
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
@@ -89,12 +93,6 @@ sudo apt-get update; \
 # PowerShell Modules
 pwsh -c "& {Install-Module -Name Az -Scope AllUsers -Repository PSGallery -Force -Verbose}"
 pwsh -c "& {Get-Module -ListAvailable}"
-
-# python 3.13 as default and echo the result
-sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
-echo "==================== PYTHON DEFAULT VERSION ===================="
-python3 --version
-echo "================================================================"
 
 # Sysprep
 /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -57,7 +57,7 @@ sudo apt install -y --no-install-recommends \
   python3.13 \
   python3-setuptools
 
-sudo apt-get install python3-apt
+sudo apt install python3-apt
 
 # set 3.13 as the default and echo the restul
 sudo ln -sf /usr/bin/python3.13 /usr/bin/python3

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -56,6 +56,9 @@ python3.7 -m pip install -U checkov==2.2.94
 sudo apt install -y --no-install-recommends \
   python3.13 \
   python3-setuptools
+
+sudo apt-get install python3-apt
+
 # set 3.13 as the default and echo the restul
 sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
 echo "==================== PYTHON DEFAULT VERSION ===================="

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -58,6 +58,13 @@ sudo apt install -y --no-install-recommends \
   python3-setuptools \
   python3-apt
 
+
+# python 3.13 as default and echo the result
+sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
+echo "==================== PYTHON DEFAULT VERSION ===================="
+python3 --version
+echo "================================================================"
+
 # Terraform 1.9.6
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
@@ -92,11 +99,3 @@ pwsh -c "& {Get-Module -ListAvailable}"
 
 # Sysprep
 /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync
-
-# python 3.13 as default
-sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
-
-# python version
-echo "==================== PYTHON DEFAULT VERSION ===================="
-python3 --version
-echo "================================================================"


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
