### PR TITLE
Feat/theodw 1690 amend rebuild table

### DIFF
--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "38c43dfe-aeb3-4edd-9b47-7c7f16ff8312"
+				"spark.autotune.trackingId": "fa26f69e-e647-46eb-82d4-05da59fb5636"
 			}
 		},
 		"metadata": {
@@ -314,9 +314,16 @@
 					}
 				},
 				"source": [
-					"pprint.pprint(combined_metadata)"
+					"combined_metadata = [\r\n",
+					"    {\"standardised_metadata\": standardised_metadata},\r\n",
+					"    {\"harmonised_metadata\": harmonised_metadata},\r\n",
+					"    {\"curated_metadata\": curated_metadata},\r\n",
+					"    {\"curated_migration_metadata\": curated_migration_metadata},\r\n",
+					"    {\"config_metadata\": config_metadata},\r\n",
+					"    {\"logging_metadata\": logging_metadata}\r\n",
+					"]"
 				],
-				"execution_count": 13
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -332,16 +339,9 @@
 					}
 				},
 				"source": [
-					"combined_metadata = [\r\n",
-					"    {\"standardised_metadata\": standardised_metadata},\r\n",
-					"    {\"harmonised_metadata\": harmonised_metadata},\r\n",
-					"    {\"curated_metadata\": curated_metadata},\r\n",
-					"    {\"curated_migration_metadata\": curated_migration_metadata},\r\n",
-					"    {\"config_metadata\": config_metadata},\r\n",
-					"    {\"logging_metadata\": logging_metadata}\r\n",
-					"]"
+					"pprint.pprint(combined_metadata)"
 				],
-				"execution_count": 12
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/existing_tables.json
+++ b/workspace/notebook/existing_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fa26f69e-e647-46eb-82d4-05da59fb5636"
+				"spark.autotune.trackingId": "385379ea-1657-4c33-8f87-22c64572d975"
 			}
 		},
 		"metadata": {
@@ -59,7 +59,7 @@
 					"import pprint\r\n",
 					"import json"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -77,7 +77,7 @@
 				"source": [
 					"storage_account = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"config_container = 'odw-config-db'\r\n",
 					"logging_container = 'logging'"
 				],
-				"execution_count": 3
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -123,7 +123,7 @@
 					"    \r\n",
 					"    return table_names"
 				],
-				"execution_count": 4
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -178,7 +178,7 @@
 					"\r\n",
 					"    return table_metadata"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"standardised_metadata = create_table_metadata(container=standardised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 6
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"harmonised_metadata = create_table_metadata(container=harmonised_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -238,7 +238,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_metadata = create_table_metadata(container=curated_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -258,7 +258,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"curated_migration_metadata = create_table_metadata(container=curated_migration_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -278,7 +278,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"config_metadata = create_table_metadata(container=config_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -298,7 +298,7 @@
 					"tables = list_tables(db_name=db_name)\r\n",
 					"logging_metadata = create_table_metadata(container=logging_container, db_name=db_name, tables=tables)"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -323,7 +323,7 @@
 					"    {\"logging_metadata\": logging_metadata}\r\n",
 					"]"
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +341,7 @@
 				"source": [
 					"pprint.pprint(combined_metadata)"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"\r\n",
 					"print(f\"Existing Tables Metadata saved to: {file_path}\")"
 				],
-				"execution_count": 14
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "90b8257f-e181-4cfb-9e0f-ec75e6b5cb17"
+				"spark.autotune.trackingId": "ef824387-2b6b-485e-9194-e5d0d51ed9c6"
 			}
 		},
 		"metadata": {
@@ -84,7 +84,7 @@
 					}
 				},
 				"source": [
-					"existing_tables = \"https://raw.githubusercontent.com/Planning-Inspectorate/odw-config/3fec337ef38dd4aea09684e4ecdd362c32ea4ee8/data-lake/existing-tables-metadata.json\""
+					"existing_tables = \"https://raw.githubusercontent.com/Planning-Inspectorate/odw-config/refs/heads/main/data-lake/existing-tables-metadata.json\""
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/new_rebuild_tables.json
+++ b/workspace/notebook/new_rebuild_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3ce391b5-27f8-46ba-abd7-66edb35bf325"
+				"spark.autotune.trackingId": "90b8257f-e181-4cfb-9e0f-ec75e6b5cb17"
 			}
 		},
 		"metadata": {
@@ -68,7 +68,7 @@
 					"import requests\r\n",
 					"import json"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -84,9 +84,9 @@
 					}
 				},
 				"source": [
-					"existing_tables = \"https://github.com/Planning-Inspectorate/odw-config/blob/3fec337ef38dd4aea09684e4ecdd362c32ea4ee8/data-lake/existing-tables-metadata.json\""
+					"existing_tables = \"https://raw.githubusercontent.com/Planning-Inspectorate/odw-config/3fec337ef38dd4aea09684e4ecdd362c32ea4ee8/data-lake/existing-tables-metadata.json\""
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -127,7 +127,7 @@
 					"    except Exception as e:\r\n",
 					"        print(f\"Failed to rebuild table {db_name}.{table_name}: {e}\")"
 				],
-				"execution_count": 3
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"    'logging_metadata'\r\n",
 					"]"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -172,7 +172,7 @@
 					"response = requests.get(existing_tables)\r\n",
 					"exisitng_tables_metadata = response.json()"
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
