### PR TITLE
THEODW-1600: Create Unit Test notebook - pins_lpa_curated (test script)

### DIFF
--- a/workspace/testing/tests/test_pins_lpa_curated.py
+++ b/workspace/testing/tests/test_pins_lpa_curated.py
@@ -3,7 +3,7 @@ import pipelineutils
 import constants
 import warnings
 
-def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoint: str):
+def test_pins_lpa_curated(credential_name, azure_credential, synapse_endpoint: str):
 
     warnings.filterwarnings("ignore", category=DeprecationWarning) 
 

--- a/workspace/testing/tests/test_pins_lpa_curated.py
+++ b/workspace/testing/tests/test_pins_lpa_curated.py
@@ -58,7 +58,7 @@ def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoi
     print("Notebook response *" +str(exitMessage) +"*")
     assert notebook_run_result == constants.NOTEBOOK_SUCCESS_STATUS 
     assert exitMessage == constants.NOTEBOOK_EXIT_CODE_SUCCESS
-    print("test_nsip_project Completed")
+    print("test_pins_lpa_curated Completed")
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests():

--- a/workspace/testing/tests/test_pins_lpa_curated.py
+++ b/workspace/testing/tests/test_pins_lpa_curated.py
@@ -1,0 +1,66 @@
+import pytest
+import pipelineutils
+import constants
+import warnings
+
+def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoint: str):
+
+    warnings.filterwarnings("ignore", category=DeprecationWarning) 
+
+    # run the testing notebook
+    notebookname: str = "py_unit_tests_pins_lpa_curated"
+    
+    notebook_raw_params = {
+        "sparkPool": "pinssynspodw",
+        "notebook": notebookname,
+        "sessionOptions": {
+            "driverMemory": "28g",
+            "driverCores": 4,
+            "executorMemory": "28g",
+            "executorCores": 4,
+            "numExecutors": 2,
+            "runAsWorkspaceSystemIdentity": False
+        },
+        "parameters": {
+            "entity_name": {
+               "type": "String",
+               "value": "pins-lpa",
+            },
+            "std_db_name": {
+               "type": "String",
+               "value": "odw_standardised_db",
+            },
+            "hrm_db_name": {
+               "type": "String",
+               "value": "odw_harmonised_db",
+            },
+            "curated_db_name": {
+               "type": "String",
+               "value": "odw_curated_db",
+            },
+            "std_table_name": {
+               "type": "String",
+               "value": "pins_lpa",
+            },
+            "hrm_table_name": {
+               "type": "String",
+               "value": "pins_lpa",
+            },
+            "curated_table_name": {
+               "type": "String",
+               "value": "pins_lpa",
+            },
+        }
+    }
+
+    #run the notebook
+    (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)
+    print("Notebook response *" +str(exitMessage) +"*")
+    assert notebook_run_result == constants.NOTEBOOK_SUCCESS_STATUS 
+    assert exitMessage == constants.NOTEBOOK_EXIT_CODE_SUCCESS
+    print("test_nsip_project Completed")
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    yield
+    print("Before and After running")


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
