### PR TITLE
Updating notebook: appeals_has_curated_mipins

### DIFF
--- a/workspace/notebook/appeals_has_curated_mipins.json
+++ b/workspace/notebook/appeals_has_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "80d2a8b2-b81e-49d4-9bb9-d9f88f40b6da"
+				"spark.autotune.trackingId": "1de92c74-8fbd-459b-9cd0-6b38f2e8309e"
 			}
 		},
 		"metadata": {
@@ -140,13 +140,14 @@
 					"AH.affectedListedBuildingNumbers            AS affectedListedBuildingNumbers,\n",
 					"CAST(AH.appellantCostsAppliedFor AS BOOLEAN) AS appellantCostsAppliedFor,\n",
 					"CAST(AH.lpaCostsAppliedFor AS BOOLEAN)       AS lpaCostsAppliedFor,\n",
+					"AH.typeOfPlanningApplication                 AS typeOfPlanningApplication,\n",
 					"AH.IngestionDate                             AS IngestionDate,\n",
 					"AH.ValidTo                                   AS ValidTo,\n",
 					"AH.IsActive                                  AS IsActive\n",
 					"FROM odw_harmonised_db.sb_appeal_has AS AH\n",
-					"where AH.lpaCode not in ('Q9999', 'Q1111')"
+					"where AH.lpaCode NOT in ('Q9999', 'Q1111')"
 				],
-				"execution_count": 1
+				"execution_count": 25
 			},
 			{
 				"cell_type": "code",
@@ -164,7 +165,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeals_has_curated_mipins;\")"
 				],
-				"execution_count": 2
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -180,12 +181,12 @@
 					}
 				},
 				"source": [
-					"from pyspark.sql import SparkSession\r\n",
-					"spark = SparkSession.builder.getOrCreate()\r\n",
-					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeals_has_curated_mipins\")\r\n",
+					"from pyspark.sql import SparkSession\n",
+					"spark = SparkSession.builder.getOrCreate()\n",
+					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeals_has_curated_mipins\")\n",
 					"view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeals_has_curated_mipins\")"
 				],
-				"execution_count": 3
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -202,10 +203,10 @@
 					"collapsed": false
 				},
 				"source": [
-					"#%%sql\r\n",
+					"#%%sql\n",
 					"#select * from odw_curated_db.appeals_has_curated_mipins"
 				],
-				"execution_count": 4
+				"execution_count": 28
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
