### PR TITLE
Updating pipeline: pln_curated

### DIFF
--- a/workspace/pipeline/pln_curated.json
+++ b/workspace/pipeline/pln_curated.json
@@ -534,7 +534,32 @@
 			{
 				"name": "Listed building",
 				"type": "SynapseNotebook",
-				"dependsOn": [],
+				"dependsOn": [
+					{
+						"activity": "pln_curated_migration",
+						"dependencyConditions": [
+							"Completed"
+						]
+					},
+					{
+						"activity": "dart_api",
+						"dependencyConditions": [
+							"Completed"
+						]
+					},
+					{
+						"activity": "appeal_s78",
+						"dependencyConditions": [
+							"Completed"
+						]
+					},
+					{
+						"activity": "pln_curated_mipins",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
 				"policy": {
 					"timeout": "0.1:00:00",
 					"retry": 3,


### PR DESCRIPTION
placed the listed building at the end of all the tasks to check if this alleviates the driver's resources in pln_curated. 