### PR TITLE
Updating notebook: py_1_raw_to_standardised_hr_functions

### DIFF
--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d81031a9-fd8a-4bff-93a2-1a118eb2880a"
+				"spark.autotune.trackingId": "581f5806-3c1c-4894-a580-d458a4251af5"
 			}
 		},
 		"metadata": {
@@ -495,7 +495,7 @@
 					"\n",
 					"    try:\n",
 					"        unmount_storage()\n",
-					"    except:\n",
+					"    except Exception as e:\n",
 					"        logInfo('Unable to unmount storage')\n",
 					"\n",
 					"    ### add date columns included with every standardised table\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3cded501-5840-42b1-87d8-b313be60bbe7"
+				"spark.autotune.trackingId": "d81031a9-fd8a-4bff-93a2-1a118eb2880a"
 			}
 		},
 		"metadata": {
@@ -495,7 +495,7 @@
 					"\n",
 					"    try:\n",
 					"        unmount_storage()\n",
-					"    except Exception as e:\n",
+					"    except:\n",
 					"        logInfo('Unable to unmount storage')\n",
 					"\n",
 					"    ### add date columns included with every standardised table\n",

--- a/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
+++ b/workspace/notebook/py_1_raw_to_standardised_hr_functions.json
@@ -21,7 +21,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5b3a3cc1-5eda-4fe0-8ad3-b9cf34d3a933"
+				"spark.autotune.trackingId": "3cded501-5840-42b1-87d8-b313be60bbe7"
 			}
 		},
 		"metadata": {
@@ -492,7 +492,11 @@
 					"    sparkDF = df.select([col for col in df.columns if not col.startswith('Unnamed')])\n",
 					"    # rows_raw = len(df.index)\n",
 					"    rows_raw = sparkDF.count()\n",
-					"    unmount_storage()\n",
+					"\n",
+					"    try:\n",
+					"        unmount_storage()\n",
+					"    except Exception as e:\n",
+					"        logInfo('Unable to unmount storage')\n",
 					"\n",
 					"    ### add date columns included with every standardised table\n",
 					"    sparkDF = sparkDF.withColumn(\"ingested_datetime\",current_timestamp())\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
