### PR TITLE
Theodw 1744 recommendations fix for pipeline investigations for failed copy data functions

### DIFF
--- a/workspace/pipeline/0_Horizon_Case_Involvement.json
+++ b/workspace/pipeline/0_Horizon_Case_Involvement.json
@@ -9,7 +9,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_EntraID.json
+++ b/workspace/pipeline/0_Raw_EntraID.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_Appeals_Document_Metadata.json
+++ b/workspace/pipeline/0_Raw_Horizon_Appeals_Document_Metadata.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_Appeals_Event_copy1.json
+++ b/workspace/pipeline/0_Raw_Horizon_Appeals_Event_copy1.json
@@ -7,7 +7,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_Appeals_Folder.json
+++ b/workspace/pipeline/0_Raw_Horizon_Appeals_Folder.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_Case_Specialisms.json
+++ b/workspace/pipeline/0_Raw_Horizon_Case_Specialisms.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
+++ b/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_Folder.json
+++ b/workspace/pipeline/0_Raw_Horizon_Folder.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_NSIP_Advice.json
+++ b/workspace/pipeline/0_Raw_Horizon_NSIP_Advice.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_NSIP_Data.json
+++ b/workspace/pipeline/0_Raw_Horizon_NSIP_Data.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_NSIP_Exam_Timetable.json
+++ b/workspace/pipeline/0_Raw_Horizon_NSIP_Exam_Timetable.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_NSIP_Relevant_Reps.json
+++ b/workspace/pipeline/0_Raw_Horizon_NSIP_Relevant_Reps.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_ODW_vw_CaseDates.json
+++ b/workspace/pipeline/0_Raw_Horizon_ODW_vw_CaseDates.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_ODW_vw_CaseDocumentDatesDates.json
+++ b/workspace/pipeline/0_Raw_Horizon_ODW_vw_CaseDocumentDatesDates.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_ODW_vw_CaseSiteStrings.json
+++ b/workspace/pipeline/0_Raw_Horizon_ODW_vw_CaseSiteStrings.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_ODW_vw_Cases_s78.json
+++ b/workspace/pipeline/0_Raw_Horizon_ODW_vw_Cases_s78.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_TypeOfProcedure.json
+++ b/workspace/pipeline/0_Raw_Horizon_TypeOfProcedure.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_TypeOfReasonForCase.json
+++ b/workspace/pipeline/0_Raw_Horizon_TypeOfReasonForCase.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseBasicData.json
+++ b/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseBasicData.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseDates.json
+++ b/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseDates.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseExtendedData.json
+++ b/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseExtendedData.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseOfficers.json
+++ b/workspace/pipeline/0_Raw_Horizon_s62a_ViewCaseOfficers.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_s62a_ViewCases.json
+++ b/workspace/pipeline/0_Raw_Horizon_s62a_ViewCases.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_vw_AddAdditionalData.json
+++ b/workspace/pipeline/0_Raw_Horizon_vw_AddAdditionalData.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/0_Raw_Horizon_vw_AdditionalFields.json
+++ b/workspace/pipeline/0_Raw_Horizon_vw_AdditionalFields.json
@@ -8,7 +8,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 3,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_event_curated_mipins.json
@@ -14,7 +14,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -63,7 +63,7 @@
 				"type": "Lookup",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -174,7 +174,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -237,7 +237,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
@@ -14,7 +14,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -72,7 +72,7 @@
 				"type": "Lookup",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -158,7 +158,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -223,7 +223,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -286,7 +286,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_s78_curated_mipins.json
@@ -14,7 +14,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -63,7 +63,7 @@
 				"type": "Lookup",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -149,7 +149,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -189,7 +189,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -277,7 +277,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_service_user_curated_mipins.json
@@ -14,7 +14,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -63,7 +63,7 @@
 				"type": "Lookup",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -174,7 +174,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -237,7 +237,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/pln_copy_entraid_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_entraid_curated_mipins.json
@@ -14,7 +14,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -63,7 +63,7 @@
 				"type": "Lookup",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -174,7 +174,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,
@@ -237,7 +237,7 @@
 					}
 				],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,

--- a/workspace/pipeline/pln_copy_nsip_project_to_mipins.json
+++ b/workspace/pipeline/pln_copy_nsip_project_to_mipins.json
@@ -7,7 +7,7 @@
 				"type": "Copy",
 				"dependsOn": [],
 				"policy": {
-					"timeout": "0.12:00:00",
+					"timeout": "0.02:00:00",
 					"retry": 0,
 					"retryIntervalInSeconds": 30,
 					"secureOutput": false,


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [x] No

 2. Have any new tables been created in Standardised?

  	- [x] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [x] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [x] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [x] No - No scripts have run 
	
 
