### PR TITLE
fix(tooling): rolling back to old azure agent image

### DIFF
--- a/infrastructure/modules/devops-agent-pool/data.tf
+++ b/infrastructure/modules/devops-agent-pool/data.tf
@@ -1,7 +1,7 @@
 data "azurerm_image" "azure_agents" {
   count = var.deploy_agent_pool ? 1 : 0
 
-  name_regex          = devops-agents-20241114120119
+  name_regex          = "devops-agents-20241114120119"
   sort_descending     = true
   resource_group_name = azurerm_resource_group.devops_agents.name
 }

--- a/infrastructure/modules/devops-agent-pool/data.tf
+++ b/infrastructure/modules/devops-agent-pool/data.tf
@@ -1,7 +1,7 @@
 data "azurerm_image" "azure_agents" {
   count = var.deploy_agent_pool ? 1 : 0
 
-  name_regex          = var.devops_agent_image_prefix
+  name_regex          = devops-agents-20241114120119
   sort_descending     = true
   resource_group_name = azurerm_resource_group.devops_agents.name
 }


### PR DESCRIPTION
rolling back to old azure agent image with terraform version 1.9.6