### PR TITLE
Update env variable definition to use compile-time expression

### DIFF
--- a/pipelines/azure-pipelines.yaml
+++ b/pipelines/azure-pipelines.yaml
@@ -53,17 +53,15 @@ schedules:
   batch: false
 
 variables:
-- name: branchName
-  value: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 - name: env
   ${{ if ne(parameters.env, 'auto') }}:
     value: ${{ parameters.env }}
   ${{ else }}:
-    ${{ if eq(variables.branchName, 'dev') }}:
+    ${{ if eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'dev') }}:
       value: dev
-    ${{ elseif eq(variables.branchName, 'testing') }}:
+    ${{ elseif eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'testing') }}:
       value: test
-    ${{ elseif eq(variables.branchName, 'main') }}:
+    ${{ elseif eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'main') }}:
       value: prod
     ${{ else }}:
       # Update to be the build env once ready


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-1638

The most recent auto-trigger from the testing branch seemed to deploy to the dev environment rather than the test env. This is due to the variable definition of `env` not allowing nested conditional assignment