### PR TITLE
Feat/theodw 1556 spike create config file for all existing tables

### DIFF
--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6069db85-240c-47b1-91f5-2d636d2c1cd7"
+				"spark.autotune.trackingId": "38c43dfe-aeb3-4edd-9b47-7c7f16ff8312"
 			}
 		},
 		"metadata": {
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
@@ -59,7 +59,7 @@
 					"import pprint\r\n",
 					"import json"
 				],
-				"execution_count": 18
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -77,7 +77,7 @@
 				"source": [
 					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 19
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"config_container = 'odw-config-db'\r\n",
 					"logging_container = 'logging'"
 				],
-				"execution_count": 20
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"    \r\n",
 					"    return table_names"
 				],
-				"execution_count": 21
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +178,7 @@
 					"\r\n",
 					"    return table_metadata"
 				],
-				"execution_count": 22
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 23
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 24
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +238,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 25
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -258,7 +258,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 26
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -278,7 +278,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 27
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -298,7 +298,25 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 28
+				"execution_count": 11
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"pprint.pprint(combined_metadata)"
+				],
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -323,25 +341,7 @@
 					"    {\"logging_metadata\": logging_metadata}\r\n",
 					"]"
 				],
-				"execution_count": 29
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"pprint.pprint(combined_metadata)"
-				],
-				"execution_count": 30
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"\r\n",
 					"print(f\"Existing Tables Metadata saved to: {file_path}\")"
 				],
-				"execution_count": 31
+				"execution_count": 14
 			}
 		]
 	}

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -1,0 +1,348 @@
+{
+	"name": "existing_tables",
+	"properties": {
+		"folder": {
+			"name": "utils"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "8dd29dc9-e7b2-4448-886d-7bf1638ef9e5"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"source": [
+					"from notebookutils import mssparkutils\r\n",
+					"from pyspark.sql import DataFrame\r\n",
+					"import pprint\r\n",
+					"import json"
+				],
+				"execution_count": 29
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
+				],
+				"execution_count": 30
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"standardised_container = 'odw-standardised'\r\n",
+					"harmonised_container = 'odw-harmonised'\r\n",
+					"curated_container = 'odw-curated'\r\n",
+					"curated_migration_container = 'odw-curated-migration'\r\n",
+					"config_container = 'odw-config-db'\r\n",
+					"logging_container = 'logging'"
+				],
+				"execution_count": 31
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def list_tables(db_name: str):\r\n",
+					"    spark.sql(f\"USE {db_name}\")\r\n",
+					"    tables_df: DataFrame = spark.sql(\"SHOW TABLES\")\r\n",
+					"    table_names: list = [row['tableName'] for row in tables_df.collect()]\r\n",
+					"    \r\n",
+					"    return table_names"
+				],
+				"execution_count": 32
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"def create_table_metadata(container: str, db_name: str, tables: list) -> dict:\r\n",
+					"    table_metadata = {}\r\n",
+					"    table_metadata = []\r\n",
+					"    for table in tables:\r\n",
+					"        try:\r\n",
+					"            table_details = spark.sql(f\"DESCRIBE FORMATTED {db_name}.{table}\")\r\n",
+					"            table_info = {row['col_name']: row['data_type'] for row in table_details.collect()}\r\n",
+					"            #print(table_info)  # Print table_info to review its contents\r\n",
+					"            #table_name = table_info.get(\"name\", table)\r\n",
+					"            table_name = table_info.get(\"Name\", table)\r\n",
+					"            table_location = table_info.get(\"Location\", \"Unknown\")\r\n",
+					"            table_format = table_info.get(\"Provider\", \"Unknown\")\r\n",
+					"            table_type = \"External\" if table_info.get(\"External\", \"false\") == \"true\" else table_info.get(\"Type\", \"Unknown\")\r\n",
+					"\r\n",
+					"            # This handles cases where tables were created in the default location by mistake by not specifying location in the create table script.\r\n",
+					"            # Therefore there were tables created in the default location. This won't be needed in future.\r\n",
+					"            if table_location.startswith('abfss://synapse'):\r\n",
+					"                location = f'abfss://{container}@{storage_account}{table_name}'\r\n",
+					"            else:\r\n",
+					"                location = table_location\r\n",
+					"            # table_metadata[table_name] = {\r\n",
+					"            #     \"table_location\": location,\r\n",
+					"            #     \"table_type\": table_type,\r\n",
+					"            #     \"table_format\": table_format\r\n",
+					"            #     }\r\n",
+					"\r\n",
+					"            table_metadata.append({\r\n",
+					"                \"database_name\": db_name,\r\n",
+					"                \"table_name\": table_name,\r\n",
+					"                \"table_format\": table_format,\r\n",
+					"                \"table_type\": table_type,\r\n",
+					"                \"table_location\": location\r\n",
+					"            })\r\n",
+					"\r\n",
+					"        except Exception as e:\r\n",
+					"            print(f\"Failed to fetch details for {table}: {e}\")\r\n",
+					"\r\n",
+					"    return table_metadata"
+				],
+				"execution_count": 33
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"db_name = \"odw_standardised_db\"\r\n",
+					"tables = list_tables(db_name=db_name)\r\n",
+					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
+				],
+				"execution_count": 34
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"db_name = \"odw_harmonised_db\"\r\n",
+					"tables = list_tables(db_name=db_name)\r\n",
+					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
+				],
+				"execution_count": 35
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"db_name = \"odw_curated_db\"\r\n",
+					"tables = list_tables(db_name=db_name)\r\n",
+					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
+				],
+				"execution_count": 36
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"db_name = \"odw_curated_migration_db\"\r\n",
+					"tables = list_tables(db_name=db_name)\r\n",
+					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
+				],
+				"execution_count": 37
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"db_name = \"odw_config_db\"\r\n",
+					"tables = list_tables(db_name=db_name)\r\n",
+					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
+				],
+				"execution_count": 38
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"db_name = \"logging\"\r\n",
+					"tables = list_tables(db_name=db_name)\r\n",
+					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
+				],
+				"execution_count": 39
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"combined_metadata = [\r\n",
+					"    {\"standardised_metadata\": standardised_metadata},\r\n",
+					"    {\"harmonised_metadata\": harmonised_metadata},\r\n",
+					"    {\"curated_metadata\": curated_metadata},\r\n",
+					"    {\"curated_migration_metadata\": curated_migration_metadata},\r\n",
+					"    {\"config_metadata\": config_metadata},\r\n",
+					"    {\"logging_metadata\": logging_metadata}\r\n",
+					"]"
+				],
+				"execution_count": 40
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"pprint.pprint(combined_metadata)"
+				],
+				"execution_count": 41
+			}
+		]
+	}
+}

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "74cb796d-6474-454b-9811-cbd280f5a425"
+				"spark.autotune.trackingId": "e8992791-7f33-4173-9e72-3acc228ddbfd"
 			}
 		},
 		"metadata": {
@@ -59,7 +59,7 @@
 					"import pprint\r\n",
 					"import json"
 				],
-				"execution_count": 9
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -77,7 +77,7 @@
 				"source": [
 					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 10
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"config_container = 'odw-config-db'\r\n",
 					"logging_container = 'logging'"
 				],
-				"execution_count": 11
+				"execution_count": 25
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"    \r\n",
 					"    return table_names"
 				],
-				"execution_count": 13
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +178,7 @@
 					"\r\n",
 					"    return table_metadata"
 				],
-				"execution_count": 14
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 15
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 16
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +238,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 17
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -258,7 +258,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 18
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
@@ -278,7 +278,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 19
+				"execution_count": 32
 			},
 			{
 				"cell_type": "code",
@@ -298,7 +298,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 20
+				"execution_count": 33
 			},
 			{
 				"cell_type": "code",
@@ -323,7 +323,7 @@
 					"    {\"logging_metadata\": logging_metadata}\r\n",
 					"]"
 				],
-				"execution_count": 21
+				"execution_count": 34
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +341,7 @@
 				"source": [
 					"pprint.pprint(combined_metadata)"
 				],
-				"execution_count": 22
+				"execution_count": 35
 			},
 			{
 				"cell_type": "code",
@@ -361,11 +361,11 @@
 					"\r\n",
 					"file_path = 'abfss://odw-config@pinsstodwdevuks9h80mb.dfs.core.windows.net/existing-tables-metadata.json'\r\n",
 					"\r\n",
-					"mssparkutils.fs.put(file_path, existing-tables-metadata, overwrite=True)\r\n",
+					"mssparkutils.fs.put(file_path, existing_tables_metadata, overwrite=True)\r\n",
 					"\r\n",
 					"print(f\"Existing Tables Metadata saved to: {file_path}\")"
 				],
-				"execution_count": null
+				"execution_count": 37
 			}
 		]
 	}

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e8992791-7f33-4173-9e72-3acc228ddbfd"
+				"spark.autotune.trackingId": "961d2acd-0238-4e85-b325-c5c0084a1acb"
 			}
 		},
 		"metadata": {
@@ -59,7 +59,7 @@
 					"import pprint\r\n",
 					"import json"
 				],
-				"execution_count": 23
+				"execution_count": 42
 			},
 			{
 				"cell_type": "code",
@@ -77,7 +77,7 @@
 				"source": [
 					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 24
+				"execution_count": 43
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"config_container = 'odw-config-db'\r\n",
 					"logging_container = 'logging'"
 				],
-				"execution_count": 25
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"    \r\n",
 					"    return table_names"
 				],
-				"execution_count": 26
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +178,7 @@
 					"\r\n",
 					"    return table_metadata"
 				],
-				"execution_count": 27
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 28
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 29
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +238,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 30
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -258,7 +258,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 31
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -278,7 +278,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 32
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -298,7 +298,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 33
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -323,7 +323,7 @@
 					"    {\"logging_metadata\": logging_metadata}\r\n",
 					"]"
 				],
-				"execution_count": 34
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +341,7 @@
 				"source": [
 					"pprint.pprint(combined_metadata)"
 				],
-				"execution_count": 35
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"\r\n",
 					"print(f\"Existing Tables Metadata saved to: {file_path}\")"
 				],
-				"execution_count": 37
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "961d2acd-0238-4e85-b325-c5c0084a1acb"
+				"spark.autotune.trackingId": "aee59033-2051-4466-a5ba-6721d1a87b9b"
 			}
 		},
 		"metadata": {
@@ -59,7 +59,7 @@
 					"import pprint\r\n",
 					"import json"
 				],
-				"execution_count": 42
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -77,7 +77,7 @@
 				"source": [
 					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 43
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"config_container = 'odw-config-db'\r\n",
 					"logging_container = 'logging'"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"    \r\n",
 					"    return table_names"
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -148,7 +148,7 @@
 					"            table_info = {row['col_name']: row['data_type'] for row in table_details.collect()}\r\n",
 					"            #print(table_info)  # Print table_info to review its contents\r\n",
 					"            #table_name = table_info.get(\"name\", table)\r\n",
-					"            table_name = table_info.get(\"Name\", table)\r\n",
+					"            table_name = table_info.get(\"Name\", table).split('.')[-1]\r\n",
 					"            table_location = table_info.get(\"Location\", \"Unknown\")\r\n",
 					"            table_format = table_info.get(\"Provider\", \"Unknown\")\r\n",
 					"            table_type = \"External\" if table_info.get(\"External\", \"false\") == \"true\" else table_info.get(\"Type\", \"Unknown\")\r\n",
@@ -178,7 +178,7 @@
 					"\r\n",
 					"    return table_metadata"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +238,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -258,7 +258,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -278,7 +278,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -298,7 +298,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -323,7 +323,7 @@
 					"    {\"logging_metadata\": logging_metadata}\r\n",
 					"]"
 				],
-				"execution_count": null
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +341,7 @@
 				"source": [
 					"pprint.pprint(combined_metadata)"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"\r\n",
 					"print(f\"Existing Tables Metadata saved to: {file_path}\")"
 				],
-				"execution_count": null
+				"execution_count": 17
 			}
 		]
 	}

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e111d9be-a3eb-4454-8a96-1421b5563c5d"
+				"spark.autotune.trackingId": "74cb796d-6474-454b-9811-cbd280f5a425"
 			}
 		},
 		"metadata": {
@@ -59,7 +59,7 @@
 					"import pprint\r\n",
 					"import json"
 				],
-				"execution_count": 29
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -77,7 +77,7 @@
 				"source": [
 					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 30
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"config_container = 'odw-config-db'\r\n",
 					"logging_container = 'logging'"
 				],
-				"execution_count": 31
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"    \r\n",
 					"    return table_names"
 				],
-				"execution_count": 32
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +178,7 @@
 					"\r\n",
 					"    return table_metadata"
 				],
-				"execution_count": 33
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 34
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 35
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +238,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 36
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -258,7 +258,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 37
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -278,7 +278,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 38
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -298,7 +298,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 39
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -323,7 +323,7 @@
 					"    {\"logging_metadata\": logging_metadata}\r\n",
 					"]"
 				],
-				"execution_count": 40
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +341,31 @@
 				"source": [
 					"pprint.pprint(combined_metadata)"
 				],
-				"execution_count": 41
+				"execution_count": 22
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"existing_tables_metadata = json.dumps(combined_metadata, indent=4)\r\n",
+					"\r\n",
+					"file_path = 'abfss://odw-config@pinsstodwdevuks9h80mb.dfs.core.windows.net/existing-tables-metadata.json'\r\n",
+					"\r\n",
+					"mssparkutils.fs.put(file_path, existing-tables-metadata, overwrite=True)\r\n",
+					"\r\n",
+					"print(f\"Existing Tables Metadata saved to: {file_path}\")"
+				],
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "aee59033-2051-4466-a5ba-6721d1a87b9b"
+				"spark.autotune.trackingId": "6069db85-240c-47b1-91f5-2d636d2c1cd7"
 			}
 		},
 		"metadata": {
@@ -59,7 +59,7 @@
 					"import pprint\r\n",
 					"import json"
 				],
-				"execution_count": 1
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -77,7 +77,7 @@
 				"source": [
 					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 2
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"config_container = 'odw-config-db'\r\n",
 					"logging_container = 'logging'"
 				],
-				"execution_count": 3
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"    \r\n",
 					"    return table_names"
 				],
-				"execution_count": 4
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +178,7 @@
 					"\r\n",
 					"    return table_metadata"
 				],
-				"execution_count": 5
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 6
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 7
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +238,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 8
+				"execution_count": 25
 			},
 			{
 				"cell_type": "code",
@@ -258,7 +258,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 9
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -278,7 +278,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 10
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -298,7 +298,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 11
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -323,7 +323,7 @@
 					"    {\"logging_metadata\": logging_metadata}\r\n",
 					"]"
 				],
-				"execution_count": 12
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +341,7 @@
 				"source": [
 					"pprint.pprint(combined_metadata)"
 				],
-				"execution_count": 13
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"\r\n",
 					"print(f\"Existing Tables Metadata saved to: {file_path}\")"
 				],
-				"execution_count": 17
+				"execution_count": 31
 			}
 		]
 	}

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8dd29dc9-e7b2-4448-886d-7bf1638ef9e5"
+				"spark.autotune.trackingId": "e111d9be-a3eb-4454-8a96-1421b5563c5d"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4209c420-974e-457e-b032-5bb6a5d1f87f"
+				"spark.autotune.trackingId": "3ce391b5-27f8-46ba-abd7-66edb35bf325"
 			}
 		},
 		"metadata": {
@@ -84,7 +84,7 @@
 					}
 				},
 				"source": [
-					"existing_tables = \"https://pinsstodwdevuks9h80mb.dfs.core.windows.net/odw-config/existing-tables-metadata.json/\" #to be changed to githhub url"
+					"existing_tables = \"https://github.com/Planning-Inspectorate/odw-config/blob/3fec337ef38dd4aea09684e4ecdd362c32ea4ee8/data-lake/existing-tables-metadata.json\""
 				],
 				"execution_count": 2
 			},

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7f0fca55-8714-469e-90c8-f4060e6692ba"
+				"spark.autotune.trackingId": "4209c420-974e-457e-b032-5bb6a5d1f87f"
 			}
 		},
 		"metadata": {
@@ -189,7 +189,7 @@
 				},
 				"source": [
 					"for metadata_name in metadata_list:\r\n",
-					"    print(f\"Rebuilding {metadata_name.split('_')[0]} tables\")\r\n",
+					"    print(f\"Rebuilding {metadata_name.rsplit('_', 1)[0]} tables\")\r\n",
 					"    metadata = next((item[metadata_name] for item in exisitng_tables_metadata if metadata_name in item), [])\r\n",
 					"    for table in metadata:\r\n",
 					"        db_name = table.get('database_name')\r\n",

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "565a3a9c-19e2-4a32-8641-7b5f4ed471c7"
+				"spark.autotune.trackingId": "6679be1d-2693-48d6-806b-3b08e116f0d0"
 			}
 		},
 		"metadata": {
@@ -84,7 +84,7 @@
 					}
 				},
 				"source": [
-					"existing_tables_json_url = \"https://\" #githhub "
+					"existing_tables = \"https://\" #githhub url"
 				],
 				"execution_count": null
 			},
@@ -143,7 +143,7 @@
 					}
 				},
 				"source": [
-					"response = requests.get(existing_tables_json_url)\r\n",
+					"response = requests.get(existing_tables)\r\n",
 					"exisitng_tables_metadata = response.json()"
 				],
 				"execution_count": null

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "92a3494a-e84d-4ba7-ac11-e574d46a4ab1"
+				"spark.autotune.trackingId": "7f0fca55-8714-469e-90c8-f4060e6692ba"
 			}
 		},
 		"metadata": {
@@ -42,7 +42,7 @@
 					"type": "AAD",
 					"authResource": "https://dev.azuresynapse.net"
 				},
-				"sparkVersion": "3.3",
+				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
 				"memory": 28,
@@ -68,7 +68,7 @@
 					"import requests\r\n",
 					"import json"
 				],
-				"execution_count": 38
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -86,7 +86,7 @@
 				"source": [
 					"existing_tables = \"https://pinsstodwdevuks9h80mb.dfs.core.windows.net/odw-config/existing-tables-metadata.json/\" #to be changed to githhub url"
 				],
-				"execution_count": 39
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -127,7 +127,33 @@
 					"    except Exception as e:\r\n",
 					"        print(f\"Failed to rebuild table {db_name}.{table_name}: {e}\")"
 				],
-				"execution_count": 40
+				"execution_count": 3
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"# List of metadata\r\n",
+					"metadata_list = [\r\n",
+					"    'standardised_metadata',\r\n",
+					"    'harmonised_metadata',\r\n",
+					"    'curated_metadata',\r\n",
+					"    'curated_migration_metadata',\r\n",
+					"    'config_metadata',\r\n",
+					"    'logging_metadata'\r\n",
+					"]"
+				],
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +172,7 @@
 					"response = requests.get(existing_tables)\r\n",
 					"exisitng_tables_metadata = response.json()"
 				],
-				"execution_count": 41
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -162,145 +188,16 @@
 					}
 				},
 				"source": [
-					"print(\"Rebuilding standardised tables\")\r\n",
-					"standardised_metadata = next((item['standardised_metadata'] for item in exisitng_tables_metadata if 'standardised_metadata' in item), [])\r\n",
-					"for table in standardised_metadata:\r\n",
-					"    db_name = table.get('database_name')\r\n",
-					"    table_name = table.get('table_name')\r\n",
-					"    table_location = table.get('table_location')\r\n",
-					"    table_format = table.get('table_format')\r\n",
-					"    table_type = table.get('table_type')\r\n",
-					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(\"Rebuilding harmonised tables\")\r\n",
-					"harmonised_metadata = next((item['harmonised_metadata'] for item in exisitng_tables_metadata if 'harmonised_metadata' in item), [])\r\n",
-					"for table in harmonised_metadata:\r\n",
-					"    db_name = table.get('database_name')\r\n",
-					"    table_name = table.get('table_name')\r\n",
-					"    table_location = table.get('table_location')\r\n",
-					"    table_format = table.get('table_format')\r\n",
-					"    table_type = table.get('table_type')\r\n",
-					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(\"Rebuilding curated tables\")\r\n",
-					"curated_metadata = next((item['curated_metadata'] for item in exisitng_tables_metadata if 'curated_metadata' in item), [])\r\n",
-					"for table in curated_metadata:\r\n",
-					"    db_name = table.get('database_name')\r\n",
-					"    table_name = table.get('table_name')\r\n",
-					"    table_location = table.get('table_location')\r\n",
-					"    table_format = table.get('table_format')\r\n",
-					"    table_type = table.get('table_type')\r\n",
-					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(\"Rebuilding curated migration tables\")\r\n",
-					"curated_migration_metadata = next((item['curated_metadata'] for item in exisitng_tables_metadata if 'curated_migration_metadata' in item), [])\r\n",
-					"for table in curated_migration_metadata:\r\n",
-					"    db_name = table.get('database_name')\r\n",
-					"    table_name = table.get('table_name')\r\n",
-					"    table_location = table.get('table_location')\r\n",
-					"    table_format = table.get('table_format')\r\n",
-					"    table_type = table.get('table_type')\r\n",
-					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(\"Rebuilding config tables\")\r\n",
-					"config_metadata = next((item['config_metadata'] for item in exisitng_tables_metadata if 'config_metadata' in item), [])\r\n",
-					"for table in config_metadata:\r\n",
-					"    db_name = table.get('database_name')\r\n",
-					"    table_name = table.get('table_name')\r\n",
-					"    table_location = table.get('table_location')\r\n",
-					"    table_format = table.get('table_format')\r\n",
-					"    table_type = table.get('table_type')\r\n",
-					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"print(\"Rebuilding logging tables\")\r\n",
-					"logging_metadata = next((item['logging_metadata'] for item in exisitng_tables_metadata if 'logging_metadata' in item), [])\r\n",
-					"for table in logging_metadata:\r\n",
-					"    db_name = table.get('database_name')\r\n",
-					"    table_name = table.get('table_name')\r\n",
-					"    table_location = table.get('table_location')\r\n",
-					"    table_format = table.get('table_format')\r\n",
-					"    table_type = table.get('table_type')\r\n",
-					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
+					"for metadata_name in metadata_list:\r\n",
+					"    print(f\"Rebuilding {metadata_name.split('_')[0]} tables\")\r\n",
+					"    metadata = next((item[metadata_name] for item in exisitng_tables_metadata if metadata_name in item), [])\r\n",
+					"    for table in metadata:\r\n",
+					"        db_name = table.get('database_name')\r\n",
+					"        table_name = table.get('table_name')\r\n",
+					"        table_location = table.get('table_location')\r\n",
+					"        table_format = table.get('table_format')\r\n",
+					"        table_type = table.get('table_type')\r\n",
+					"        rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
 				],
 				"execution_count": null
 			}

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -1,0 +1,309 @@
+{
+	"name": "new_rebuild_tables",
+	"properties": {
+		"folder": {
+			"name": "utils"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "565a3a9c-19e2-4a32-8641-7b5f4ed471c7"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.3",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"import requests\r\n",
+					"import json"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"existing_tables_json_url = \"https://\" #githhub "
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"def rebuild_table(db_name: str, table_name: str, table_location: str, table_format: str, table_type: str):\r\n",
+					"    try:\r\n",
+					"        # Validate parameters\r\n",
+					"        if not db_name or db_name == \"Unknown\":\r\n",
+					"            raise ValueError(\"Database name not provided or is of value 'Unknown'.\")\r\n",
+					"        if not table_name or table_name == \"Unknown\":\r\n",
+					"            raise ValueError(\"Table name not provided or is of value 'Unknown'.\")\r\n",
+					"        if not table_location or table_location == \"Unknown\":\r\n",
+					"            raise ValueError(\"Location not provided or is of value = 'Unknown'.\")\r\n",
+					"        if not table_format or table_format == \"Unknown\":\r\n",
+					"            raise ValueError(\"Table format not provided or is of value 'Unknown'.\")\r\n",
+					"        if not table_type or table_type == \"Unknown\":\r\n",
+					"            raise ValueError(\"Table type not provided or is of value 'Unknown'.\")\r\n",
+					"\r\n",
+					"\r\n",
+					"        # revert back to initial properties based on table_type values\r\n",
+					"        if table_type == \"Managed\":\r\n",
+					"            tbl_properties = \"TBLPROPERTIES ('Type'='MANAGED')\"\r\n",
+					"        elif table_type == \"External\":\r\n",
+					"            tbl_properties = \"TBLPROPERTIES ('External'='true')\"\r\n",
+					"        else:\r\n",
+					"            raise ValueError(\"Invalid, expected table_type value is 'MANAGED' or 'External'.\")\r\n",
+					"\r\n",
+					"\r\n",
+					"        # Create or rebuild the table\r\n",
+					"        spark.sql(f\"\"\"CREATE TABLE IF NOT EXISTS {db_name}.{table_name}\r\n",
+					"        USING {table_format}\r\n",
+					"        LOCATION '{table_location}'\r\n",
+					"        {tbl_properties}\r\n",
+					"        \"\"\")\r\n",
+					"        print(f\"Table {db_name}.{table_name} rebuilt at location\\n{table_location}\")\r\n",
+					"    except ValueError as ve:\r\n",
+					"        print(f\"Validation error: {ve}\")\r\n",
+					"    except Exception as e:\r\n",
+					"        print(f\"Failed to rebuild table {db_name}.{table_name}: {e}\")"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"response = requests.get(existing_tables_json_url)\r\n",
+					"exisitng_tables_metadata = response.json()"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(\"Rebuilding standardised tables\")\r\n",
+					"standardised_metadata = next((item['standardised_metadata'] for item in exisitng_tables_metadata if 'standardised_metadata' in item), [])\r\n",
+					"for table in standardised_metadata:\r\n",
+					"    db_name = table.get('database_name')\r\n",
+					"    table_name = table.get('table_name')\r\n",
+					"    table_location = table.get('table_location')\r\n",
+					"    table_format = table.get('table_format')\r\n",
+					"    table_type = table.get('table_type')\r\n",
+					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(\"Rebuilding harmonised tables\")\r\n",
+					"harmonised_metadata = next((item['harmonised_metadata'] for item in exisitng_tables_metadata if 'harmonised_metadata' in item), [])\r\n",
+					"for table in harmonised_metadata:\r\n",
+					"    db_name = table.get('database_name')\r\n",
+					"    table_name = table.get('table_name')\r\n",
+					"    table_location = table.get('table_location')\r\n",
+					"    table_format = table.get('table_format')\r\n",
+					"    table_type = table.get('table_type')\r\n",
+					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(\"Rebuilding curated tables\")\r\n",
+					"curated_metadata = next((item['curated_metadata'] for item in exisitng_tables_metadata if 'curated_metadata' in item), [])\r\n",
+					"for table in curated_metadata:\r\n",
+					"    db_name = table.get('database_name')\r\n",
+					"    table_name = table.get('table_name')\r\n",
+					"    table_location = table.get('table_location')\r\n",
+					"    table_format = table.get('table_format')\r\n",
+					"    table_type = table.get('table_type')\r\n",
+					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(\"Rebuilding curated migration tables\")\r\n",
+					"curated_migration_metadata = next((item['curated_metadata'] for item in exisitng_tables_metadata if 'curated_migration_metadata' in item), [])\r\n",
+					"for table in curated_migration_metadata:\r\n",
+					"    db_name = table.get('database_name')\r\n",
+					"    table_name = table.get('table_name')\r\n",
+					"    table_location = table.get('table_location')\r\n",
+					"    table_format = table.get('table_format')\r\n",
+					"    table_type = table.get('table_type')\r\n",
+					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(\"Rebuilding config tables\")\r\n",
+					"config_metadata = next((item['config_metadata'] for item in exisitng_tables_metadata if 'config_metadata' in item), [])\r\n",
+					"for table in config_metadata:\r\n",
+					"    db_name = table.get('database_name')\r\n",
+					"    table_name = table.get('table_name')\r\n",
+					"    table_location = table.get('table_location')\r\n",
+					"    table_format = table.get('table_format')\r\n",
+					"    table_type = table.get('table_type')\r\n",
+					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"jupyter": {
+						"source_hidden": false,
+						"outputs_hidden": false
+					},
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"print(\"Rebuilding logging tables\")\r\n",
+					"logging_metadata = next((item['logging_metadata'] for item in exisitng_tables_metadata if 'logging_metadata' in item), [])\r\n",
+					"for table in logging_metadata:\r\n",
+					"    db_name = table.get('database_name')\r\n",
+					"    table_name = table.get('table_name')\r\n",
+					"    table_location = table.get('table_location')\r\n",
+					"    table_format = table.get('table_format')\r\n",
+					"    table_type = table.get('table_type')\r\n",
+					"    rebuild_table(db_name=db_name, table_name=table_name, table_location=table_location, table_format=table_format, table_type=table_type)"
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6679be1d-2693-48d6-806b-3b08e116f0d0"
+				"spark.autotune.trackingId": "92a3494a-e84d-4ba7-ac11-e574d46a4ab1"
 			}
 		},
 		"metadata": {
@@ -68,7 +68,7 @@
 					"import requests\r\n",
 					"import json"
 				],
-				"execution_count": null
+				"execution_count": 38
 			},
 			{
 				"cell_type": "code",
@@ -84,9 +84,9 @@
 					}
 				},
 				"source": [
-					"existing_tables = \"https://\" #githhub url"
+					"existing_tables = \"https://pinsstodwdevuks9h80mb.dfs.core.windows.net/odw-config/existing-tables-metadata.json/\" #to be changed to githhub url"
 				],
-				"execution_count": null
+				"execution_count": 39
 			},
 			{
 				"cell_type": "code",
@@ -127,7 +127,7 @@
 					"    except Exception as e:\r\n",
 					"        print(f\"Failed to rebuild table {db_name}.{table_name}: {e}\")"
 				],
-				"execution_count": null
+				"execution_count": 40
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 					"response = requests.get(existing_tables)\r\n",
 					"exisitng_tables_metadata = response.json()"
 				],
-				"execution_count": null
+				"execution_count": 41
 			},
 			{
 				"cell_type": "code",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
