### PR TITLE
feat/theodw-1627

### DIFF
--- a/workspace/notebook/py_create_random_sb_data.json
+++ b/workspace/notebook/py_create_random_sb_data.json
@@ -20,12 +20,12 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4f380eed-fb36-4f94-8c3c-6f876eb2a423"
+				"spark.autotune.trackingId": "91e04e74-de7c-46ee-b1d4-02a83b96f94d"
 			}
 		},
 		"metadata": {
 			"saveOutput": true,
-			"enableDebugMode": false,
+			"enableDebugMode": true,
 			"kernelspec": {
 				"name": "synapse_pyspark",
 				"display_name": "Synapse PySpark"
@@ -63,7 +63,7 @@
 					"from pyspark.sql.functions import lit, monotonically_increasing_id, col, when\n",
 					"from pyspark.sql import Row, DataFrame"
 				],
-				"execution_count": 7
+				"execution_count": 168
 			},
 			{
 				"cell_type": "code",
@@ -73,11 +73,11 @@
 					]
 				},
 				"source": [
-					"entity_name = \"service-user\"\n",
-					"primary_key = \"id\"\n",
-					"num_records = 10"
+					"entity_name = \"s51-advice\"\n",
+					"primary_key = \"adviceId\"\n",
+					"num_records = 1000"
 				],
-				"execution_count": 8
+				"execution_count": 169
 			},
 			{
 				"cell_type": "markdown",
@@ -106,17 +106,13 @@
 					"            existing_ids.add(new_id)\n",
 					"    return new_uuids\n",
 					"    \n",
-					"def generate_random_value(field_name: str, field_type):\n",
+					"def generate_random_value(field_name: str, field_type, json_field):\n",
 					"    \"\"\"Generate a random value based on the field's data type.\"\"\"\n",
-					"    if field_name == \"message_type\":\n",
-					"        return \"Create\"\n",
-					"    if field_name == \"message_id\":\n",
-					"        return faker.unique.uuid4()\n",
-					"    if field_name == \"IsActive\":\n",
-					"        return random.choice([\"Y\"])\n",
 					"    if field_name == \"caseReference\":\n",
 					"        return f\"TR{random.randint(1, 10**6)}\"\n",
 					"    if isinstance(field_type, StringType):\n",
+					"        if 'enum' in json_field:\n",
+					"            return random.choice(json_field['enum'])\n",
 					"        return faker.word()\n",
 					"    elif isinstance(field_type, LongType):\n",
 					"        return random.randint(1, 10**9)\n",
@@ -132,37 +128,53 @@
 					"        return datetime.now().date() - timedelta(days=random.randint(0, 365))\n",
 					"    elif isinstance(field_type, BooleanType):\n",
 					"        return random.choice([True, False])\n",
+					"    elif isinstance(field_type, ArrayType):\n",
+					"        num_array_elements = random.randint(0, 10)\n",
+					"        if isinstance(field_type.elementType, StringType):\n",
+					"            return [faker.word() for _ in range(num_array_elements)]\n",
+					"        else:\n",
+					"            return []\n",
 					"    else:\n",
 					"        return None\n",
 					"\n",
-					"def generate_random_row(schema):\n",
+					"def generate_random_row(spark_schema, json_schema):\n",
 					"    \"\"\"Generate a random row of data based on the schema.\"\"\"\n",
-					"    return {field.name: generate_random_value(field.name, field.dataType) for field in schema.fields}\n",
+					"    return {field.name: generate_random_value(field.name, field.dataType, json_schema[field.name]) for field in schema.fields}\n",
 					"\n",
-					"def generate_random_dataframe(schema: StructType, num_records: int):\n",
+					"def generate_random_dataframe(spark_schema: StructType, json_schema: dict, num_records: int):\n",
 					"    \"\"\"Generate a PySpark DataFrame with random data based on the schema.\"\"\"\n",
 					"    # Generate random data\n",
-					"    data = [generate_random_row(schema) for _ in range(num_records)]\n",
-					"    \n",
+					"    data = [generate_random_row(spark_schema, json_schema) for _ in range(num_records)]\n",
+					"\n",
+					"    for row in data:\n",
+					"        row['EventType'] = 'Create'\n",
+					"        row['sourceSystem'] = 'ODT'\n",
+					"        row['message_id'] = faker.unique.uuid4()\n",
+					"\n",
 					"    # Create DataFrame\n",
-					"    return spark.createDataFrame(data, schema=schema)"
+					"    return spark.createDataFrame(data)"
 				],
-				"execution_count": 9
+				"execution_count": 170
 			},
 			{
 				"cell_type": "code",
 				"source": [
-					"schema = StructType.fromJson(json.loads(mssparkutils.notebook.run(path=\"service-bus/py_create_spark_schema\", \n",
-					"                            arguments={\"entity_name\": entity_name, \"db_name\": 'odw_curated_db'})))"
+					"spark_schema = StructType.fromJson(json.loads(mssparkutils.notebook.run(path=\"service-bus/py_create_spark_schema\", \n",
+					"                            arguments={\"entity_name\": entity_name, \"db_name\": 'odw_curated_db'})))\n",
+					"\n",
+					"json_schema = mssparkutils.notebook.run(path=\"service-bus/py_create_spark_schema\", \n",
+					"                            arguments={\"entity_name\": entity_name, \"db_name\": 'odw_curated_db', 'return_json_schema': True})\n",
+					"json_schema = json.loads(json_schema.replace(\"'\", '\"').replace(\"None\", \"null\").replace(\"True\", \"true\").replace(\"False\", \"false\"))\n",
+					""
 				],
-				"execution_count": 10
+				"execution_count": 171
 			},
 			{
 				"cell_type": "code",
 				"source": [
-					"df = generate_random_dataframe(schema, num_records)"
+					"df = generate_random_dataframe(spark_schema, json_schema['properties'], num_records)"
 				],
-				"execution_count": 11
+				"execution_count": 172
 			},
 			{
 				"cell_type": "code",
@@ -172,7 +184,27 @@
 				"source": [
 					"display(df)"
 				],
-				"execution_count": 12
+				"execution_count": 173
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"formatted_data = [\n",
+					"    {\n",
+					"        'Body': str({k: v for k, v in row.asDict().items() if k != 'EventType'}),\n",
+					"        'UserProperties': {'type': row['EventType']}\n",
+					"    }\n",
+					"    for row in df.collect()\n",
+					"]"
+				],
+				"execution_count": 174
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"mssparkutils.notebook.exit(formatted_data)"
+				],
+				"execution_count": 175
 			}
 		]
 	}

--- a/workspace/notebook/py_create_random_sb_data.json
+++ b/workspace/notebook/py_create_random_sb_data.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "37a961b6-f8f6-4aab-ae76-6f18ed356283"
+				"spark.autotune.trackingId": "c53e86e1-0807-44e7-bf15-d26f2ad32b53"
 			}
 		},
 		"metadata": {
@@ -63,7 +63,7 @@
 					"from pyspark.sql.functions import lit, monotonically_increasing_id, col, when\n",
 					"from pyspark.sql import Row, DataFrame"
 				],
-				"execution_count": 176
+				"execution_count": 190
 			},
 			{
 				"cell_type": "code",
@@ -74,10 +74,10 @@
 				},
 				"source": [
 					"entity_name = \"s51-advice\"\n",
-					"primary_key = \"adviceId\"\n",
-					"num_records = 100"
+					"# primary_key = \"\"\n",
+					"num_records = 10"
 				],
-				"execution_count": 177
+				"execution_count": 191
 			},
 			{
 				"cell_type": "markdown",
@@ -151,10 +151,16 @@
 					"        row['sourceSystem'] = 'ODT'\n",
 					"        row['message_id'] = faker.unique.uuid4()\n",
 					"\n",
+					"    # randomly change the eventType to 'Update' for 10% rows\n",
+					"    num_elements_to_update = max(1, int(len(data) * 0.1))\n",
+					"    indices_to_update = random.sample(range(len(data)), num_elements_to_update)\n",
+					"    for idx in indices_to_update:\n",
+					"        data[idx]['EventType'] = 'Update'\n",
+					"\n",
 					"    # Create DataFrame\n",
 					"    return spark.createDataFrame(data)"
 				],
-				"execution_count": 178
+				"execution_count": 202
 			},
 			{
 				"cell_type": "code",
@@ -167,15 +173,18 @@
 					"json_schema = json.loads(json_schema.replace(\"'\", '\"').replace(\"None\", \"null\").replace(\"True\", \"true\").replace(\"False\", \"false\"))\n",
 					"json_schema = json_schema['properties']"
 				],
-				"execution_count": 179
+				"execution_count": 193
 			},
 			{
 				"cell_type": "code",
+				"metadata": {
+					"collapsed": false
+				},
 				"source": [
 					"df = generate_random_dataframe(spark_schema, json_schema, num_records)\n",
-					"# display(df)"
+					"display(df)"
 				],
-				"execution_count": 180
+				"execution_count": 203
 			},
 			{
 				"cell_type": "code",
@@ -188,14 +197,14 @@
 					"    for row in df.collect()\n",
 					"]"
 				],
-				"execution_count": 181
+				"execution_count": 195
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"mssparkutils.notebook.exit(formatted_data)"
 				],
-				"execution_count": 182
+				"execution_count": 196
 			}
 		]
 	}

--- a/workspace/notebook/py_create_random_sb_data.json
+++ b/workspace/notebook/py_create_random_sb_data.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "91e04e74-de7c-46ee-b1d4-02a83b96f94d"
+				"spark.autotune.trackingId": "37a961b6-f8f6-4aab-ae76-6f18ed356283"
 			}
 		},
 		"metadata": {
@@ -63,7 +63,7 @@
 					"from pyspark.sql.functions import lit, monotonically_increasing_id, col, when\n",
 					"from pyspark.sql import Row, DataFrame"
 				],
-				"execution_count": 168
+				"execution_count": 176
 			},
 			{
 				"cell_type": "code",
@@ -75,9 +75,9 @@
 				"source": [
 					"entity_name = \"s51-advice\"\n",
 					"primary_key = \"adviceId\"\n",
-					"num_records = 1000"
+					"num_records = 100"
 				],
-				"execution_count": 169
+				"execution_count": 177
 			},
 			{
 				"cell_type": "markdown",
@@ -154,7 +154,7 @@
 					"    # Create DataFrame\n",
 					"    return spark.createDataFrame(data)"
 				],
-				"execution_count": 170
+				"execution_count": 178
 			},
 			{
 				"cell_type": "code",
@@ -165,26 +165,17 @@
 					"json_schema = mssparkutils.notebook.run(path=\"service-bus/py_create_spark_schema\", \n",
 					"                            arguments={\"entity_name\": entity_name, \"db_name\": 'odw_curated_db', 'return_json_schema': True})\n",
 					"json_schema = json.loads(json_schema.replace(\"'\", '\"').replace(\"None\", \"null\").replace(\"True\", \"true\").replace(\"False\", \"false\"))\n",
-					""
+					"json_schema = json_schema['properties']"
 				],
-				"execution_count": 171
+				"execution_count": 179
 			},
 			{
 				"cell_type": "code",
 				"source": [
-					"df = generate_random_dataframe(spark_schema, json_schema['properties'], num_records)"
+					"df = generate_random_dataframe(spark_schema, json_schema, num_records)\n",
+					"# display(df)"
 				],
-				"execution_count": 172
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"collapsed": false
-				},
-				"source": [
-					"display(df)"
-				],
-				"execution_count": 173
+				"execution_count": 180
 			},
 			{
 				"cell_type": "code",
@@ -197,14 +188,14 @@
 					"    for row in df.collect()\n",
 					"]"
 				],
-				"execution_count": 174
+				"execution_count": 181
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"mssparkutils.notebook.exit(formatted_data)"
 				],
-				"execution_count": 175
+				"execution_count": 182
 			}
 		]
 	}

--- a/workspace/notebook/py_create_random_sb_data.json
+++ b/workspace/notebook/py_create_random_sb_data.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c53e86e1-0807-44e7-bf15-d26f2ad32b53"
+				"spark.autotune.trackingId": "443f6c26-b5e6-448e-a113-f9ef8e974a97"
 			}
 		},
 		"metadata": {
@@ -63,7 +63,7 @@
 					"from pyspark.sql.functions import lit, monotonically_increasing_id, col, when\n",
 					"from pyspark.sql import Row, DataFrame"
 				],
-				"execution_count": 190
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -73,11 +73,11 @@
 					]
 				},
 				"source": [
-					"entity_name = \"s51-advice\"\n",
+					"entity_name = \"\"\n",
 					"# primary_key = \"\"\n",
-					"num_records = 10"
+					"num_records = 100"
 				],
-				"execution_count": 191
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -139,7 +139,7 @@
 					"\n",
 					"def generate_random_row(spark_schema, json_schema):\n",
 					"    \"\"\"Generate a random row of data based on the schema.\"\"\"\n",
-					"    return {field.name: generate_random_value(field.name, field.dataType, json_schema[field.name]) for field in schema.fields}\n",
+					"    return {field.name: generate_random_value(field.name, field.dataType, json_schema[field.name]) for field in spark_schema.fields}\n",
 					"\n",
 					"def generate_random_dataframe(spark_schema: StructType, json_schema: dict, num_records: int):\n",
 					"    \"\"\"Generate a PySpark DataFrame with random data based on the schema.\"\"\"\n",
@@ -156,11 +156,16 @@
 					"    indices_to_update = random.sample(range(len(data)), num_elements_to_update)\n",
 					"    for idx in indices_to_update:\n",
 					"        data[idx]['EventType'] = 'Update'\n",
+					"    \n",
+					"    # randomly change the eventType to 'Delete' for 10% rows\n",
+					"    indices_to_update = random.sample(range(len(data)), num_elements_to_update)\n",
+					"    for idx in indices_to_update:\n",
+					"        data[idx]['EventType'] = 'Delete'\n",
 					"\n",
 					"    # Create DataFrame\n",
 					"    return spark.createDataFrame(data)"
 				],
-				"execution_count": 202
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -173,7 +178,7 @@
 					"json_schema = json.loads(json_schema.replace(\"'\", '\"').replace(\"None\", \"null\").replace(\"True\", \"true\").replace(\"False\", \"false\"))\n",
 					"json_schema = json_schema['properties']"
 				],
-				"execution_count": 193
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -184,7 +189,7 @@
 					"df = generate_random_dataframe(spark_schema, json_schema, num_records)\n",
 					"display(df)"
 				],
-				"execution_count": 203
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -197,14 +202,14 @@
 					"    for row in df.collect()\n",
 					"]"
 				],
-				"execution_count": 195
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"mssparkutils.notebook.exit(formatted_data)"
 				],
-				"execution_count": 196
+				"execution_count": 14
 			}
 		]
 	}

--- a/workspace/notebook/py_create_random_sb_data.json
+++ b/workspace/notebook/py_create_random_sb_data.json
@@ -1,0 +1,157 @@
+{
+	"name": "py_create_random_sb_data",
+	"properties": {
+		"folder": {
+			"name": "utils"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "9a01f006-ac1c-4f61-b8f0-aa2e124f08cc"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "python"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "code",
+				"source": [
+					"import pprint\n",
+					"import json\n",
+					"from pyspark.sql.types import *\n",
+					"import random\n",
+					"from datetime import datetime, timedelta\n",
+					"from faker import Faker\n",
+					"from pyspark.sql.functions import lit, monotonically_increasing_id, col, when\n",
+					"from pyspark.sql import Row, DataFrame"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"tags": [
+						"parameters"
+					]
+				},
+				"source": [
+					"entity_name = \"nsip-subscription\"\n",
+					"primary_key = \"subscriptionId\"\n",
+					"num_records = 10"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"schema = StructType.fromJson(json.loads(mssparkutils.notebook.run(path=\"service-bus/py_create_spark_schema\", \n",
+					"                            arguments={\"entity_name\": entity_name, \"db_name\": 'odw_curated_db'})))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Functions to generate a DataFrame with random values"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"faker = Faker()\n",
+					"\n",
+					"def generate_unique_uuids(existing_ids, count):\n",
+					"    new_uuids = []\n",
+					"    while len(new_uuids) < count:\n",
+					"        new_id = faker.unique.uuid4()\n",
+					"        if new_id not in existing_ids:\n",
+					"            new_uuids.append(new_id)\n",
+					"            existing_ids.add(new_id)\n",
+					"    return new_uuids\n",
+					"    \n",
+					"def generate_random_value(field_name: str, field_type):\n",
+					"    \"\"\"Generate a random value based on the field's data type.\"\"\"\n",
+					"    if field_name == \"message_type\":\n",
+					"        return \"Create\"\n",
+					"    if field_name == \"message_id\":\n",
+					"        return faker.unique.uuid4()\n",
+					"    if field_name == \"IsActive\":\n",
+					"        return random.choice([\"Y\"])\n",
+					"    if field_name == \"caseReference\":\n",
+					"        return f\"TR{random.randint(1, 10**6)}\"\n",
+					"    if isinstance(field_type, StringType):\n",
+					"        return faker.word()\n",
+					"    elif isinstance(field_type, LongType):\n",
+					"        return random.randint(1, 10**9)\n",
+					"    elif isinstance(field_type, IntegerType):\n",
+					"        return random.randint(1, 10**5)\n",
+					"    elif isinstance(field_type, DoubleType):\n",
+					"        return random.uniform(1.0, 1000.0)\n",
+					"    elif isinstance(field_type, FloatType):\n",
+					"        return random.uniform(1.0, 100.0)\n",
+					"    elif isinstance(field_type, TimestampType):\n",
+					"        return datetime.now() - timedelta(seconds=random.randint(0, 86400 * 365))\n",
+					"    elif isinstance(field_type, DateType):\n",
+					"        return datetime.now().date() - timedelta(days=random.randint(0, 365))\n",
+					"    elif isinstance(field_type, BooleanType):\n",
+					"        return random.choice([True, False])\n",
+					"    else:\n",
+					"        return None\n",
+					"\n",
+					"def generate_random_row(schema):\n",
+					"    \"\"\"Generate a random row of data based on the schema.\"\"\"\n",
+					"    return {field.name: generate_random_value(field.name, field.dataType) for field in schema.fields}\n",
+					"\n",
+					"def generate_random_dataframe(schema: StructType, num_records: int):\n",
+					"    \"\"\"Generate a PySpark DataFrame with random data based on the schema.\"\"\"\n",
+					"    # Generate random data\n",
+					"    data = [generate_random_row(schema) for _ in range(num_records)]\n",
+					"    \n",
+					"    # Create DataFrame\n",
+					"    return spark.createDataFrame(data, schema=schema)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"df = generate_random_dataframe(std_schema, num_records)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"display(df)"
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/py_create_random_sb_data.json
+++ b/workspace/notebook/py_create_random_sb_data.json
@@ -6,6 +6,10 @@
 		},
 		"nbformat": 4,
 		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw",
+			"type": "BigDataPoolReference"
+		},
 		"sessionProperties": {
 			"driverMemory": "28g",
 			"driverCores": 4,
@@ -16,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "9a01f006-ac1c-4f61-b8f0-aa2e124f08cc"
+				"spark.autotune.trackingId": "4f380eed-fb36-4f94-8c3c-6f876eb2a423"
 			}
 		},
 		"metadata": {
@@ -24,10 +28,25 @@
 			"enableDebugMode": false,
 			"kernelspec": {
 				"name": "synapse_pyspark",
-				"display_name": "python"
+				"display_name": "Synapse PySpark"
 			},
 			"language_info": {
 				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw",
+				"name": "pinssynspodw",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.4",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -44,7 +63,7 @@
 					"from pyspark.sql.functions import lit, monotonically_increasing_id, col, when\n",
 					"from pyspark.sql import Row, DataFrame"
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -54,19 +73,11 @@
 					]
 				},
 				"source": [
-					"entity_name = \"nsip-subscription\"\n",
-					"primary_key = \"subscriptionId\"\n",
+					"entity_name = \"service-user\"\n",
+					"primary_key = \"id\"\n",
 					"num_records = 10"
 				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"source": [
-					"schema = StructType.fromJson(json.loads(mssparkutils.notebook.run(path=\"service-bus/py_create_spark_schema\", \n",
-					"                            arguments={\"entity_name\": entity_name, \"db_name\": 'odw_curated_db'})))"
-				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -136,21 +147,32 @@
 					"    # Create DataFrame\n",
 					"    return spark.createDataFrame(data, schema=schema)"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
 				"source": [
-					"df = generate_random_dataframe(std_schema, num_records)"
+					"schema = StructType.fromJson(json.loads(mssparkutils.notebook.run(path=\"service-bus/py_create_spark_schema\", \n",
+					"                            arguments={\"entity_name\": entity_name, \"db_name\": 'odw_curated_db'})))"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
+				"source": [
+					"df = generate_random_dataframe(schema, num_records)"
+				],
+				"execution_count": 11
+			},
+			{
+				"cell_type": "code",
+				"metadata": {
+					"collapsed": false
+				},
 				"source": [
 					"display(df)"
 				],
-				"execution_count": null
+				"execution_count": 12
 			}
 		]
 	}

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6ab78a86-fcbb-48e9-bf75-c149f23feee4"
+				"spark.autotune.trackingId": "bed51e03-b96b-4b95-b174-c7c0762acead"
 			}
 		},
 		"metadata": {
@@ -89,7 +89,8 @@
 					"entity_name = ''\r\n",
 					"db_name = ''\r\n",
 					"incremental_key = ''\r\n",
-					"is_servicebus_schema: bool = True"
+					"is_servicebus_schema: bool = True\r\n",
+					"return_json_schema = False"
 				],
 				"execution_count": 42
 			},
@@ -395,6 +396,9 @@
 				},
 				"source": [
 					"resolved_schema: dict = resolve_refs(json_schema, json_schema.get('$defs', {}))\r\n",
+					"if return_json_schema:\r\n",
+					"    mssparkutils.notebook.exit(resolved_schema)\r\n",
+					"    \r\n",
 					"spark_schema: StructType = transform_schema(resolved_schema)\r\n",
 					"final_schema: StructType = add_master_columns_to_schema(db_name)"
 				],
@@ -414,7 +418,7 @@
 					}
 				},
 				"source": [
-					"logInfo(f\"Spark schema created\")\n",
+					"logInfo(f\"Spark schema created\")\r\n",
 					"mssparkutils.notebook.exit(final_schema.json())"
 				],
 				"execution_count": null

--- a/workspace/pipeline/pln_publish_random_messages_to_sb.json
+++ b/workspace/pipeline/pln_publish_random_messages_to_sb.json
@@ -22,7 +22,7 @@
 					"parameters": {
 						"entity_name": {
 							"value": {
-								"value": "@variables('entity_name')",
+								"value": "@pipeline().parameters.entity_name",
 								"type": "Expression"
 							},
 							"type": "string"
@@ -67,16 +67,16 @@
 							"type": "Expression"
 						},
 						"topic_name": {
-							"value": "@variables('entity_name')",
+							"value": "@pipeline().parameters.entity_name",
 							"type": "Expression"
 						}
 					}
 				}
 			}
 		],
-		"variables": {
+		"parameters": {
 			"entity_name": {
-				"type": "String"
+				"type": "string"
 			}
 		},
 		"folder": {

--- a/workspace/pipeline/pln_publish_random_messages_to_sb.json
+++ b/workspace/pipeline/pln_publish_random_messages_to_sb.json
@@ -1,0 +1,87 @@
+{
+	"name": "pln_publish_random_messages_to_sb",
+	"properties": {
+		"activities": [
+			{
+				"name": "Create Random Data",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_create_random_sb_data",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"entity_name": {
+							"value": {
+								"value": "@variables('entity_name')",
+								"type": "Expression"
+							},
+							"type": "string"
+						},
+						"num_records": {
+							"value": "10",
+							"type": "int"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "Publish messages to Service Bus",
+				"description": "Runs only for Dev or Test",
+				"type": "ExecutePipeline",
+				"dependsOn": [
+					{
+						"activity": "Create Random Data",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"pipeline": {
+						"referenceName": "pln_publish_to_sb",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true,
+					"parameters": {
+						"service_bus_name": {
+							"value": "@if(equals(pipeline().DataFactory, 'pins-synw-odw-test-uks'), 'pins-sb-odw-test-uks-hk2zun', 'pins-sb-odw-dev-uks-b9rt9m')",
+							"type": "Expression"
+						},
+						"messages": {
+							"value": "@activity('Create Random Data').output.status.Output.result.exitValue",
+							"type": "Expression"
+						},
+						"topic_name": {
+							"value": "@variables('entity_name')",
+							"type": "Expression"
+						}
+					}
+				}
+			}
+		],
+		"variables": {
+			"entity_name": {
+				"type": "String"
+			}
+		},
+		"folder": {
+			"name": "utils"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/pln_publish_random_messages_to_sb.json
+++ b/workspace/pipeline/pln_publish_random_messages_to_sb.json
@@ -67,7 +67,7 @@
 							"type": "Expression"
 						},
 						"topic_name": {
-							"value": "@pipeline().parameters.entity_name",
+							"value": "@pipeline().parameters.topic_name",
 							"type": "Expression"
 						}
 					}
@@ -76,6 +76,9 @@
 		],
 		"parameters": {
 			"entity_name": {
+				"type": "string"
+			},
+			"topic_name": {
 				"type": "string"
 			}
 		},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
