### PR TITLE
Feat/theodw 1655 build a dummy function in existing function app2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,13 +10,13 @@
 /infrastructure/**                                              @ChrisToppingKandC @beejjacobs @m-juckes-pins @stef-solirius
 
 # Azure Synapse files
-/workspace/**                                                   @ChrisToppingKandC @RobPalmer30 @muhammadkc @stef-solirius
+/workspace/**                                                   @ChrisToppingKandC @alex-ghoth @muhammadkc @stef-solirius
 
 # Azure DevOps pipeline files
-/pipelines/**                                                   @ChrisToppingKandC @muhammadkc @m-juckes-pins @IsminiA @kathryn-thompson @stef-solirius
+/pipelines/**                                                   @ChrisToppingKandC @muhammadkc @m-juckes-pins @IsminiA @kathryn-thompson @stef-solirius @alex-ghoth
 
 # Add protection for certain file extensions,
 # i.e. a python or sql expert must approve
-*.py                                                            @ChrisToppingKandC @RobPalmer30 @muhammadkc @stef-solirius
-*.ipynb                                                         @ChrisToppingKandC @RobPalmer30 @muhammadkc @stef-solirius
-*.sql                                                           @ChrisToppingKandC @RobPalmer30 @muhammadkc @stef-solirius
+*.py                                                            @ChrisToppingKandC @alex-ghoth @muhammadkc @stef-solirius
+*.ipynb                                                         @ChrisToppingKandC @alex-ghoth @muhammadkc @stef-solirius
+*.sql                                                           @ChrisToppingKandC @alex-ghoth @muhammadkc @stef-solirius

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -847,52 +847,35 @@ def getDaRT(req: func.HttpRequest, dart: func.SqlRowList) -> func.HttpResponse:
     except Exception as e:
         return func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
 
-@_app.function_name("testFunction")
+@_app.function_name(name="testFunction")
 @_app.route(route="testFunction", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
-def test_function(req: func.HttpRequest) -> func.HttpResponse:
-    """
-    Azure Function endpoint for querying the tables_logs table.
-
-    Args:
-        req: An instance of `func.HttpRequest` representing the HTTP request.
-
-    Returns:
-        An instance of `func.HttpResponse` representing the HTTP response.
-    """
-
+@_app.sql_input(
+    arg_name="logs",
+    command_text="""
+    SELECT TOP (1000) [file_ID],
+                    [ingested_datetime],
+                    [ingested_by_process_name],
+                    [input_file],
+                    [modified_datetime],
+                    [modified_by_process_name],
+                    [entity_name],
+                    [rows_raw],
+                    [rows_new]
+    FROM logging.dbo.tables_logs
+    """,
+    command_type="Text",
+    connection_string_setting="SqlConnectionString"
+)
+def test_function(req: func.HttpRequest, logs: func.SqlRowList) -> func.HttpResponse:
     try:
-        _SCHEMA = _SCHEMAS["tables-logs.schema.json"]
-        _TOPIC = config["global"]["entities"]["tables-logs"]["topic"]
-        _SUBSCRIPTION = config["global"]["entities"]["tables-logs"]["subscription"]
-
-        _data = get_messages_and_validate(
-            namespace=_NAMESPACE,
-            credential=_CREDENTIAL,
-            topic=_TOPIC,
-            subscription=_SUBSCRIPTION,
-            max_message_count=_MAX_MESSAGE_COUNT,
-            max_wait_time=_MAX_WAIT_TIME,
-            schema=_SCHEMA,
-        )
-
-        _message_count = send_to_storage(
-            account_url=_STORAGE,
-            credential=_CREDENTIAL,
-            container=_CONTAINER,
-            entity="tables-logs",
-            data=_data,
-        )
-
-        response = json.dumps({"message": f"{_SUCCESS_RESPONSE} - {_message_count} messages sent to storage", "count": _message_count})
+        rows = []
+        for r in logs:
+            rows.append(json.loads(r.to_json()))
 
         return func.HttpResponse(
-            response,
-            status_code=200
+            json.dumps(rows),
+            status_code=200,
+            mimetype="application/json"
         )
-
     except Exception as e:
-        return (
-            func.HttpResponse(f"Validation error: {str(e)}", status_code=500)
-            if f"{_VALIDATION_ERROR}" in str(e)
-            else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
-        )
+        return func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -846,3 +846,53 @@ def getDaRT(req: func.HttpRequest, dart: func.SqlRowList) -> func.HttpResponse:
         )
     except Exception as e:
         return func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
+
+@_app.function_name("testFunction")
+@_app.route(route="testFunction", methods=["get"], auth_level=func.AuthLevel.FUNCTION)
+def test_function(req: func.HttpRequest) -> func.HttpResponse:
+    """
+    Azure Function endpoint for querying the tables_logs table.
+
+    Args:
+        req: An instance of `func.HttpRequest` representing the HTTP request.
+
+    Returns:
+        An instance of `func.HttpResponse` representing the HTTP response.
+    """
+
+    try:
+        _SCHEMA = _SCHEMAS["tables-logs.schema.json"]
+        _TOPIC = config["global"]["entities"]["tables-logs"]["topic"]
+        _SUBSCRIPTION = config["global"]["entities"]["tables-logs"]["subscription"]
+
+        _data = get_messages_and_validate(
+            namespace=_NAMESPACE,
+            credential=_CREDENTIAL,
+            topic=_TOPIC,
+            subscription=_SUBSCRIPTION,
+            max_message_count=_MAX_MESSAGE_COUNT,
+            max_wait_time=_MAX_WAIT_TIME,
+            schema=_SCHEMA,
+        )
+
+        _message_count = send_to_storage(
+            account_url=_STORAGE,
+            credential=_CREDENTIAL,
+            container=_CONTAINER,
+            entity="tables-logs",
+            data=_data,
+        )
+
+        response = json.dumps({"message": f"{_SUCCESS_RESPONSE} - {_message_count} messages sent to storage", "count": _message_count})
+
+        return func.HttpResponse(
+            response,
+            status_code=200
+        )
+
+    except Exception as e:
+        return (
+            func.HttpResponse(f"Validation error: {str(e)}", status_code=500)
+            if f"{_VALIDATION_ERROR}" in str(e)
+            else func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
+        )

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -879,3 +879,4 @@ def test_function(req: func.HttpRequest, logs: func.SqlRowList) -> func.HttpResp
         )
     except Exception as e:
         return func.HttpResponse(f"Unknown error: {str(e)}", status_code=500)
+    

--- a/functions/local.settings.json
+++ b/functions/local.settings.json
@@ -3,6 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AzureWebJobsFeatureFlags": "EnableWorkerIndexing"
+    "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
+    "SqlConnectionString": "Server=tcp:pins-synw-odw-dev-uks-ondemand.sql.azuresynapse.net,1433;Persist Security Info=False;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Database=odw_curated_db;Authentication=Active Directory Default;"
   }
 }


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ X] No

 2. Have any new tables been created in Standardised?

  	- [ X] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ X] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ X] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 5. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ X] No - No scripts have run 
	
 
