### PR TITLE
Rel/8 0 4

### DIFF
--- a/workspace/pipeline/pln_post_deployment.json
+++ b/workspace/pipeline/pln_post_deployment.json
@@ -3,7 +3,7 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "rel_8_0_3_hotfix",
+				"name": "rel_8_0_5_pins_inspector",
 				"type": "ExecutePipeline",
 				"dependsOn": [],
 				"policy": {
@@ -12,23 +12,7 @@
 				"userProperties": [],
 				"typeProperties": {
 					"pipeline": {
-						"referenceName": "rel_8_0_3_hotfix",
-						"type": "PipelineReference"
-					},
-					"waitOnCompletion": true
-				}
-			},
-			{
-				"name": "rel_8_0_4_hotfix",
-				"type": "ExecutePipeline",
-				"dependsOn": [],
-				"policy": {
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"pipeline": {
-						"referenceName": "rel_8_0_4_hotfix",
+						"referenceName": "rel_8_0_5_pins_inspector",
 						"type": "PipelineReference"
 					},
 					"waitOnCompletion": true

--- a/workspace/pipeline/rel_8_0_5_pins_inspector.json
+++ b/workspace/pipeline/rel_8_0_5_pins_inspector.json
@@ -1,0 +1,73 @@
+{
+	"name": "rel_8_0_5_pins_inspector",
+	"properties": {
+		"activities": [
+			{
+				"name": "Create PINS Inspector",
+				"description": "Create PINS Inspector",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_harmonised_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "pins-inspector",
+							"type": "string"
+						},
+						"is_servicebus_schema": {
+							"value": "False",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "Ingest PINS Inspector harmonised",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "Create PINS Inspector",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "pins_inspectors",
+						"type": "NotebookReference"
+					},
+					"snapshot": true
+				}
+			}
+		],
+		"folder": {
+			"name": "Releases/8.0.5"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/rel_8_0_5_pins_inspector.json
+++ b/workspace/pipeline/rel_8_0_5_pins_inspector.json
@@ -63,6 +63,36 @@
 					},
 					"snapshot": true
 				}
+			},
+			{
+				"name": "py_delete_table",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_delete_table",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_harmonised_db",
+							"type": "string"
+						},
+						"table_name": {
+							"value": "pins_inspectors",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
 			}
 		],
 		"folder": {

--- a/workspace/pipeline/rel_8_0_5_pins_inspector.json
+++ b/workspace/pipeline/rel_8_0_5_pins_inspector.json
@@ -3,8 +3,8 @@
 	"properties": {
 		"activities": [
 			{
-				"name": "Create PINS Inspector",
-				"description": "Create PINS Inspector",
+				"name": "Create PINS Inspector Hrm",
+				"description": "Create PINS Inspector Hrm",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {
@@ -42,13 +42,13 @@
 				"type": "SynapseNotebook",
 				"dependsOn": [
 					{
-						"activity": "Create PINS Inspector",
+						"activity": "Create PINS Inspector Hrm",
 						"dependencyConditions": [
 							"Succeeded"
 						]
 					},
 					{
-						"activity": "Create PINS Inspector_copy1",
+						"activity": "Create PINS Inspector Std",
 						"dependencyConditions": [
 							"Succeeded"
 						]
@@ -101,8 +101,8 @@
 				}
 			},
 			{
-				"name": "Create PINS Inspector_copy1",
-				"description": "Create PINS Inspector",
+				"name": "Create PINS Inspector Std",
+				"description": "Create PINS Inspector Std",
 				"type": "SynapseNotebook",
 				"dependsOn": [],
 				"policy": {

--- a/workspace/pipeline/rel_8_0_5_pins_inspector.json
+++ b/workspace/pipeline/rel_8_0_5_pins_inspector.json
@@ -46,6 +46,12 @@
 						"dependencyConditions": [
 							"Succeeded"
 						]
+					},
+					{
+						"activity": "Create PINS Inspector_copy1",
+						"dependencyConditions": [
+							"Succeeded"
+						]
 					}
 				],
 				"policy": {
@@ -84,6 +90,71 @@
 					"parameters": {
 						"db_name": {
 							"value": "odw_harmonised_db",
+							"type": "string"
+						},
+						"table_name": {
+							"value": "pins_inspectors",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "Create PINS Inspector_copy1",
+				"description": "Create PINS Inspector",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_standardised_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "pins-inspector",
+							"type": "string"
+						},
+						"is_servicebus_schema": {
+							"value": "False",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "py_delete_table_copy1",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_delete_table",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_standardised_db",
 							"type": "string"
 						},
 						"table_name": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
