### PR TITLE
Updating pipeline: 0_Listed_Buildings_API_to_RAW

### DIFF
--- a/workspace/pipeline/0_Listed_Buildings_API_to_RAW.json
+++ b/workspace/pipeline/0_Listed_Buildings_API_to_RAW.json
@@ -101,8 +101,8 @@
 				]
 			},
 			{
-				"name": "Listed building failure",
-				"type": "Fail",
+				"name": "Record ListedBuilding Failure",
+				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
 						"activity": "ListedBuilding",
@@ -111,15 +111,73 @@
 						]
 					}
 				],
+				"policy": {
+					"secureInput": false
+				},
 				"userProperties": [],
 				"typeProperties": {
-					"message": "Listed building API feed failed",
-					"errorCode": "500"
+					"pipeline": {
+						"referenceName": "pln_log_to_appins",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true,
+					"parameters": {
+						"Stage": "Fail",
+						"PipelineName": {
+							"value": "@activity('ListedBuilding').Output.pipelineName",
+							"type": "Expression"
+						},
+						"PipelineRunID": {
+							"value": "@activity('ListedBuilding').Output.pipelineRunId",
+							"type": "Expression"
+						},
+						"StartTime": {
+							"value": "@activity('ListedBuilding').ExecutionStartTime",
+							"type": "Expression"
+						},
+						"EndTime": {
+							"value": "@activity('ListedBuilding').ExecutionEndTime",
+							"type": "Expression"
+						},
+						"ErrorMessage": {
+							"value": "@activity('ListedBuilding').Error.message",
+							"type": "Expression"
+						},
+						"StatusMessage": {
+							"value": "@activity('ListedBuilding').Status",
+							"type": "Expression"
+						},
+						"PipelineTriggeredbyPipelineName": {
+							"value": "@activity('ListedBuilding').PipelineName",
+							"type": "Expression"
+						},
+						"PipelineTriggeredbyPipelineRunID": {
+							"value": "@activity('ListedBuilding').PipelineRunId",
+							"type": "Expression"
+						},
+						"PipelineExecutionTimeInSec": {
+							"value": "@activity('ListedBuilding').Duration",
+							"type": "Expression"
+						},
+						"ActivityType": {
+							"value": "@activity('ListedBuilding').ActivityType",
+							"type": "Expression"
+						},
+						"DurationSeconds": {
+							"value": "@activity('ListedBuilding').Duration",
+							"type": "Expression"
+						},
+						"StatusCode": {
+							"value": "@activity('ListedBuilding').StatusCode",
+							"type": "Expression"
+						},
+						"AppInsIKey": "@variables('apps_insights_ikey')"
+					}
 				}
 			},
 			{
-				"name": "Listed building outline failure",
-				"type": "Fail",
+				"name": "Record ListedBuildingOutline Failure",
+				"type": "ExecutePipeline",
 				"dependsOn": [
 					{
 						"activity": "ListedBuildingOutline",
@@ -128,10 +186,68 @@
 						]
 					}
 				],
+				"policy": {
+					"secureInput": false
+				},
 				"userProperties": [],
 				"typeProperties": {
-					"message": "Listed building outline API feed failed",
-					"errorCode": "500"
+					"pipeline": {
+						"referenceName": "pln_log_to_appins",
+						"type": "PipelineReference"
+					},
+					"waitOnCompletion": true,
+					"parameters": {
+						"Stage": "Fail",
+						"PipelineName": {
+							"value": "@activity('ListedBuildingOutline').Output.pipelineName",
+							"type": "Expression"
+						},
+						"PipelineRunID": {
+							"value": "@activity('ListedBuildingOutline').Output.pipelineRunId",
+							"type": "Expression"
+						},
+						"StartTime": {
+							"value": "@activity('ListedBuildingOutline').ExecutionStartTime",
+							"type": "Expression"
+						},
+						"EndTime": {
+							"value": "@activity('ListedBuildingOutline').ExecutionEndTime",
+							"type": "Expression"
+						},
+						"ErrorMessage": {
+							"value": "@activity('ListedBuildingOutline').Error.message",
+							"type": "Expression"
+						},
+						"StatusMessage": {
+							"value": "@activity('ListedBuildingOutline').Status",
+							"type": "Expression"
+						},
+						"PipelineTriggeredbyPipelineName": {
+							"value": "@activity('ListedBuildingOutline').PipelineName",
+							"type": "Expression"
+						},
+						"PipelineTriggeredbyPipelineRunID": {
+							"value": "@activity('ListedBuildingOutline').PipelineRunId",
+							"type": "Expression"
+						},
+						"PipelineExecutionTimeInSec": {
+							"value": "@activity('ListedBuildingOutline').Duration",
+							"type": "Expression"
+						},
+						"ActivityType": {
+							"value": "@activity('ListedBuildingOutline').ActivityType",
+							"type": "Expression"
+						},
+						"DurationSeconds": {
+							"value": "@activity('ListedBuildingOutline').Duration",
+							"type": "Expression"
+						},
+						"StatusCode": {
+							"value": "@activity('ListedBuildingOutline').StatusCode",
+							"type": "Expression"
+						},
+						"AppInsIKey": "@variables('apps_insights_ikey')"
+					}
 				}
 			}
 		],


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
