### PR TITLE
Feat/theodw 1669 test appeal document py test appeal document notebook unit test fail

### DIFF
--- a/workspace/notebook/appeal_document.json
+++ b/workspace/notebook/appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3ec305f6-c19a-47bd-908a-48567b2049a6"
+				"spark.autotune.trackingId": "fdd79d2d-f81e-4048-ba98-88584b990cb8"
 			}
 		},
 		"metadata": {
@@ -83,7 +83,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import json"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -101,7 +101,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -117,11 +117,11 @@
 					}
 				},
 				"source": [
-					"db_name: str = \"odw_curated_db\"\r\n",
-					"entity_name: str = \"appeal-document\"\r\n",
+					"db_name: str = \"odw_curated_db\"\n",
+					"entity_name: str = \"appeal-document\"\n",
 					"table_name: str = \"odw_curated_db.appeal_document\""
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -190,13 +190,11 @@
 					"    doc.horizonFolderId\n",
 					"    \n",
 					"FROM odw_harmonised_db.appeal_document as doc\n",
-					"LEFT JOIN odw_curated_db.nsip_project as proj\n",
-					"ON doc.caseReference = proj.caseReference\n",
 					"WHERE doc.IsActive = 'Y'\n",
 					"\"\"\"\n",
 					")"
 				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -225,10 +223,10 @@
 					}
 				},
 				"source": [
-					"schema = mssparkutils.notebook.run(\"py_create_spark_schema\", 30, {\"db_name\": db_name, \"entity_name\": entity_name})\r\n",
+					"schema = mssparkutils.notebook.run(\"py_create_spark_schema\", 30, {\"db_name\": db_name, \"entity_name\": entity_name})\n",
 					"spark_schema = StructType.fromJson(json.loads(schema))"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -259,7 +257,7 @@
 				"source": [
 					"data = spark.createDataFrame(df.rdd, schema=spark_schema)"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "markdown",
@@ -288,11 +286,11 @@
 					}
 				},
 				"source": [
-					"logInfo(f\"Writing to {table_name}\")\r\n",
-					"df.write.mode(\"overwrite\").format(\"parquet\").saveAsTable(table_name)\r\n",
+					"logInfo(f\"Writing to {table_name}\")\n",
+					"df.write.mode(\"overwrite\").format(\"parquet\").saveAsTable(table_name)\n",
 					"logInfo(f\"Written to {table_name}\")"
 				],
-				"execution_count": null
+				"execution_count": 11
 			}
 		]
 	}

--- a/workspace/notebook/appeal_document.json
+++ b/workspace/notebook/appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fdd79d2d-f81e-4048-ba98-88584b990cb8"
+				"spark.autotune.trackingId": "39b29914-e428-4e76-8da9-0a9c7cc4bdf4"
 			}
 		},
 		"metadata": {
@@ -83,7 +83,7 @@
 					"from pyspark.sql import DataFrame\n",
 					"import json"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -101,7 +101,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 6
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -121,7 +121,7 @@
 					"entity_name: str = \"appeal-document\"\n",
 					"table_name: str = \"odw_curated_db.appeal_document\""
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -194,7 +194,7 @@
 					"\"\"\"\n",
 					")"
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -226,7 +226,7 @@
 					"schema = mssparkutils.notebook.run(\"py_create_spark_schema\", 30, {\"db_name\": db_name, \"entity_name\": entity_name})\n",
 					"spark_schema = StructType.fromJson(json.loads(schema))"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -257,7 +257,7 @@
 				"source": [
 					"data = spark.createDataFrame(df.rdd, schema=spark_schema)"
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -290,7 +290,7 @@
 					"df.write.mode(\"overwrite\").format(\"parquet\").saveAsTable(table_name)\n",
 					"logInfo(f\"Written to {table_name}\")"
 				],
-				"execution_count": 11
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a08b5560-6a4d-47b8-a875-4a274321c947"
+				"spark.autotune.trackingId": "50d5e74d-fee2-402a-a22e-bdd1fc9b2fba"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 85
+				"execution_count": 104
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 86
+				"execution_count": 105
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 87
+				"execution_count": 106
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 88
+				"execution_count": 107
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 89
+				"execution_count": 108
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 90
+				"execution_count": 109
 			},
 			{
 				"cell_type": "code",
@@ -236,7 +236,7 @@
 					"\n",
 					"    return (std_count, hrm_count, std_count == hrm_count)"
 				],
-				"execution_count": 91
+				"execution_count": 110
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 92
+				"execution_count": 111
 			},
 			{
 				"cell_type": "markdown",
@@ -299,7 +299,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": 93
+				"execution_count": 112
 			},
 			{
 				"cell_type": "markdown",
@@ -338,7 +338,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 94
+				"execution_count": 113
 			},
 			{
 				"cell_type": "markdown",
@@ -372,7 +372,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 95
+				"execution_count": 114
 			},
 			{
 				"cell_type": "code",
@@ -417,7 +417,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 96
+				"execution_count": 115
 			},
 			{
 				"cell_type": "code",
@@ -462,7 +462,7 @@
 					"    print(\"Failed: Trace Horizon data to Harmonised\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 97
+				"execution_count": 116
 			},
 			{
 				"cell_type": "code",
@@ -495,7 +495,7 @@
 					"    print(\"Failed: data coming from ODT (back-office-appeals) and Horizon\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 98
+				"execution_count": 117
 			},
 			{
 				"cell_type": "code",
@@ -517,7 +517,7 @@
 					"    print(\"Failed: test_sb_std_to_sb_hrm_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 99
+				"execution_count": 118
 			},
 			{
 				"cell_type": "code",
@@ -539,7 +539,7 @@
 					"    print(\"Failed: test_sb_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 100
+				"execution_count": 119
 			},
 			{
 				"cell_type": "code",
@@ -561,7 +561,7 @@
 					"    print(\"Failed: test_hrm_to_curated_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 101
+				"execution_count": 120
 			},
 			{
 				"cell_type": "code",
@@ -583,7 +583,7 @@
 					"    print(\"Failed: test_horizon_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 102
+				"execution_count": 121
 			},
 			{
 				"cell_type": "code",
@@ -599,14 +599,14 @@
 					}
 				},
 				"source": [
-					"if test_aie_std_to_hrm_no_dropping_records(std_db_name,aie_std_table_name,hrm_db_name,aie_hrm_table_name):\n",
+					"if test_aie_std_to_hrm_latest_records(std_db_name,aie_std_table_name,hrm_db_name,aie_hrm_table_name):\n",
 					"    pass\n",
 					"else:\n",
 					"    print(\"Failed: test_aie_std_to_hrm_no_dropping_records\")\n",
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 103
+				"execution_count": 122
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "b6715909-f629-4c1a-9a0a-c58bfc1835b2"
+				"spark.autotune.trackingId": "e28e1945-6a33-4808-800f-2ee0b8438bd9"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 24
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 25
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -116,25 +116,25 @@
 					}
 				},
 				"source": [
-					"horizon_std_df = spark.table(f\"{std_db_name}.{horizon_std_table_name}\")\r\n",
-					"aie_std_df = spark.table(f\"{std_db_name}.{aie_std_table_name}\")\r\n",
-					"aie_hrm_df = spark.table(f\"{hrm_db_name}.{aie_hrm_table_name}\")\r\n",
-					"hrm_final_df = spark.table(f\"{hrm_db_name}.{hrm_table_final}\")\r\n",
-					"hrm_final_df_active = hrm_final_df.filter(\"IsActive = 'Y'\")\r\n",
-					"curated_df = spark.table(f\"{curated_db_name}.{curated_table_name}\")\r\n",
-					"sb_std_df = spark.table(f\"{std_db_name}.{std_table_name}\")\r\n",
-					"sb_hrm_df = spark.table(f\"{hrm_db_name}.{hrm_table_name}\")\r\n",
-					"horizon_documentIds = horizon_std_df.select(\"documentId\")\r\n",
-					"aie_std_documentIds = aie_std_df.select(\"documentId\")\r\n",
-					"aie_hrm_documentIds = aie_hrm_df.select(\"documentId\")\r\n",
-					"hrm_final_documentIds = hrm_final_df.select(\"documentId\")\r\n",
-					"sb_std_documentIds = sb_std_df.select(\"documentId\")\r\n",
-					"sb_hrm_documentIds = sb_hrm_df.select(\"documentId\")\r\n",
-					"curated_documentIds = curated_df.select(\"documentId\")\r\n",
-					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\r\n",
+					"horizon_std_df = spark.table(f\"{std_db_name}.{horizon_std_table_name}\")\n",
+					"aie_std_df = spark.table(f\"{std_db_name}.{aie_std_table_name}\")\n",
+					"aie_hrm_df = spark.table(f\"{hrm_db_name}.{aie_hrm_table_name}\")\n",
+					"hrm_final_df = spark.table(f\"{hrm_db_name}.{hrm_table_final}\")\n",
+					"hrm_final_df_active = hrm_final_df.filter(\"IsActive = 'Y'\")\n",
+					"curated_df = spark.table(f\"{curated_db_name}.{curated_table_name}\")\n",
+					"sb_std_df = spark.table(f\"{std_db_name}.{std_table_name}\")\n",
+					"sb_hrm_df = spark.table(f\"{hrm_db_name}.{hrm_table_name}\")\n",
+					"horizon_documentIds = horizon_std_df.select(\"documentId\")\n",
+					"aie_std_documentIds = aie_std_df.select(\"documentId\")\n",
+					"aie_hrm_documentIds = aie_hrm_df.select(\"documentId\")\n",
+					"hrm_final_documentIds = hrm_final_df.select(\"documentId\")\n",
+					"sb_std_documentIds = sb_std_df.select(\"documentId\")\n",
+					"sb_hrm_documentIds = sb_hrm_df.select(\"documentId\")\n",
+					"curated_documentIds = curated_df.select(\"documentId\")\n",
+					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 26
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 27
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 28
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,27 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 29
+				"execution_count": 6
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"def test_std_same_rows_hrm(std_table: str, hrm_table: str) -> tuple[int, int, bool]:\n",
+					"    std_table_full: str = f\"{std_db_name}.{std_table}\"\n",
+					"    hrm_table_full: str = f\"{hrm_db_name}.{hrm_table}\"\n",
+					"\n",
+					"    # filter standardised df with non-null message_type\n",
+					"    std_df: DataFrame = spark.table(std_table_full)\n",
+					"\n",
+					"    if \"message_type\" in std_df.columns:\n",
+					"        std_df = std_df.filter(std_df.message_type.isNotNull() & std_df.message_id.isNotNull())\n",
+					"    \n",
+					"    std_count: int = std_df.count()\n",
+					"    hrm_count: int = spark.table(hrm_table_full).dropDuplicates([\"documentId\", \"message_id\"]).count()\n",
+					"\n",
+					"    return (std_count, hrm_count, std_count == hrm_count)"
+				],
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -239,7 +259,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 30
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -279,7 +299,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": 31
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -318,7 +338,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 32
+				"execution_count": 45
 			},
 			{
 				"cell_type": "markdown",
@@ -352,7 +372,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 33
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -397,7 +417,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 34
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -442,7 +462,7 @@
 					"    print(\"Failed: Trace Horizon data to Harmonised\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 35
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -475,7 +495,7 @@
 					"    print(\"Failed: data coming from ODT (back-office-appeals) and Horizon\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 36
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -497,7 +517,7 @@
 					"    print(\"Failed: test_sb_std_to_sb_hrm_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 37
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -519,7 +539,7 @@
 					"    print(\"Failed: test_sb_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 38
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -541,7 +561,7 @@
 					"    print(\"Failed: test_hrm_to_curated_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 39
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -563,7 +583,7 @@
 					"    print(\"Failed: test_horizon_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 40
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -586,7 +606,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 41
+				"execution_count": 47
 			},
 			{
 				"cell_type": "code",
@@ -608,7 +628,7 @@
 					"    print(\"Failed: test_aie_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 42
+				"execution_count": 43
 			},
 			{
 				"cell_type": "code",
@@ -630,7 +650,7 @@
 					"    print(\"Failed: test_document_row_counts_match\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 43
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -652,7 +672,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_message_id_dropped\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 44
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -674,7 +694,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_active_deleted_record\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 45
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -692,7 +712,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 46
+				"execution_count": 30
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d1988a38-48e3-48f7-b955-4e7bfc50aff2"
+				"spark.autotune.trackingId": "7c0c3cf2-2b8d-488f-b5ce-35f439b0bba9"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 1
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 2
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 3
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 4
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 5
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 6
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -236,7 +236,7 @@
 					"\n",
 					"    return (std_count, hrm_count, std_count == hrm_count)"
 				],
-				"execution_count": 7
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 8
+				"execution_count": 14
 			},
 			{
 				"cell_type": "markdown",
@@ -299,7 +299,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": 9
+				"execution_count": 15
 			},
 			{
 				"cell_type": "markdown",
@@ -338,7 +338,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 10
+				"execution_count": 16
 			},
 			{
 				"cell_type": "markdown",
@@ -372,7 +372,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 11
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -417,7 +417,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 12
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -462,7 +462,7 @@
 					"    print(\"Failed: Trace Horizon data to Harmonised\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 13
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -495,7 +495,7 @@
 					"    print(\"Failed: data coming from ODT (back-office-appeals) and Horizon\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 14
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -517,7 +517,7 @@
 					"    print(\"Failed: test_sb_std_to_sb_hrm_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 15
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -539,7 +539,7 @@
 					"    print(\"Failed: test_sb_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 16
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -561,7 +561,7 @@
 					"    print(\"Failed: test_hrm_to_curated_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 17
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -583,7 +583,7 @@
 					"    print(\"Failed: test_horizon_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 18
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -606,7 +606,73 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 19
+				"execution_count": 25
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"### Kranht Test "
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"def test_aie_std_to_hrm_latest_records_test(std_db_name: str, aie_std_table_name: str,hrm_db_name: str, aie_hrm_table_name: str) -> bool:\n",
+					"    from pyspark.sql import DataFrame, SparkSession\n",
+					"    \n",
+					"    spark = SparkSession.builder.getOrCreate()\n",
+					"    \n",
+					"    try:\n",
+					"        # Get latest document IDs from standardized table\n",
+					"        aie_std_latest_documentIds = spark.sql(f\"\"\"\n",
+					"            SELECT DISTINCT documentId FROM {std_db_name}.{aie_std_table_name} WHERE expected_from = (SELECT MAX(expected_from)  FROM {std_db_name}.{aie_std_table_name}\n",
+					"            )\n",
+					"        \"\"\").select(\"documentId\")\n",
+					"        \n",
+					"        # Get document IDs from harmonized table\n",
+					"        aie_hrm_documentIds = spark.sql(f\"\"\"SELECT DISTINCT documentId FROM {hrm_db_name}.{aie_hrm_table_name} \"\"\").select(\"documentId\")\n",
+					"        \n",
+					"        # Compare counts of latest records\n",
+					"        return aie_std_latest_documentIds.count() == aie_hrm_documentIds.count()\n",
+					"        \n",
+					"    except Exception as e:\n",
+					"        print(f\"Validation failed: {str(e)}\")\n",
+					"        return False\n",
+					""
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"if test_aie_std_to_hrm_no_dropping_records_test(aie_std_table_name, aie_hrm_table_name):\n",
+					"    pass\n",
+					"else:\n",
+					"    print(\"Failed: test_aie_std_to_hrm_no_dropping_records\")\n",
+					"    exitCode += 1\n",
+					""
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"#### Kranht test end "
+				]
 			},
 			{
 				"cell_type": "code",
@@ -628,7 +694,7 @@
 					"    print(\"Failed: test_aie_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 20
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -650,7 +716,7 @@
 					"    print(\"Failed: test_document_row_counts_match\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 21
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -672,7 +738,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_message_id_dropped\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 22
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -694,7 +760,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_active_deleted_record\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 23
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -712,7 +778,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 24
+				"execution_count": 30
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c863337f-514e-4d75-8684-8105eca78f72"
+				"spark.autotune.trackingId": "a08b5560-6a4d-47b8-a875-4a274321c947"
 			}
 		},
 		"metadata": {
@@ -236,7 +236,7 @@
 					"\n",
 					"    return (std_count, hrm_count, std_count == hrm_count)"
 				],
-				"execution_count": null
+				"execution_count": 91
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": null
+				"execution_count": 92
 			},
 			{
 				"cell_type": "markdown",
@@ -299,7 +299,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": null
+				"execution_count": 93
 			},
 			{
 				"cell_type": "markdown",
@@ -338,7 +338,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": null
+				"execution_count": 94
 			},
 			{
 				"cell_type": "markdown",
@@ -372,7 +372,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": null
+				"execution_count": 95
 			},
 			{
 				"cell_type": "code",
@@ -417,7 +417,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 96
 			},
 			{
 				"cell_type": "code",
@@ -462,7 +462,7 @@
 					"    print(\"Failed: Trace Horizon data to Harmonised\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 97
 			},
 			{
 				"cell_type": "code",
@@ -495,7 +495,7 @@
 					"    print(\"Failed: data coming from ODT (back-office-appeals) and Horizon\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 98
 			},
 			{
 				"cell_type": "code",
@@ -517,7 +517,7 @@
 					"    print(\"Failed: test_sb_std_to_sb_hrm_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 99
 			},
 			{
 				"cell_type": "code",
@@ -539,7 +539,7 @@
 					"    print(\"Failed: test_sb_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 100
 			},
 			{
 				"cell_type": "code",
@@ -561,7 +561,7 @@
 					"    print(\"Failed: test_hrm_to_curated_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 101
 			},
 			{
 				"cell_type": "code",
@@ -583,7 +583,7 @@
 					"    print(\"Failed: test_horizon_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 102
 			},
 			{
 				"cell_type": "code",
@@ -599,14 +599,14 @@
 					}
 				},
 				"source": [
-					"if test_aie_std_to_hrm_no_dropping_records(aie_std_table_name, aie_hrm_table_name):\n",
+					"if test_aie_std_to_hrm_no_dropping_records(std_db_name,aie_std_table_name,hrm_db_name,aie_hrm_table_name):\n",
 					"    pass\n",
 					"else:\n",
 					"    print(\"Failed: test_aie_std_to_hrm_no_dropping_records\")\n",
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 103
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f39ca7b0-1eb4-4382-b13b-560bff1fee22"
+				"spark.autotune.trackingId": "c863337f-514e-4d75-8684-8105eca78f72"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 46
+				"execution_count": 85
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": null
+				"execution_count": 86
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": null
+				"execution_count": 87
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 10
+				"execution_count": 88
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 11
+				"execution_count": 89
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 12
+				"execution_count": 90
 			},
 			{
 				"cell_type": "code",
@@ -236,7 +236,7 @@
 					"\n",
 					"    return (std_count, hrm_count, std_count == hrm_count)"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -299,7 +299,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -338,7 +338,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 16
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -372,7 +372,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 17
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -417,7 +417,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 18
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -462,7 +462,7 @@
 					"    print(\"Failed: Trace Horizon data to Harmonised\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 19
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -495,7 +495,7 @@
 					"    print(\"Failed: data coming from ODT (back-office-appeals) and Horizon\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 20
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -517,7 +517,7 @@
 					"    print(\"Failed: test_sb_std_to_sb_hrm_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 21
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -539,7 +539,7 @@
 					"    print(\"Failed: test_sb_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 22
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -561,7 +561,7 @@
 					"    print(\"Failed: test_hrm_to_curated_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 23
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -583,7 +583,7 @@
 					"    print(\"Failed: test_horizon_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 24
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -606,73 +606,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 25
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"### Kranht Test "
-				]
-			},
-			{
-				"cell_type": "code",
-				"source": [
-					"def test_aie_std_to_hrm_latest_records_test(std_db_name: str, aie_std_table_name: str,hrm_db_name: str, aie_hrm_table_name: str) -> bool:\n",
-					"    from pyspark.sql import DataFrame, SparkSession\n",
-					"    \n",
-					"    spark = SparkSession.builder.getOrCreate()\n",
-					"    \n",
-					"    try:\n",
-					"        # Get latest document IDs from standardized table\n",
-					"        aie_std_latest_documentIds = spark.sql(f\"\"\"\n",
-					"            SELECT DISTINCT documentId FROM {std_db_name}.{aie_std_table_name} WHERE expected_from = (SELECT MAX(expected_from)  FROM {std_db_name}.{aie_std_table_name}\n",
-					"            )\n",
-					"        \"\"\").select(\"documentId\")\n",
-					"        \n",
-					"        # Get document IDs from harmonized table\n",
-					"        aie_hrm_documentIds = spark.sql(f\"\"\"SELECT DISTINCT documentId FROM {hrm_db_name}.{aie_hrm_table_name} \"\"\").select(\"documentId\")\n",
-					"        \n",
-					"        # Compare counts of latest records\n",
-					"        return aie_std_latest_documentIds.count() == aie_hrm_documentIds.count()\n",
-					"        \n",
-					"    except Exception as e:\n",
-					"        print(f\"Validation failed: {str(e)}\")\n",
-					"        return False\n",
-					""
-				],
-				"execution_count": 31
-			},
-			{
-				"cell_type": "code",
-				"source": [
-					"if test_aie_std_to_hrm_no_dropping_records_test(std_db_name,aie_std_table_name,hrm_db_name,aie_hrm_table_name):\n",
-					"    pass\n",
-					"else:\n",
-					"    print(\"Failed: test_aie_std_to_hrm_no_dropping_records\")\n",
-					"    exitCode += 1\n",
-					""
-				],
 				"execution_count": null
-			},
-			{
-				"cell_type": "markdown",
-				"metadata": {
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					}
-				},
-				"source": [
-					"#### Kranht test end "
-				]
 			},
 			{
 				"cell_type": "code",
@@ -694,7 +628,7 @@
 					"    print(\"Failed: test_aie_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 26
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -716,7 +650,7 @@
 					"    print(\"Failed: test_document_row_counts_match\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 27
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -738,7 +672,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_message_id_dropped\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 28
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -760,7 +694,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_active_deleted_record\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 29
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -778,7 +712,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 30
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7c0c3cf2-2b8d-488f-b5ce-35f439b0bba9"
+				"spark.autotune.trackingId": "f39ca7b0-1eb4-4382-b13b-560bff1fee22"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 7
+				"execution_count": 46
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -647,12 +647,12 @@
 					"        return False\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
 				"source": [
-					"if test_aie_std_to_hrm_no_dropping_records_test(aie_std_table_name, aie_hrm_table_name):\n",
+					"if test_aie_std_to_hrm_no_dropping_records_test(std_db_name,aie_std_table_name,hrm_db_name,aie_hrm_table_name):\n",
 					"    pass\n",
 					"else:\n",
 					"    print(\"Failed: test_aie_std_to_hrm_no_dropping_records\")\n",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "50d5e74d-fee2-402a-a22e-bdd1fc9b2fba"
+				"spark.autotune.trackingId": "d2c32fe2-8e2f-40ad-92ed-2805d63a8cf7"
 			}
 		},
 		"metadata": {
@@ -71,7 +71,7 @@
 					"from pyspark.sql import functions as F\n",
 					"import pprint"
 				],
-				"execution_count": 104
+				"execution_count": 74
 			},
 			{
 				"cell_type": "code",
@@ -100,7 +100,7 @@
 					"hrm_table_final: str = 'appeal_document'\n",
 					"curated_table_name: str = 'appeal_document'"
 				],
-				"execution_count": 105
+				"execution_count": 75
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,7 @@
 					"aie_appeals_documentIds = aie_std_documentIds.intersect(horizon_documentIds)\n",
 					"aie_appeals_documents_count = aie_appeals_documentIds.count()"
 				],
-				"execution_count": 106
+				"execution_count": 76
 			},
 			{
 				"cell_type": "code",
@@ -153,7 +153,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 107
+				"execution_count": 77
 			},
 			{
 				"cell_type": "code",
@@ -198,7 +198,7 @@
 					"  \"horizonFolderId\"\n",
 					"]"
 				],
-				"execution_count": 108
+				"execution_count": 78
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 109
+				"execution_count": 79
 			},
 			{
 				"cell_type": "code",
@@ -236,7 +236,7 @@
 					"\n",
 					"    return (std_count, hrm_count, std_count == hrm_count)"
 				],
-				"execution_count": 110
+				"execution_count": 80
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 111
+				"execution_count": 81
 			},
 			{
 				"cell_type": "markdown",
@@ -299,7 +299,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": 112
+				"execution_count": 82
 			},
 			{
 				"cell_type": "markdown",
@@ -338,7 +338,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 113
+				"execution_count": 83
 			},
 			{
 				"cell_type": "markdown",
@@ -372,7 +372,7 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 114
+				"execution_count": 84
 			},
 			{
 				"cell_type": "code",
@@ -417,7 +417,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 115
+				"execution_count": 85
 			},
 			{
 				"cell_type": "code",
@@ -462,7 +462,7 @@
 					"    print(\"Failed: Trace Horizon data to Harmonised\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 116
+				"execution_count": 86
 			},
 			{
 				"cell_type": "code",
@@ -495,7 +495,7 @@
 					"    print(\"Failed: data coming from ODT (back-office-appeals) and Horizon\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 117
+				"execution_count": 87
 			},
 			{
 				"cell_type": "code",
@@ -517,7 +517,7 @@
 					"    print(\"Failed: test_sb_std_to_sb_hrm_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 118
+				"execution_count": 88
 			},
 			{
 				"cell_type": "code",
@@ -539,7 +539,7 @@
 					"    print(\"Failed: test_sb_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 119
+				"execution_count": 89
 			},
 			{
 				"cell_type": "code",
@@ -561,7 +561,7 @@
 					"    print(\"Failed: test_hrm_to_curated_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 120
+				"execution_count": 90
 			},
 			{
 				"cell_type": "code",
@@ -583,7 +583,7 @@
 					"    print(\"Failed: test_horizon_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 121
+				"execution_count": 91
 			},
 			{
 				"cell_type": "code",
@@ -606,7 +606,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 122
+				"execution_count": 92
 			},
 			{
 				"cell_type": "code",
@@ -628,7 +628,7 @@
 					"    print(\"Failed: test_aie_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 93
 			},
 			{
 				"cell_type": "code",
@@ -650,7 +650,7 @@
 					"    print(\"Failed: test_document_row_counts_match\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 94
 			},
 			{
 				"cell_type": "code",
@@ -672,7 +672,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_message_id_dropped\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 95
 			},
 			{
 				"cell_type": "code",
@@ -694,7 +694,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_active_deleted_record\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": null
+				"execution_count": 96
 			},
 			{
 				"cell_type": "code",
@@ -712,7 +712,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": null
+				"execution_count": 97
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e28e1945-6a33-4808-800f-2ee0b8438bd9"
+				"spark.autotune.trackingId": "cc274afa-4896-46a2-a9fc-9a8eedf18289"
 			}
 		},
 		"metadata": {
@@ -236,7 +236,7 @@
 					"\n",
 					"    return (std_count, hrm_count, std_count == hrm_count)"
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 7
+				"execution_count": 8
 			},
 			{
 				"cell_type": "markdown",
@@ -299,7 +299,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": 8
+				"execution_count": 9
 			},
 			{
 				"cell_type": "markdown",
@@ -338,7 +338,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 45
+				"execution_count": 10
 			},
 			{
 				"cell_type": "markdown",
@@ -417,7 +417,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 18
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -462,7 +462,7 @@
 					"    print(\"Failed: Trace Horizon data to Harmonised\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 19
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -495,7 +495,7 @@
 					"    print(\"Failed: data coming from ODT (back-office-appeals) and Horizon\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 20
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -517,7 +517,7 @@
 					"    print(\"Failed: test_sb_std_to_sb_hrm_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 21
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -539,7 +539,7 @@
 					"    print(\"Failed: test_sb_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 22
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -561,7 +561,7 @@
 					"    print(\"Failed: test_hrm_to_curated_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 23
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -583,7 +583,7 @@
 					"    print(\"Failed: test_horizon_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 24
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -606,7 +606,7 @@
 					"    exitCode += 1\n",
 					""
 				],
-				"execution_count": 47
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -628,7 +628,7 @@
 					"    print(\"Failed: test_aie_hrm_to_hrm_final_no_dropping_records\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 43
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -650,7 +650,7 @@
 					"    print(\"Failed: test_document_row_counts_match\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 27
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -672,7 +672,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_message_id_dropped\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 28
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -694,7 +694,7 @@
 					"    print(\"Failed: test_sb_std_to_hrm_no_active_deleted_record\")\n",
 					"    exitCode += 1"
 				],
-				"execution_count": 29
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -712,7 +712,7 @@
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 30
+				"execution_count": 24
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/py_unit_tests_appeal_document.json
+++ b/workspace/notebook/py_unit_tests_appeal_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cc274afa-4896-46a2-a9fc-9a8eedf18289"
+				"spark.autotune.trackingId": "d1988a38-48e3-48f7-b955-4e7bfc50aff2"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/py_unit_tests_functions.json
+++ b/workspace/notebook/py_unit_tests_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "592d81a5-62f3-4ee6-adc2-5fd758bd3582"
+				"spark.autotune.trackingId": "31f493e0-279a-40d1-8f70-a6ed682b3cc8"
 			}
 		},
 		"metadata": {
@@ -74,7 +74,7 @@
 					"storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"path_to_orchestration_file: str = \"abfss://odw-config@\"+storage_account+\"orchestration/orchestration.json\""
 				],
-				"execution_count": 1
+				"execution_count": 38
 			},
 			{
 				"cell_type": "code",
@@ -86,7 +86,7 @@
 					"    definition: dict = next((d for d in definitions if entity_name == d['Source_Filename_Start']), None)\n",
 					"    return definition['Harmonised_Incremental_Key'] if definition and 'Harmonised_Incremental_Key' in definition else None"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_functions.json
+++ b/workspace/notebook/py_unit_tests_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5967baab-c3b9-4ae6-8aca-b9e336401992"
+				"spark.autotune.trackingId": "592d81a5-62f3-4ee6-adc2-5fd758bd3582"
 			}
 		},
 		"metadata": {
@@ -74,7 +74,7 @@
 					"storage_account: str = mssparkutils.notebook.run('/utils/py_utils_get_storage_account')\n",
 					"path_to_orchestration_file: str = \"abfss://odw-config@\"+storage_account+\"orchestration/orchestration.json\""
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -86,7 +86,7 @@
 					"    definition: dict = next((d for d in definitions if entity_name == d['Source_Filename_Start']), None)\n",
 					"    return definition['Harmonised_Incremental_Key'] if definition and 'Harmonised_Incremental_Key' in definition else None"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -108,7 +108,7 @@
 					"    spark_schema = StructType.fromJson(json.loads(schema))\n",
 					"    return spark_schema"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -128,7 +128,7 @@
 					"    spark_dataframe: DataFrame = spark.createDataFrame([], schema=create_spark_schema(db_name, entity_name))\n",
 					"    return spark_dataframe"
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -147,7 +147,7 @@
 					"def get_dataframe(query: str) -> DataFrame:\n",
 					"    return spark.sql(query)"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -176,7 +176,7 @@
 					"        diff_df.show()\n",
 					"        return False"
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -217,7 +217,7 @@
 					"        result.update(extract_field(field))\n",
 					"    return result"
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -268,7 +268,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -299,7 +299,7 @@
 					"\n",
 					"    return (std_count, hrm_count, std_count == hrm_count)"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -330,7 +330,7 @@
 					"    \n",
 					"    return (hrm_count, curated_count, hrm_count == curated_count)"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"        print(f\"Data in Standardised not in Harmonised: {missing_rows_in_hrm.count()} rows\")\n",
 					"        display(missing_rows_in_hrm)"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -394,7 +394,7 @@
 					"\n",
 					"    return df_harmonise_only_hzn"
 				],
-				"execution_count": null
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -424,7 +424,7 @@
 					"    cur_count = df_curated.count()\n",
 					"    return (hrm_count, cur_count, hrm_count == cur_count)"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -454,7 +454,7 @@
 					"    return (count_not_hzn_records == 0, total_count, distinct_count, total_count == distinct_count)\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -486,7 +486,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -515,7 +515,7 @@
 					"    \"\"\")\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -544,7 +544,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -574,7 +574,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -604,7 +604,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -620,11 +620,27 @@
 					}
 				},
 				"source": [
-					"def test_aie_std_to_hrm_no_dropping_records(aie_std_table_name: str, aie_hrm_table_name: str) -> bool:\n",
-					"    df: DataFrame = aie_std_documentIds.subtract(aie_hrm_documentIds)\n",
+					"def test_aie_std_to_hrm_latest_records(std_db_name: str, aie_std_table_name: str, hrm_db_name: str, aie_hrm_table_name: str) -> bool:\n",
+					"    \n",
+					"    # Get latest document IDs from standardized table\n",
+					"    aie_std_latest_documentIds = spark.sql(f\"\"\"\n",
+					"        SELECT DISTINCT documentId FROM {std_db_name}.{aie_std_table_name} \n",
+					"        WHERE expected_from = (\n",
+					"            SELECT MAX(expected_from) \n",
+					"            FROM {std_db_name}.{aie_std_table_name}\n",
+					"        )\"\"\").select(\"documentId\")\n",
+					"   \n",
+					"\n",
+					"    # Get document IDs from harmonized table\n",
+					"    aie_hrm_documentIds = spark.sql(f\"\"\"\n",
+					"        SELECT DISTINCT documentId \n",
+					"        FROM {hrm_db_name}.{aie_hrm_table_name}\"\"\").select(\"documentId\")\n",
+					"\n",
+					"    df: DataFrame = aie_std_latest_documentIds.subtract(aie_hrm_documentIds)\n",
+					"    # Compare counts of latest records\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -647,7 +663,7 @@
 					"    else:\n",
 					"        return True"
 				],
-				"execution_count": null
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -679,7 +695,7 @@
 					"\n",
 					"    return non_zero_differences.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 22
 			},
 			{
 				"cell_type": "markdown",
@@ -720,7 +736,7 @@
 					"\n",
 					"    return result_df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -732,7 +748,7 @@
 					"    results = df.filter(\"IsActive = 'N' and ValidTo is null\")\n",
 					"    return results.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -744,7 +760,7 @@
 					"    results = df.filter(\"IsActive = 'Y' and ValidTo is not null\")\n",
 					"    return results.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 25
 			},
 			{
 				"cell_type": "markdown",
@@ -800,7 +816,7 @@
 					"\n",
 					"    return df_hzn.count() == df_cur.count()"
 				],
-				"execution_count": null
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -842,7 +858,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -872,7 +888,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 28
 			},
 			{
 				"cell_type": "markdown",
@@ -918,7 +934,7 @@
 					"\n",
 					"    return df_hzn.count() == df_cur.count()"
 				],
-				"execution_count": null
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -955,7 +971,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 30
 			},
 			{
 				"cell_type": "markdown",
@@ -997,7 +1013,7 @@
 					"    return df.count() == 0\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
@@ -1029,7 +1045,7 @@
 					"    return df.count() == 0\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 32
 			},
 			{
 				"cell_type": "code",
@@ -1067,7 +1083,7 @@
 					"    return True  \n",
 					"        "
 				],
-				"execution_count": null
+				"execution_count": 33
 			},
 			{
 				"cell_type": "markdown",
@@ -1117,7 +1133,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 34
 			},
 			{
 				"cell_type": "code",
@@ -1152,7 +1168,7 @@
 					"\n",
 					"    return df.count() == 0"
 				],
-				"execution_count": null
+				"execution_count": 35
 			},
 			{
 				"cell_type": "code",
@@ -1189,7 +1205,7 @@
 					"    \n",
 					"    return len(invalid_message_ids) == 0"
 				],
-				"execution_count": null
+				"execution_count": 36
 			},
 			{
 				"cell_type": "code",
@@ -1233,7 +1249,7 @@
 					"\n",
 					"    return len(mismatched_message_ids) == 0"
 				],
-				"execution_count": null
+				"execution_count": 37
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
