### PR TITLE
Wrap reference commit message reference in quotes

### DIFF
--- a/.github/workflows/dev-to-test.yml
+++ b/.github/workflows/dev-to-test.yml
@@ -27,7 +27,7 @@ jobs:
       id: check_test_branch_exists
     - name: Extract most recent commit message
       shell: bash
-      run: echo "message=${{ github.event.head_commit.message }}" >> $GITHUB_OUTPUT
+      run: echo "message='${{ github.event.head_commit.message }}'" >> $GITHUB_OUTPUT
       id: extract_commit_message
     - name: Raise Pull Request
       env:


### PR DESCRIPTION
Testing that `dev-to-test.yml` is auto-triggered when merging into dev