### PR TITLE
Feat/odw mcp108 s78

### DIFF
--- a/workspace/dataset/appeals_s78_curated_mipins.json
+++ b/workspace/dataset/appeals_s78_curated_mipins.json
@@ -1,0 +1,19 @@
+{
+	"name": "appeals_s78_curated_mipins",
+	"properties": {
+		"linkedServiceName": {
+			"referenceName": "ls_ssql_builtin",
+			"type": "LinkedServiceReference",
+			"parameters": {
+				"db_name": "odw_curated_db"
+			}
+		},
+		"annotations": [],
+		"type": "AzureSqlTable",
+		"schema": [],
+		"typeProperties": {
+			"schema": "dbo",
+			"table": "appeals_s78_curated_mipins"
+		}
+	}
+}

--- a/workspace/dataset/appeals_s78_mipins.json
+++ b/workspace/dataset/appeals_s78_mipins.json
@@ -1,0 +1,16 @@
+{
+	"name": "appeals_s78_mipins",
+	"properties": {
+		"linkedServiceName": {
+			"referenceName": "ls_sql_mipins",
+			"type": "LinkedServiceReference"
+		},
+		"annotations": [],
+		"type": "AzureSqlTable",
+		"schema": [],
+		"typeProperties": {
+			"schema": "odw",
+			"table": "appeals_s78_curated_mipins"
+		}
+	}
+}

--- a/workspace/notebook/appeal_s78_curated_mipins.json
+++ b/workspace/notebook/appeal_s78_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "eae61229-1742-47c9-a5af-b8ba956d7c68"
+				"spark.autotune.trackingId": "6ad8415f-f1ab-4fec-b176-0f54d93d1d75"
 			}
 		},
 		"metadata": {
@@ -206,14 +206,14 @@
 					"FROM odw_harmonised_db.sb_appeal_s78 AS AH\n",
 					"where AH.lpaCode NOT in ('Q9999', 'Q1111')"
 				],
-				"execution_count": 24
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeals_s78_curated_mipins;\")"
 				],
-				"execution_count": 25
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -223,21 +223,18 @@
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeals_s78_curated_mipins\")\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeals_s78_curated_mipins\")"
 				],
-				"execution_count": 26
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
 				"metadata": {
-					"microsoft": {
-						"language": "sparksql"
-					},
 					"collapsed": false
 				},
 				"source": [
-					"%%sql\n",
-					"select * from odw_curated_db.appeals_s78_curated_mipins"
+					"#%%sql\n",
+					"#select * from odw_curated_db.appeals_s78_curated_mipins"
 				],
-				"execution_count": 27
+				"execution_count": 31
 			}
 		]
 	}

--- a/workspace/notebook/appeal_s78_curated_mipins.json
+++ b/workspace/notebook/appeal_s78_curated_mipins.json
@@ -1,0 +1,244 @@
+{
+	"name": "appeal_s78_curated_mipins",
+	"properties": {
+		"folder": {
+			"name": "odw-curated"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "eae61229-1742-47c9-a5af-b8ba956d7c68"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.4",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"\n",
+					"CREATE OR REPLACE VIEW odw_curated_db.vw_appeals_s78_curated_mipins\n",
+					"\n",
+					"AS\n",
+					"\n",
+					"SELECT DISTINCT \n",
+					"CAST(AH.caseId AS INT)                      AS caseId,\n",
+					"AH.caseReference                            AS caseReference,\n",
+					"AH.submissionId                             AS submissionId,\n",
+					"AH.caseStatus                               AS caseStatus,\n",
+					"AH.caseType                                 AS caseType,\n",
+					"AH.caseProcedure                            AS caseProcedure,\n",
+					"AH.lpaCode                                  AS lpaCode,\n",
+					"AH.caseOfficerId                            AS caseOfficerId,\n",
+					"AH.inspectorId                              AS inspectorId,\n",
+					"AH.allocationLevel                          AS allocationLevel,\n",
+					"CAST(AH.allocationBand AS NUMERIC)          AS allocationBand,\n",
+					"AH.caseSpecialisms                          AS caseSpecialisms,\n",
+					"AH.caseSubmittedDate                        AS caseSubmittedDate,\n",
+					"AH.caseCreatedDate                          AS caseCreatedDate,\n",
+					"AH.caseUpdatedDate                          AS caseUpdatedDate,\n",
+					"AH.caseValidDate                            AS caseValidDate,\n",
+					"AH.caseValidationDate                       AS caseValidationDate,\n",
+					"AH.caseValidationOutcome                    AS caseValidationOutcome,\n",
+					"AH.caseValidationInvalidDetails             AS caseValidationInvalidDetails,\n",
+					"cast(AH.caseValidationIncompleteDetails as string)          AS caseValidationIncompleteDetails,\n",
+					"AH.caseExtensionDate                        AS caseExtensionDate,\n",
+					"AH.caseStartedDate                          AS caseStartedDate,\n",
+					"AH.casePublishedDate                        AS casePublishedDate,\n",
+					"AH.linkedCaseStatus                         AS linkedCaseStatus,\n",
+					"AH.leadCaseReference                        AS leadCaseReference,\n",
+					"AH.lpaQuestionnaireDueDate                  AS lpaQuestionnaireDueDate,\n",
+					"AH.lpaQuestionnaireSubmittedDate            AS lpaQuestionnaireSubmittedDate,\n",
+					"AH.lpaQuestionnaireCreatedDate              AS lpaQuestionnaireCreatedDate,\n",
+					"AH.lpaQuestionnairePublishedDate            AS lpaQuestionnairePublishedDate,\n",
+					"AH.lpaQuestionnaireValidationOutcome        AS lpaQuestionnaireValidationOutcome,\n",
+					"AH.lpaQuestionnaireValidationOutcomeDate    AS lpaQuestionnaireValidationOutcomeDate,\n",
+					"cast(AH.lpaQuestionnaireValidationDetails as string)        AS lpaQuestionnaireValidationDetails,\n",
+					"AH.lpaStatement                             AS lpaStatement,\n",
+					"AH.caseWithdrawnDate                        AS caseWithdrawnDate,\n",
+					"AH.caseTransferredDate                      AS caseTransferredDate,\n",
+					"AH.transferredCaseClosedDate                AS transferredCaseClosedDate,\n",
+					"AH.caseDecisionOutcomeDate                  AS caseDecisionOutcomeDate,\n",
+					"AH.caseDecisionPublishedDate                AS caseDecisionPublishedDate,\n",
+					"AH.caseDecisionOutcome                      AS caseDecisionOutcome,\n",
+					"AH.caseCompletedDate                        AS caseCompletedDate,\n",
+					"CAST(AH.enforcementNotice AS BOOLEAN)       AS enforcementNotice,\n",
+					"AH.applicationReference                     AS applicationReference,\n",
+					"AH.applicationDate                          AS applicationDate,\n",
+					"AH.applicationDecision                      AS applicationDecision,\n",
+					"AH.applicationDecisionDate                  AS applicationDecisionDate,\n",
+					"AH.caseSubmissionDueDate                    AS caseSubmissionDueDate,\n",
+					"AH.siteAddressLine1                         AS siteAddressLine1,\n",
+					"AH.siteAddressLine2                         AS siteAddressLine2,\n",
+					"AH.siteAddressTown                          AS siteAddressTown,\n",
+					"AH.siteAddressCounty                        AS siteAddressCounty,\n",
+					"AH.siteAddressPostcode                      AS siteAddressPostcode,\n",
+					"cast(AH.siteAccessDetails as string)        AS siteAccessDetails,\n",
+					"cast(AH.siteSafetyDetails as string)        AS siteSafetyDetails,\n",
+					"CAST(AH.siteAreaSquareMetres AS BOOLEAN)    AS siteAreaSquareMetres,\n",
+					"CAST(AH.floorSpaceSquareMetres AS NUMERIC)  AS floorSpaceSquareMetres,\n",
+					"CAST(AH.isCorrectAppealType AS BOOLEAN)     AS isCorrectAppealType,\n",
+					"CAST(AH.isGreenBelt AS BOOLEAN)             AS isGreenBelt,\n",
+					"CAST(AH.inConservationArea AS BOOLEAN)      AS inConservationArea,\n",
+					"CAST(AH.ownsAllLand AS BOOLEAN)             AS ownsAllLand,\n",
+					"CAST(AH.ownsSomeLand AS BOOLEAN)            AS ownsSomeLand,\n",
+					"AH.knowsOtherOwners                         AS knowsOtherOwners,\n",
+					"AH.knowsAllOwners                           AS knowsAllOwners,\n",
+					"CAST(AH.advertisedAppeal AS BOOLEAN)        AS advertisedAppeal,\n",
+					"cast(AH.notificationMethod as string)       AS notificationMethod,\n",
+					"CAST(AH.ownersInformed AS BOOLEAN)          AS ownersInformed,\n",
+					"AH.originalDevelopmentDescription           AS originalDevelopmentDescription,\n",
+					"CAST(AH.changedDevelopmentDescription       AS BOOLEAN) AS changedDevelopmentDescription,\n",
+					"AH.newConditionDetails                      AS newConditionDetails,\n",
+					"CAST(AH.nearbyCaseReferences AS STRING)     AS nearbyCaseReferences,\n",
+					"CAST(AH.neighbouringSiteAddresses AS STRING) AS neighbouringSiteAddresses,\n",
+					"CAST(AH.affectedListedBuildingNumbers AS STRING)   AS affectedListedBuildingNumbers,\n",
+					"CAST(AH.changedListedBuildingNumbers AS STRING)             AS changedListedBuildingNumbers,\n",
+					"CAST(AH.appellantCostsAppliedFor AS BOOLEAN) AS appellantCostsAppliedFor,\n",
+					"CAST(AH.lpaCostsAppliedFor AS BOOLEAN)       AS lpaCostsAppliedFor,\n",
+					"AH.agriculturalHolding                       AS agriculturalHolding,\n",
+					"AH.tenantAgriculturalHolding                 AS tenantAgriculturalHolding,\n",
+					"AH.otherTenantsAgriculturalHolding           AS otherTenantsAgriculturalHolding,\n",
+					"AH.informedTenantsAgriculturalHolding        AS informedTenantsAgriculturalHolding,\n",
+					"AH.appellantProcedurePreference              AS appellantProcedurePreference,\n",
+					"AH.appellantProcedurePreferenceDetails       AS appellantProcedurePreferenceDetails,\n",
+					"AH.appellantProcedurePreferenceDuration      AS appellantProcedurePreferenceDuration,\n",
+					"AH.appellantProcedurePreferenceWitnessCount  AS appellantProcedurePreferenceWitnessCount,\n",
+					"AH.statusPlanningObligation                  AS statusPlanningObligation,\n",
+					"AH.affectsScheduledMonument                  AS affectsScheduledMonument,\n",
+					"AH.hasProtectedSpecies                       AS hasProtectedSpecies,\n",
+					"AH.isAonbNationalLandscape                   AS isAonbNationalLandscape,\n",
+					"CAST(AH.designatedSitesNames AS STRING)       AS designatedSitesNames,\n",
+					"AH.isGypsyOrTravellerSite                    AS isGypsyOrTravellerSite,\n",
+					"AH.isPublicRightOfWay                        AS isPublicRightOfWay,\n",
+					"AH.eiaEnvironmentalImpactSchedule            AS eiaEnvironmentalImpactSchedule,\n",
+					"AH.eiaDevelopmentDescription                 AS eiaDevelopmentDescription,\n",
+					"AH.eiaSensitiveAreaDetails                   AS eiaSensitiveAreaDetails,\n",
+					"AH.eiaColumnTwoThreshold                     AS eiaColumnTwoThreshold,\n",
+					"AH.eiaScreeningOpinion                       AS eiaScreeningOpinion,\n",
+					"AH.eiaRequiresEnvironmentalStatement         AS eiaRequiresEnvironmentalStatement,\n",
+					"AH.eiaCompletedEnvironmentalStatement        AS eiaCompletedEnvironmentalStatement,\n",
+					"AH.hasStatutoryConsultees                    AS hasStatutoryConsultees,\n",
+					"AH.consultedBodiesDetails                    AS consultedBodiesDetails,\n",
+					"AH.hasInfrastructureLevy                     AS hasInfrastructureLevy,\n",
+					"AH.isInfrastructureLevyFormallyAdopted       AS isInfrastructureLevyFormallyAdopted,\n",
+					"AH.infrastructureLevyAdoptedDate             AS infrastructureLevyAdoptedDate,\n",
+					"AH.infrastructureLevyExpectedDate            AS infrastructureLevyExpectedDate,\n",
+					"AH.lpaProcedurePreference                    AS lpaProcedurePreference,\n",
+					"AH.lpaProcedurePreferenceDetails             AS lpaProcedurePreferenceDetails,\n",
+					"AH.lpaProcedurePreferenceDuration            AS lpaProcedurePreferenceDuration,\n",
+					"AH.caseworkReason                            AS caseworkReason,\n",
+					"AH.developmentType                           AS developmentType,\n",
+					"AH.importantInformation                      AS importantInformation, \n",
+					"AH.jurisdiction                              AS jurisdiction,\n",
+					"AH.redeterminedIndicator                     AS redeterminedIndicator,\n",
+					"AH.dateCostsReportDespatched                 AS dateCostsReportDespatched, \n",
+					"AH.dateNotRecoveredOrDerecovered             AS dateNotRecoveredOrDerecovered,\n",
+					"AH.dateRecovered                             AS dateRecovered,\n",
+					"AH.originalCaseDecisionDate                  AS originalCaseDecisionDate,\n",
+					"AH.targetDate                                AS targetDate,\n",
+					"AH.appellantCommentsSubmittedDate            AS appellantCommentsSubmittedDate,\n",
+					"AH.appellantStatementSubmittedDate           AS appellantStatementSubmittedDate,\n",
+					"AH.appellantProofsSubmittedDate              AS appellantProofsSubmittedDate,\n",
+					"AH.finalCommentsDueDate                      AS finalCommentsDueDate,\n",
+					"AH.interestedPartyRepsDueDate                AS interestedPartyRepsDueDate,\n",
+					"AH.lpaCommentsSubmittedDate                  AS lpaCommentsSubmittedDate,\n",
+					"AH.lpaProofsSubmittedDate                    AS lpaProofsSubmittedDate,\n",
+					"AH.lpaStatementSubmittedDate                 AS lpaStatementSubmittedDate,\n",
+					"AH.proofsOfEvidenceDueDate                   AS proofsOfEvidenceDueDate,\n",
+					"AH.siteNoticesSentDate                       AS siteNoticesSentDate,\n",
+					"AH.statementDueDate                          AS statementDueDate,\n",
+					"AH.reasonForNeighbourVisits                  AS reasonForNeighbourVisits, \n",
+					"AH.numberOfResidencesNetChange               AS numberOfResidencesNetChange,\n",
+					"AH.siteGridReferenceEasting                  AS siteGridReferenceEasting,\n",
+					"AH.siteGridReferenceNorthing                 AS siteGridReferenceNorthing,\n",
+					"AH.siteViewableFromRoad                      AS siteViewableFromRoad,\n",
+					"AH.siteWithinSSSI                            AS siteWithinSSSI,\n",
+					"AH.typeOfPlanningApplication                 AS typeOfPlanningApplication,\n",
+					"AH.IngestionDate                             AS IngestionDate,\n",
+					"AH.ValidTo                                   AS ValidTo,\n",
+					"AH.IsActive                                  AS IsActive\n",
+					"FROM odw_harmonised_db.sb_appeal_s78 AS AH\n",
+					"where AH.lpaCode NOT in ('Q9999', 'Q1111')"
+				],
+				"execution_count": 24
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"spark.sql(f\"drop table if exists odw_curated_db.appeals_s78_curated_mipins;\")"
+				],
+				"execution_count": 25
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"from pyspark.sql import SparkSession\n",
+					"spark = SparkSession.builder.getOrCreate()\n",
+					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeals_s78_curated_mipins\")\n",
+					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeals_s78_curated_mipins\")"
+				],
+				"execution_count": 26
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
+					"collapsed": false
+				},
+				"source": [
+					"%%sql\n",
+					"select * from odw_curated_db.appeals_s78_curated_mipins"
+				],
+				"execution_count": 27
+			}
+		]
+	}
+}

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -132,7 +132,7 @@
 				"typeProperties": {
 					"variableName": "RowCount_s78",
 					"value": {
-						"value": "@activity('copy_appeals_s78_cuarted_mipins').output",
+						"value": "@activity('copy_appeals_s78_cuarted_mipins').output.rowscopied",
 						"type": "Expression"
 					}
 				}
@@ -167,7 +167,7 @@
 							"type": "DateTime"
 						},
 						"source_system": {
-							"value": "Back Office - s78",
+							"value": "Back Office-s78",
 							"type": "String"
 						}
 					}

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -112,8 +112,37 @@
 						"type": "DatasetReference"
 					}
 				}
+			},
+			{
+				"name": "Record_Count",
+				"type": "SetVariable",
+				"dependsOn": [
+					{
+						"activity": "copy_appeals_s78_cuarted_mipins",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"variableName": "RowCount_s78",
+					"value": {
+						"value": "@activity('copy_appeals_s78_cuarted_mipins').output",
+						"type": "Expression"
+					}
+				}
 			}
 		],
+		"variables": {
+			"RowCount_s78": {
+				"type": "Integer"
+			}
+		},
 		"folder": {
 			"name": "mipins"
 		},

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -5,7 +5,14 @@
 			{
 				"name": "copy_appeals_s78_cuarted_mipins",
 				"type": "Copy",
-				"dependsOn": [],
+				"dependsOn": [
+					{
+						"activity": "Lookup-LogStart",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
 				"policy": {
 					"timeout": "0.12:00:00",
 					"retry": 0,
@@ -50,6 +57,61 @@
 						"type": "DatasetReference"
 					}
 				]
+			},
+			{
+				"name": "Lookup-LogStart",
+				"type": "Lookup",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"source": {
+						"type": "AzureSqlSource",
+						"sqlReaderStoredProcedureName": "[Audit].[usp_addETLLog]",
+						"storedProcedureParameters": {
+							"Description": {
+								"type": "String",
+								"value": "appeal_s78_curated_mipins_pipeline_started"
+							},
+							"ErrorMessage": {
+								"type": "String",
+								"value": null
+							},
+							"LogType": {
+								"type": "String",
+								"value": "1"
+							},
+							"Param1Value": {
+								"type": "String",
+								"value": null
+							},
+							"RowCount": {
+								"type": "Int32",
+								"value": null
+							},
+							"RunId": {
+								"type": "Int32",
+								"value": null
+							},
+							"Source": {
+								"type": "String",
+								"value": "appeal_s78"
+							}
+						},
+						"queryTimeout": "02:00:00",
+						"partitionOption": "None"
+					},
+					"dataset": {
+						"referenceName": "Lookup_LogStart",
+						"type": "DatasetReference"
+					}
+				}
 			}
 		],
 		"folder": {

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -176,11 +176,165 @@
 					"referenceName": "ls_sql_mipins",
 					"type": "LinkedServiceReference"
 				}
+			},
+			{
+				"name": "Sp_log_success",
+				"type": "SqlServerStoredProcedure",
+				"dependsOn": [
+					{
+						"activity": "SP_update dim_source_system",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"storedProcedureName": "[Audit].[usp_addETLLog]",
+					"storedProcedureParameters": {
+						"Description": {
+							"value": "appeal_s78_curated_mipins_pipeline_completed",
+							"type": "String"
+						},
+						"ErrorMessage": {
+							"value": null,
+							"type": "String"
+						},
+						"LogType": {
+							"value": "2",
+							"type": "String"
+						},
+						"Param1Value": {
+							"value": null,
+							"type": "String"
+						},
+						"RowCount": {
+							"value": {
+								"value": "@variables('RowCount_s78')",
+								"type": "Expression"
+							},
+							"type": "Int32"
+						},
+						"RunId": {
+							"value": {
+								"value": "@activity('Lookup-LogStart').output.firstRow.Runid",
+								"type": "Expression"
+							},
+							"type": "Int32"
+						},
+						"Source": {
+							"value": "appeal_s78",
+							"type": "String"
+						}
+					}
+				},
+				"linkedServiceName": {
+					"referenceName": "ls_sql_mipins",
+					"type": "LinkedServiceReference"
+				}
+			},
+			{
+				"name": "Error",
+				"type": "SetVariable",
+				"dependsOn": [
+					{
+						"activity": "SP_update dim_source_system",
+						"dependencyConditions": [
+							"Failed",
+							"Skipped"
+						]
+					}
+				],
+				"policy": {
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"variableName": "Error_s78",
+					"value": {
+						"value": "@replace(concat(activity('Lookup-LogStart').Error?.message,'|',activity('copy_appeals_s78_cuarted_mipins').Error?.message,'|',activity('SP_update dim_source_system').Error?.message),'|','')",
+						"type": "Expression"
+					}
+				}
+			},
+			{
+				"name": "Sp_log_failed",
+				"type": "SqlServerStoredProcedure",
+				"dependsOn": [
+					{
+						"activity": "Error",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"storedProcedureName": "[Audit].[usp_addETLLog]",
+					"storedProcedureParameters": {
+						"Description": {
+							"value": "appeal_s78_curated_mipins_pipeline_failed",
+							"type": "String"
+						},
+						"ErrorMessage": {
+							"value": {
+								"value": "@variables('Error_s78')",
+								"type": "Expression"
+							},
+							"type": "String"
+						},
+						"LogType": {
+							"value": "2",
+							"type": "String"
+						},
+						"Param1Value": {
+							"value": null,
+							"type": "String"
+						},
+						"RowCount": {
+							"value": null,
+							"type": "Int32"
+						},
+						"RunId": {
+							"value": {
+								"value": "@activity('Lookup-LogStart').output.firstRow.Runid",
+								"type": "Expression"
+							},
+							"type": "Int32"
+						},
+						"Source": {
+							"value": "appeal_s78",
+							"type": "String"
+						}
+					}
+				},
+				"linkedServiceName": {
+					"referenceName": "ls_sql_mipins",
+					"type": "LinkedServiceReference"
+				}
 			}
 		],
 		"variables": {
 			"RowCount_s78": {
 				"type": "Integer"
+			},
+			"Error_s78": {
+				"type": "String"
 			}
 		},
 		"folder": {

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -1,0 +1,38 @@
+{
+	"name": "pln_copy_appeal_s78_curated_mipins",
+	"properties": {
+		"activities": [
+			{
+				"name": "copy_appeals_s78_cuarted_mipins",
+				"type": "Copy",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"source": {
+						"type": "AzureSqlSource",
+						"queryTimeout": "02:00:00",
+						"partitionOption": "None"
+					},
+					"enableStaging": false
+				},
+				"inputs": [
+					{
+						"referenceName": "appeals_s78_curated_mipins",
+						"type": "DatasetReference"
+					}
+				]
+			}
+		],
+		"folder": {
+			"name": "mipins"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -20,11 +20,33 @@
 						"queryTimeout": "02:00:00",
 						"partitionOption": "None"
 					},
-					"enableStaging": false
+					"sink": {
+						"type": "AzureSqlSink",
+						"preCopyScript": "drop table if exists odw.appeals_s78_curated_mipins",
+						"writeBehavior": "insert",
+						"sqlWriterUseTableLock": false,
+						"tableOption": "autoCreate",
+						"disableMetricsCollection": false
+					},
+					"enableStaging": false,
+					"translator": {
+						"type": "TabularTranslator",
+						"typeConversion": true,
+						"typeConversionSettings": {
+							"allowDataTruncation": true,
+							"treatBooleanAsNumber": false
+						}
+					}
 				},
 				"inputs": [
 					{
 						"referenceName": "appeals_s78_curated_mipins",
+						"type": "DatasetReference"
+					}
+				],
+				"outputs": [
+					{
+						"referenceName": "appeals_s78_mipins",
 						"type": "DatasetReference"
 					}
 				]

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -136,6 +136,46 @@
 						"type": "Expression"
 					}
 				}
+			},
+			{
+				"name": "SP_update dim_source_system",
+				"type": "SqlServerStoredProcedure",
+				"dependsOn": [
+					{
+						"activity": "Record_Count",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"storedProcedureName": "[Live].[upd_dim_source_system]",
+					"storedProcedureParameters": {
+						"refresh_date": {
+							"value": {
+								"value": "@utcNow('yyyy-MM-ddTHH:mm:ss.fff')",
+								"type": "Expression"
+							},
+							"type": "DateTime"
+						},
+						"source_system": {
+							"value": "Back Office - s78",
+							"type": "String"
+						}
+					}
+				},
+				"linkedServiceName": {
+					"referenceName": "ls_sql_mipins",
+					"type": "LinkedServiceReference"
+				}
 			}
 		],
 		"variables": {

--- a/workspace/pipeline/pln_curated_mipins.json
+++ b/workspace/pipeline/pln_curated_mipins.json
@@ -241,6 +241,56 @@
 					},
 					"waitOnCompletion": true
 				}
+			},
+			{
+				"name": "appeal_s78_curated_mipins",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "pln_copy_nsip_project_to_mipins",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "appeal_s78_curated_mipins",
+						"type": "NotebookReference"
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "pln_copy_appeal_s78_curated_mipins",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "appeal_s78_curated_mipins",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_copy_appeal_s78_curated_mipins",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true
+				}
 			}
 		],
 		"folder": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
