### PR TITLE
Automated Pull Request from dev branch to testing branch (#1795)

### DIFF
--- a/.github/workflows/dev-to-test.yml
+++ b/.github/workflows/dev-to-test.yml
@@ -1,0 +1,67 @@
+###
+# This pipeline automatically raises a PR from dev->test whenever something is pushed into dev
+###
+name: Create Pull Request from dev branch to test branch
+
+on:
+  push:
+    branches:
+      - dev
+
+env:
+  TEST_BRANCH_NAME: 'testing'
+
+jobs:
+  create_test_branch_and_raise_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: dev
+    - name: Check the ${{ env.TEST_BRANCH_NAME }} branch exists
+      shell: bash
+      run: |
+        testingBranches=$(git ls-remote --heads origin ${{ env.TEST_BRANCH_NAME }})
+        echo $testingBranches
+        if [[ -z "$testingBranches" ]]; then
+            echo "A test branch should be created"
+            echo "createTestBranch=true" >> $GITHUB_OUTPUT
+        else
+            echo "The test branch already exists"
+            echo "createTestBranch=false" >> $GITHUB_OUTPUT      
+        fi
+      id: check_test_branch_exists
+    - name: Extract most recent commit message
+      shell: bash
+      env:
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+      run: |
+        delimiter=$(openssl rand -hex 8)
+        echo "message<<$delimiter" >> $GITHUB_OUTPUT
+        echo "$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+        echo "$delimiter" >> $GITHUB_OUTPUT
+      id: extract_commit_message
+    - name: Raise Pull Request
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMIT_MESSAGE: ${{ steps.extract_commit_message.outputs.message }}
+      run: |
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git config user.name "${GITHUB_ACTOR}"
+        if [[ "${{ steps.check_test_branch_exists.outputs.createTestBranch }}" = true ]]; then
+            echo "The $TEST_BRANCH_NAME branch does not exist, creating the branch and raising a pull request"
+            git fetch
+            git checkout main
+            git pull
+            git checkout -b $TEST_BRANCH_NAME
+            git push --set-upstream origin $TEST_BRANCH_NAME
+        else
+            echo "The $TEST_BRANCH_NAME branch already exists, not creating the branch"
+        fi
+        pullRequests=$(gh pr list -B $TEST_BRANCH_NAME -H dev)
+        if [[ -z "$pullRequests" ]]; then
+            echo "No pull requests found from dev->$TEST_BRANCH_NAME , raising a pull request"
+            gh pr create -B $TEST_BRANCH_NAME -H dev --title "Automated Pull Request from dev branch to ${{ env.TEST_BRANCH_NAME }} branch" --body "$COMMIT_MESSAGE"
+        else
+            echo "A pull request from the dev branch to the $TEST_BRANCH_NAME branch already exists" 
+        fi

--- a/.github/workflows/only-dev-merge-into-test.yaml
+++ b/.github/workflows/only-dev-merge-into-test.yaml
@@ -1,0 +1,16 @@
+name: Check is dev branch
+
+on:
+  pull_request:
+    branches: 
+      - testing
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.head_ref != 'dev'
+        run: |
+          echo "ERROR: You can only merge to testing from the dev branch"
+          exit 1

--- a/.github/workflows/only-test-merge-into-main.yaml
+++ b/.github/workflows/only-test-merge-into-main.yaml
@@ -1,0 +1,16 @@
+name: Check is test branch
+
+on:
+  pull_request:
+    branches: 
+      - main
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.head_ref != 'testing'
+        run: |
+          echo "ERROR: You can only merge to main from the testing branch"
+          exit 1

--- a/pipelines/azure-pipelines.yaml
+++ b/pipelines/azure-pipelines.yaml
@@ -1,0 +1,116 @@
+name: Synapse CI/CD
+
+# This is the main CI/CD pipeline of the ODW. This is used to manage the CI/CD through the dev, test and main branches
+parameters:
+# Whether or not to run tests
+- name: runTests
+  type: boolean
+  default: true
+# Whether or not to enforce the deployment of the infrastructure
+- name: enforceInfrastructureDeployment
+  type: boolean
+  default: false
+# Whether or not to enforce the deployment of the azure functions
+- name: enforceFunctionsDeployment
+  type: boolean
+  default: false
+# Whether or not to enforce the deployment of the synapse workspace
+- name: enforceSynapseDeployment
+  type: boolean
+  default: false
+# Whether or not the deployment is for the backup resources
+- name: failoverDeployment
+  type: boolean
+  default: false
+# User-specified environment to deploy to. By default this is auto, which lets the pipeline decide as part of CI/CD
+- name: env
+  default: 'auto'
+  values:
+  - 'auto'
+  - 'dev'
+  - 'test'
+  - 'prod'
+
+# Run when Pull Request raised to the dev or testing branch
+pr:
+- dev
+
+# Run when merged into main or testing
+trigger:
+ branches:
+  include:
+  - main
+  - testing
+
+# Automatically run against the dev branch at a set time every day
+schedules:
+- cron: '30 13 * * 1-5' # cron syntax defining a schedule. At 1:30pm every week day
+  displayName: Daily testing branch run
+  branches:
+    include:
+    - dev
+  always: true
+  batch: false
+
+variables:
+- name: env
+  ${{ if ne(parameters.env, 'auto') }}:
+    value: ${{ parameters.env }}
+  ${{ else }}:
+    ${{ if eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'dev') }}:
+      value: dev
+    ${{ elseif eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'testing') }}:
+      value: test
+    ${{ elseif eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'main') }}:
+      value: prod
+    ${{ else }}:
+      # Update to be the build env once ready
+      value: dev
+
+- name: variableGroupName
+  ${{ if eq(variables.env, 'prod') }}:
+    value: "Terraform Prod"
+  ${{ elseif eq(variables.env, 'test') }}:
+    value: "Terraform Test"
+  ${{ else }}:
+    value: "Terraform Dev"
+- name: agentPool
+  value: 'pins-agent-pool-odw-${{ variables.env }}-uks'
+- name: azureSubscription
+  value: 'pins-agent-pool-odw-${{ variables.env }}-uks'
+- group: ${{ variables.variableGroupName }}
+
+stages:
+- template: stages/pre-deployment.yaml
+  parameters:
+    agentPool: ${{ variables.agentPool }}
+    enforceInfrastructureDeployment: ${{ parameters.enforceInfrastructureDeployment }}
+    enforceFunctionsDeployment: ${{ parameters.enforceFunctionsDeployment }}
+    enforceSynapseDeployment: ${{ parameters.enforceSynapseDeployment }}
+
+- template: stages/wait-for-approval.yaml
+
+- template: stages/conditional-deployment-infrastructure.yaml
+  parameters:
+    agentPool: ${{ variables.agentPool }}
+    env: ${{ variables.env }}
+    armServiceConnectionName: "Azure Devops Pipelines - ODW ${{ upper(variables.env) }} - Infrastructure"
+    failoverDeployment: ${{ parameters.failoverDeployment }}
+    outputsFileName: "tfoutputs.json"
+
+- template: stages/conditional-deployment-functionapp.yaml
+  parameters:
+    agentPool: ${{ variables.agentPool }}
+    env: ${{ variables.env }}
+
+- template: stages/conditional-deployment-synapse.yaml
+  parameters:
+    agentPool: ${{ variables.agentPool }}
+    env: ${{ variables.env }}
+    armServiceConnectionName: "ODW ${{ upper(variables.env) }} - Infrastructure"
+
+- ${{ if eq(parameters.runTests, true) }}:
+  - template: stages/conditional-run-tests.yaml
+    parameters:
+      agentPool: ${{ variables.agentPool }}
+      env: ${{ variables.env }}

--- a/pipelines/jobs/deploy-functionapp.yaml
+++ b/pipelines/jobs/deploy-functionapp.yaml
@@ -1,0 +1,47 @@
+parameters:
+  agentPool: ''
+  env: ''
+  appName: ''
+
+##
+# Deploy Azure Synapse
+##
+jobs:
+- job: DeployFunctionAppJob
+  pool: ${{ parameters.agentPool }}
+  timeoutInMinutes: 0 # Max timeout
+  steps:
+  # Checkout the Github repo, in this case ODW-Service.
+  - checkout: self
+    displayName: 'Checkout repo'
+  
+  # Switch to functions directory and create a file containing a list of all files in the top level folder.
+  - script: |
+      cd $(Build.SourcesDirectory)/functions
+      find . -maxdepth 1 -type f | sed 's|^\./||' > $(Build.SourcesDirectory)/functions/filelist.txt
+    displayName: 'Creating top level files list'
+  
+  # Create a zip file of all the files in the filelist.
+  - script: |
+      cd $(Build.SourcesDirectory)/functions
+      cat $(Build.SourcesDirectory)/functions/filelist.txt | xargs zip -r $(Build.ArtifactStagingDirectory)/functions.zip
+    displayName: 'Archive top level files'
+  
+  # Publish the zip file as an artifact to be used further in the pipeline.
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish build artifact'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: 'FunctionCode'
+  
+  # Download the artifact first - the zip file.
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/download_function_code.yaml
+
+  # Use the Azure CLI to deploy the zip file to the Function App in Azure.
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/deploy_to_function_app.yaml
+    parameters:
+      environment: ${{ parameters.env }}
+      armServiceConnectionName: "Azure Devops Pipelines - ODW ${{ upper(parameters.env) }} - Infrastructure"
+      resourceGroup: 'pins-rg-function-app-odw-${{ parameters.env }}-uks'
+      functionApp: 'pins-${{ parameters.appName }}-odw-${{ parameters.env }}-uks'
+      zipFile: '$(System.ArtifactsDirectory)/FunctionCode/functions.zip'

--- a/pipelines/jobs/deploy-infrastructure.yaml
+++ b/pipelines/jobs/deploy-infrastructure.yaml
@@ -1,0 +1,133 @@
+parameters:
+  agentPool: ''
+  env: ''
+  armServiceConnectionName: ''
+  failoverDeployment: false
+  outputsFileName: ''
+
+
+##
+# Deploy Infrastructure
+##
+jobs:
+- job: DeployInfrastructureJob
+  pool: ${{ parameters.agentPool }}
+  timeoutInMinutes: 0 # Max timeout
+  steps:
+  ###
+  # Validation phase
+  ###
+
+  # Checkout repo
+  - checkout: self
+    displayName: 'Checkout Repo'
+
+  # Install required packages
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/install-tflint.yaml
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/install-checkov.yaml
+
+  # Download firewall rule configuration file
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/download-secure-file.yaml
+    parameters:
+      secureFileName: allowed_ip_addresses.yaml
+      workingDirectory: infrastructure/configuration/firewall-rules
+  
+  # Login to Azure using Terraform service principal
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-login.yaml
+
+  # Run terraform init
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/terraform-init.yaml
+    parameters:
+      environment: ${{ parameters.env }}
+      workingDirectory: infrastructure
+
+  # Run Terraform format
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/terraform-format.yaml
+    parameters:
+      workingDirectory: infrastructure
+
+  # Run Terraform validate
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/terraform-validate.yaml
+    parameters:
+      workingDirectory: infrastructure
+
+  # Run TFLint
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/tflint-validate.yaml
+    parameters:
+      configFilePath: $(Build.Repository.LocalPath)/.tflint.hcl
+      workingDirectory: infrastructure
+
+  # Run Checkov
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/checkov-validate.yaml
+    parameters:
+      framework: terraform
+      workingDirectory: infrastructure
+  
+  ###
+  ## Terraform deployment phase
+  ###
+  # Run Terraform plan
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/terraform-plan.yaml
+    parameters:
+      environment: ${{ parameters.env }}
+      failoverDeployment: ${{ parameters.failoverDeployment }}
+      planFileName: tfplan
+      workingDirectory: infrastructure
+  
+  # Copy Terraform plan files to artifact directory
+  - task: CopyFiles@2
+    displayName: 'Create Artifact'
+    inputs:
+      sourceFolder: infrastructure
+      contents: |
+        .terraform/**
+        .terraform.lock.hcl
+        *.tftpl
+        tfplan
+      targetFolder: $(Build.ArtifactStagingDirectory)
+
+  # Publish pipeline artifacts
+  - publish: $(Build.ArtifactStagingDirectory)
+    artifact: terraform-plan
+    displayName: 'Publish Artifact'
+  
+  # Unlock resources
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-resource-unlock.yaml
+    parameters:
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+  
+  # Run Terraform apply
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/terraform-apply.yaml
+    parameters:
+      environment: ${{ parameters.env }}
+      planFilePath: tfplan
+      workingDirectory: infrastructure
+  
+  # Get Terraform outputs
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/terraform-outputs.yaml
+    parameters:
+      outputsFileName: ${{ parameters.outputsFileName }}
+      workingDirectory: infrastructure
+
+  # Convert Terraform outputs to local pipeline variables
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/terraform-outputs-to-variables.yaml
+    parameters:
+      multiStageVariables: false
+      outputsFileName: ${{ parameters.outputsFileName }}
+      workingDirectory: infrastructure
+
+  # Approve the data lake managed private endpoint if it has been reinstated
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-private-endpoint-approval.yaml
+    parameters:
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+      resourceIds:
+      - $(data_lake_account_id)
+      - $(data_lake_account_id_failover)
+
+  # Lock resources
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-resource-lock.yaml
+    parameters:
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+      resourceIds:
+      - $(data_lake_account_id)
+      - $(data_lake_account_id_failover)

--- a/pipelines/jobs/deploy-synapse.yaml
+++ b/pipelines/jobs/deploy-synapse.yaml
@@ -1,0 +1,138 @@
+parameters:
+  agentPool: ''
+  env: ''
+  armServiceConnectionName: ''
+  activateTriggers: false
+  primaryWorkspace: true
+
+##
+# Deploy Azure Synapse
+##
+jobs:
+- job: DeploySynapseJob
+  pool: ${{ parameters.agentPool }}
+  timeoutInMinutes: 0 # Max timeout
+  variables:
+  - name: overridesFileName
+    value: 'TemplateParametersForWorkspace.json'
+  - name: artifactName
+    value: 'synapse-release'
+  - name: synapseTriggers 
+    ${{ if eq(parameters.env , 'dev') }}: 
+      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly' 
+    ${{ if eq(parameters.env , 'test') }}:
+      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly' 
+    ${{ if eq(parameters.env , 'prod') }}: 
+      value: 'tr_daily_7days_1800,tr_backup_daily,tr_weekly'
+  steps:
+  # Checkout repo
+  - checkout: self
+    displayName: 'Checkout'
+    persistCredentials: true
+    fetchDepth: 0
+  # Login to Azure using Terraform service principal
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-login.yaml
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/get-synapse-details.yaml
+    parameters:
+      env: ${{ parameters.env }}
+      pythonVersion: 3
+      failoverDeployment: false
+  # Set source branch
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/branch-set-source.yaml
+
+  # Switch to the Synapse Workspace publish branch
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/branch-switch.yaml
+    parameters:
+      branchName: 'workspace_publish'
+      showDirectory: $(Build.SourcesDirectory)/$(synapse_workspace_name)
+
+  # Copy Synapse Workspace ARM template files to artifact directory
+  - task: CopyFiles@2
+    displayName: 'Create Release Artifacts'
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/$(synapse_workspace_name)
+      contents: |
+        TemplateForWorkspace.json
+        TemplateParametersForWorkspace.json
+      targetFolder: $(Build.ArtifactStagingDirectory)
+
+  # Switch back to the source branch
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/branch-switch.yaml
+    parameters:
+      branchName: $(source_branch)
+      showDirectory: $(Build.SourcesDirectory)
+
+  # Pre-Override Replacement
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-parameters-override.yaml
+    parameters:
+      overrideFind: 'pinsstodwdevuks9h80mb'
+      overrideReplace: $(data_lake_account_name)
+      templateParametersOverridesFileName: ${{ variables.overridesFileName }}
+      workingDirectory: $(Build.ArtifactStagingDirectory)
+
+  # Publish pipeline artifacts
+  - publish: $(Build.ArtifactStagingDirectory)
+    artifact: ${{ variables.artifactName }}
+    displayName: 'Publish Artifacts'
+  
+  # Check if the dedicated SQL pool is currently paused
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-check.yaml
+    parameters:
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+      synapseWorkspaceName: $(synapse_workspace_name)
+  
+  # Disable triggers in the target Synapse Workspace
+  - task: AzureSynapseWorkspace.synapsecicd-deploy.toggle-trigger.toggle-triggers-dev@2
+    displayName: 'Disable Synapse Triggers'
+    inputs:
+      azureSubscription: ${{ parameters.armServiceConnectionName }}
+      ResourceGroupName: $(data_resource_group_name)
+      WorkspaceName: $(synapse_workspace_name)
+      ToggleOn: false
+  
+  # Resume the dedicated SQL pool if it was in a paused state
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-resume.yaml
+    parameters:
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+      synapseWorkspaceName: $(synapse_workspace_name)
+  
+  # Deploy Synapse Workspace artifacts from the source Workspace to the target Workspace
+  - task: Synapse workspace deployment@2
+    continueOnError: false
+    retryCountOnTaskFailure: '2'
+    displayName: 'Deploy Workspace'
+    inputs:
+      AzureResourceManagerConnection: ${{ parameters.armServiceConnectionName }}
+      DeleteArtifactsNotInTemplate: true
+      Environment: 'prod'
+      operation: 'deploy'
+      OverrideArmParameters: |
+        workspaceName: $(synapse_workspace_name)
+        ls_dsql_connectionString: Integrated Security=False;Encrypt=True;Connection Timeout=30;Data Source=$(synapse_dsql_endpoint);Initial Catalog=@{linkedService().db_name}
+        ls_ssql_builtin_connectionString: Integrated Security=False;Encrypt=True;Connection Timeout=30;Data Source=$(synapse_ssql_endpoint);Initial Catalog=@{linkedService().db_name}
+        ls_backup_destination_properties_typeProperties_url: $(data_lake_dfs_endpoint_failover)
+        ls_backup_source_properties_typeProperties_url: $(data_lake_dfs_endpoint)
+        ls_kv_properties_typeProperties_baseUrl: $(key_vault_uri)
+        ls_servicebus_properties_typeProperties_url: $(service_bus_namespace_name).servicebus.windows.net
+        ls_servicebus_properties_typeProperties_aadResourceId: https://servicebus.azure.net
+        ls_storage_properties_typeProperties_url: $(data_lake_dfs_endpoint)
+      ParametersFile: '$(Build.ArtifactStagingDirectory)/${{ variables.overridesFileName }}'
+      ResourceGroupName: $(data_resource_group_name)
+      TargetWorkspaceName: $(synapse_workspace_name)
+      TemplateFile: '$(Build.ArtifactStagingDirectory)/TemplateForWorkspace.json'
+  
+  # Pause the dedicated SQL pool if it was previously resumed
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-pause.yaml
+    parameters:
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+      synapseWorkspaceName: $(synapse_workspace_name)
+  
+  # Re-enable triggers in the target Synapse Workspace
+  - task: AzureSynapseWorkspace.synapsecicd-deploy.toggle-trigger.toggle-triggers-dev@2
+    condition: succeededOrFailed()
+    displayName: 'Enable Synapse Triggers'
+    inputs:
+      azureSubscription: ${{ parameters.armServiceConnectionName }}
+      ResourceGroupName: $(data_resource_group_name)
+      WorkspaceName: $(synapse_workspace_name)
+      Triggers: ${{ variables.synapseTriggers }}

--- a/pipelines/jobs/run-synapse-integrationtests.yaml
+++ b/pipelines/jobs/run-synapse-integrationtests.yaml
@@ -1,0 +1,22 @@
+parameters:
+  agentPool: ''
+  env: ''
+
+##
+# Run Synapse integration tests
+##
+jobs:
+- job: RunSynapseIntegrationTestsJob
+  pool: ${{ parameters.agentPool }}
+  timeoutInMinutes: 0 # Max timeout
+  steps:
+  - checkout: self
+    clean: true
+  - task: AzureCLI@2
+    displayName: 'Testing'
+    inputs:
+      azureSubscription: 'ODW ${{ upper(parameters.env) }} - Infrastructure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        echo "No tests to run"

--- a/pipelines/jobs/run-synapse-smoketests.yaml
+++ b/pipelines/jobs/run-synapse-smoketests.yaml
@@ -1,0 +1,21 @@
+parameters:
+  agentPool: ''
+  env: ''
+
+##
+# Run Synapse smoke tests
+##
+jobs:
+- job: RunSynapseSmokeTestsJob
+  pool: ${{ parameters.agentPool }}
+  steps:
+  - checkout: self
+    clean: true
+  - task: AzureCLI@2
+    displayName: 'Testing'
+    inputs:
+      azureSubscription: 'ODW ${{ upper(parameters.env) }} - Infrastructure'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        echo "No tests to run"

--- a/pipelines/jobs/run-synapse-unittests.yaml
+++ b/pipelines/jobs/run-synapse-unittests.yaml
@@ -1,0 +1,26 @@
+parameters:
+  agentPool: ''
+  env: ''
+
+##
+# Run Synapse unit tests
+##
+jobs:
+- job: RunSynapseUnitTestsJob
+  pool: ${{ parameters.agentPool }}
+  steps:
+  - checkout: self
+    clean: true
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-login.yaml
+  - script: |
+      export PATH="$PATH:/home/AzDevOps/.local/bin/"
+      sudo apt-get install unixodbc-dev
+      sudo curl -fsSL https://aka.ms/install-azd.sh | bash
+      pip install pandas pyarrow pytest pytest-azurepipelines aiohttp pyodbc azure-storage-blob azure-keyvault-secrets azure-identity azure-storage-file-datalake azure-synapse azure-mgmt-resource pytest pytest-xdist[psutil]
+      cd $(Build.SourcesDirectory)/workspace/testing/tests
+      export SYNAPSE_ENDPOINT="${{ format('https://pins-synw-odw-{0}-uks.dev.azuresynapse.net/', lower(parameters.env)) }}"
+      export CREDENTIAL_NAME="${{ format('https://dev.azuresynapse.net/.default', lower(parameters.env)) }}"
+      echo $SYNAPSE_ENDPOINT 
+      echo $CREDENTIAL_NAME
+      pytest -vv -rP -n 4
+    displayName: 'pytest'

--- a/pipelines/scripts/get_synapse_details.py
+++ b/pipelines/scripts/get_synapse_details.py
@@ -1,0 +1,177 @@
+import subprocess
+import json
+import argparse
+from typing import List, Dict, Any, Union
+
+
+class NameFactory():
+    """
+        Class for handling switching the names of resources depending on if the deployment
+        is for disaster recovery
+    """
+    @classmethod
+    def get(cls, env: str, failover_deployment: bool = False):
+        base_names = {
+            "keyvault_resource_group": f"pins-rg-data-odw-{env}-uks"
+        }
+        if failover_deployment:
+            return {
+                **base_names,
+                **{
+                    "data_lake_resource_group": f"pins-rg-data-odw-{env}-ukw",
+                    "data_lake_resource_group_backup": f"pins-rg-data-odw-{env}-uks",
+                    "data_lake_name": f"pinsstodw{env}ukw",
+                    "data_lake_name_backup": f"pinsstodw{env}uks",
+                    "service_bus_resource_group": f"pins-rg-ingestion-odw-{env}-ukw",
+                    "devops_agent_pool_resource_group_name": f"pins-rg-devops-odw-{env}-ukw"
+                }
+            }
+        return {
+            **base_names,
+            **{
+                "data_lake_resource_group": f"pins-rg-data-odw-{env}-uks",
+                "data_lake_resource_group_backup": f"pins-rg-data-odw-{env}-ukw",
+                "data_lake_name": f"pinsstodw{env}uks",
+                "data_lake_name_backup": f"pinsstodw{env}ukw",
+                "service_bus_resource_group": f"pins-rg-ingestion-odw-{env}-uks",
+                "devops_agent_pool_resource_group_name": f"pins-rg-devops-odw-{env}-uks"
+            }
+        }
+
+
+def run_az_cli_command(args: List[str]):
+    """
+        Run an az cli command. Raises a `RuntimeException` if something goes wrong
+    """
+    print(f"Running command: '{' '.join(args)}'")
+    try:
+        return subprocess.check_output(args)
+    except subprocess.CalledProcessError as e:
+        exception = e
+    raise RuntimeError(f"Exception raised when running the above command: {exception.output.decode('utf-8')}")
+
+
+def get_storage_accounts(resource_group_name: str) -> List[Dict[str, Any]]:
+    """
+        Return all storage accounts under the given resource group
+    """
+    return json.loads(run_az_cli_command(["az", "storage", "account", "list", "--resource-group", resource_group_name]))
+
+
+def get_key_vaults(resource_group_name: str) -> List[Dict[str, Any]]:
+    """
+        Return all key vaults under the given resource group
+    """
+    return json.loads(run_az_cli_command(["az", "keyvault", "list", "--resource-group", resource_group_name]))
+
+
+def get_services_buses(resource_group_name: str) -> List[Dict[str, Any]]:
+    """
+        Return all service buses under the given resource group
+    """
+    return json.loads(run_az_cli_command(["az", "servicebus", "namespace", "list", "--resource-group", resource_group_name]))
+
+
+def get_synapse_workspace(resource_group_name: str) -> List[Dict[str, Any]]:
+    """
+        Return all synapse workspaces under the given resource group
+    """
+    return json.loads(run_az_cli_command(["az", "synapse", "workspace", "list", "--resource-group", resource_group_name]))
+
+
+def get_service_bus_connection_string(resource_group_name: str, service_bus_name: str) -> str:
+    """
+        Return the primary connection string of the given service bus under the specified resource group
+    """
+    args = [
+        "--resource-group",
+        resource_group_name,
+        "--namespace-name",
+        service_bus_name,
+        "-n",
+        "RootManageSharedAccessKey",
+        "--query",
+        "primaryConnectionString",
+        "-o",
+        "tsv"
+    ]
+    command_to_run = ["az", "servicebus", "namespace", "authorization-rule", "keys", "list"] + args
+
+    return run_az_cli_command(command_to_run).decode("ascii")
+
+
+def get_resource(resource_type: str, resource_group_name: str, resource_name_prefix: str, optional: bool = False) -> Union[Dict[str, Any], None]:
+    """
+        Extracts a single resource of specified resource_type under a particular resource group, by selecting the resource that
+        matches the given prefix. If more than one resource is identified with the prefix (or if none are found), then raises an exception.
+        If the resource is optional, then if it is not found then None is returned
+    """
+    resource_type_function_map = {
+        "Blob Storage": get_storage_accounts,
+        "Key Vault": get_key_vaults,
+        "Service Bus": get_services_buses,
+        "Synapse Workspace": get_synapse_workspace
+    }
+    if resource_type not in resource_type_function_map:
+        raise ValueError(f"No resource getter defined for resource_type {resource_type}")
+    all_resources = resource_type_function_map[resource_type](resource_group_name)
+    candidate_resources = [x for x in all_resources if x["name"].startswith(resource_name_prefix)]
+    if len(candidate_resources) != 1:
+        if optional and not candidate_resources:
+            return None
+        raise ValueError(
+            f"Expected only a single {resource_type} resource to match the prefix {resource_name_prefix}, but there were {len(candidate_resources)}"
+        )
+    return candidate_resources[0]
+
+
+if __name__ == "__main__":
+    # Load command line arguments
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-e", "--env", help="Environment to run against")
+    parser.add_argument("-f", "--failover_deployment", help="If this is a backup deployment", default=False)
+    args = parser.parse_args()
+    env = args.env
+    failover_deployment = str(args.failover_deployment).lower() == "true"
+
+    # Set resource group during processing based on Terraform logic
+    names = NameFactory.get(env, failover_deployment)
+    data_lake_resource_group = names["data_lake_resource_group"]
+    data_lake_resource_group_backup = names["data_lake_resource_group_backup"]
+    data_lake_name = names["data_lake_name"]
+    data_lake_name_backup = names["data_lake_name_backup"]
+    keyvault_resource_group = names["keyvault_resource_group"]
+    service_bus_resource_group = names["service_bus_resource_group"]
+    devops_agent_pool_resource_group_name = names["devops_agent_pool_resource_group_name"]
+
+    # Extract relevant Azure resources
+    main_datalake = get_resource("Blob Storage", data_lake_resource_group, data_lake_name)
+    backup_datalake = get_resource("Blob Storage", data_lake_resource_group_backup, data_lake_name_backup, optional=True)
+    key_vault = get_resource("Key Vault", keyvault_resource_group, f"pinskvsynwodw{env}uks")
+    service_bus = get_resource("Service Bus", service_bus_resource_group, f"pins-sb-odw-{env}")
+    synapse_workspace = get_resource("Synapse Workspace", data_lake_resource_group, f"pins-synw-odw-{env}")
+    service_bus_primary_connection_string = get_service_bus_connection_string(service_bus_resource_group, service_bus["name"])
+    
+    # Save variables to Azure Pipeline
+    variables = {
+        "data_lake_account_id": main_datalake["id"],
+        "data_lake_account_id_failover": backup_datalake["id"],
+        "data_lake_account_name": main_datalake["name"],
+        "data_lake_dfs_endpoint": main_datalake["primaryEndpoints"]["dfs"],
+        "data_lake_dfs_endpoint_failover": backup_datalake["primaryEndpoints"]["dfs"],
+        "data_resource_group_name": f"pins-rg-data-odw-{env}-uks",
+        "devops_agent_pool_resource_group_name": devops_agent_pool_resource_group_name,
+        "key_vault_uri": key_vault["properties"]["vaultUri"],
+        "service_bus_namespace_name": service_bus["name"],
+        "service_bus_primary_connection_string": service_bus_primary_connection_string,
+        "synapse_dev_endpoint": synapse_workspace["connectivityEndpoints"]["dev"],
+        "synapse_dsql_endpoint": synapse_workspace["connectivityEndpoints"]["sql"],
+        "synapse_ssql_endpoint": synapse_workspace["connectivityEndpoints"]["sqlOnDemand"],
+        "synapse_workspace_id": synapse_workspace["id"],
+        "synapse_workspace_name": synapse_workspace["name"]
+    }
+    print("Setting the following variables")
+    print(json.dumps(variables, indent=4))
+    for variable_name, variable_value in variables.items():
+        print(f"Saving variable '{variable_name}'")
+        print(f'##vso[task.setvariable variable={variable_name};]{variable_value}')

--- a/pipelines/stages/conditional-deployment-functionapp.yaml
+++ b/pipelines/stages/conditional-deployment-functionapp.yaml
@@ -1,0 +1,21 @@
+parameters:
+  agentPool: ''
+  env: ''
+
+##
+# Deploy Azure Functions only if a modification has been detected in the codebase
+##
+stages:
+- stage: DeployFunctionApp
+  displayName: 'Deploy Function App to the ${{ parameters.env }} environment'
+  condition: |
+    and(
+      not(or(failed(), canceled())),
+      eq(dependencies.PreDeploy.outputs['PreDeploymentJob.checkModifiedComponents.functionsModified'], true)
+    )
+  jobs:
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/jobs/deploy-functionapp.yaml
+    parameters:
+      agentPool: ${{ parameters.agentPool }}
+      env: ${{ parameters.env }}
+      appName: 'fnapp01'

--- a/pipelines/stages/conditional-deployment-infrastructure.yaml
+++ b/pipelines/stages/conditional-deployment-infrastructure.yaml
@@ -1,0 +1,26 @@
+parameters:
+  agentPool: ''
+  env: ''
+  armServiceConnectionName: ''
+  failoverDeployment: false
+  outputsFileName: ''
+
+##
+# Deploy Infrastructure only if a modification has been detected in the codebase
+##
+stages:
+- stage: DeployInfrastructure
+  displayName: 'Deploy Infrastructure to the ${{ parameters.env }} environment'
+  condition: |
+    and(
+      not(or(failed(), canceled())),
+      eq(dependencies.PreDeploy.outputs['PreDeploymentJob.checkModifiedComponents.infrastructureModified'], true)
+    )
+  jobs:
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/jobs/deploy-infrastructure.yaml
+    parameters:
+      agentPool: ${{ parameters.agentPool }}
+      env: ${{ parameters.env }}
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+      failoverDeployment: ${{ parameters.failoverDeployment }}
+      outputsFileName: ${{ parameters.outputsFileName }}

--- a/pipelines/stages/conditional-deployment-synapse.yaml
+++ b/pipelines/stages/conditional-deployment-synapse.yaml
@@ -1,0 +1,26 @@
+parameters:
+  agentPool: ''
+  env: ''
+  armServiceConnectionName: ''
+
+##
+# Deploy Azure Synapse only if a modification has been detected in the codebase
+##
+stages:
+- stage: DeploySynapse
+  displayName: 'Deploy Synapse to the ${{ parameters.env }} environment'
+  condition: |
+    and(
+      not(or(failed(), canceled())),
+      eq(dependencies.PreDeploy.outputs['PreDeploymentJob.checkModifiedComponents.synapseModified'], true)
+    )
+  jobs:
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/jobs/deploy-synapse.yaml
+    parameters:
+      agentPool: ${{ parameters.agentPool }}
+      env: ${{ parameters.env }}
+      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+      activateTriggers: false
+      runUnitTests: true
+      runIntegrationTests: True
+      runEndToEndTests: true

--- a/pipelines/stages/conditional-run-tests.yaml
+++ b/pipelines/stages/conditional-run-tests.yaml
@@ -1,0 +1,26 @@
+parameters:
+  agentPool: ''
+  env: ''
+
+##
+# Run tests relevant to specific environments
+##
+stages:
+- stage: RunTests
+  displayName: 'Run tests in the ${{ parameters.env }} environment'
+  condition: |
+    not(or(failed(), canceled()))
+  jobs:
+  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/jobs/run-synapse-smoketests.yaml
+    parameters:
+      agentPool: ${{ parameters.agentPool }}
+      env: ${{ parameters.env }}
+  - ${{ if ne(parameters.env, 'prod') }}:
+    - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/jobs/run-synapse-unittests.yaml
+      parameters:
+        agentPool: ${{ parameters.agentPool }}
+        env: ${{ parameters.env }}
+    - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/jobs/run-synapse-integrationtests.yaml
+      parameters:
+        agentPool: ${{ parameters.agentPool }}
+        env: ${{ parameters.env }}

--- a/pipelines/stages/pre-deployment.yaml
+++ b/pipelines/stages/pre-deployment.yaml
@@ -1,0 +1,23 @@
+parameters:
+  agentPool: ''
+  enforceInfrastructureDeployment: false
+  enforceFunctionsDeployment: false
+  enforceSynapseDeployment: false
+
+##
+# Check which components need to be deployed
+##
+stages:
+- stage: PreDeploy
+  displayName: 'Pre-deployment checks to work out what needs to be deployed'
+  jobs:
+  - job: PreDeploymentJob
+    pool: ${{ parameters.agentPool }}
+    steps:
+    - checkout: 'self'
+      fetchDepth: 0
+    - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/check-which-component-is-modified.yaml
+      parameters:
+        enforceInfrastructureDeployment: ${{ parameters.enforceInfrastructureDeployment }}
+        enforceFunctionsDeployment: ${{ parameters.enforceFunctionsDeployment }}
+        enforceSynapseDeployment: ${{ parameters.enforceSynapseDeployment }}

--- a/pipelines/stages/wait-for-approval.yaml
+++ b/pipelines/stages/wait-for-approval.yaml
@@ -1,0 +1,17 @@
+##
+# Wait for admins to approve this stage before proceeding with subsequent stages
+##
+stages:
+- stage: WaitForApproval
+  displayName: Wait For Approval Before Deploying
+  condition: eq(variables.env, 'prod')
+  jobs:
+  - deployment: WaitForApprovalJob
+    displayName: Wait For Approval
+    environment: $(env)
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - script: echo "Approved"
+            displayName: Approved Message

--- a/pipelines/steps/branch-set-source.yaml
+++ b/pipelines/steps/branch-set-source.yaml
@@ -1,11 +1,14 @@
-parameters:
-  - name: branchName
-    type: string
-
 steps:
-  - powershell: |
-      $SourceBranch = "${{ parameters.branchName }}" -replace "refs/heads/", ""
-      Write-Host "Exporting current branch name $SourceBranch..."
-      Write-Host "##[command][task.setvariable variable=source_branch;isOutput=false]$SourceBranch"
-      Write-Host "##vso[task.setvariable variable=source_branch;isOutput=false]$SourceBranch"
+  - bash: |
+      baseBranch="$(Build.SourceBranch)"
+      echo "Build reason '$(Build.Reason)'"
+      if [[ $(Build.Reason) == "PullRequest" ]]; then
+          baseBranch="$(System.PullRequest.SourceBranch)"
+      fi
+      echo "Base branch set to $baseBranch"
+      toReplace="refs/heads/"
+      toReplaceWith=""
+      sourceBranch="${baseBranch/$toReplace/$toReplaceWith}"
+      echo "Exporting current branch name $sourceBranch..."
+      echo "##vso[task.setvariable variable=source_branch;isOutput=false]$sourceBranch"
     displayName: 'Set Source Branch'

--- a/pipelines/steps/check-which-component-is-modified.yaml
+++ b/pipelines/steps/check-which-component-is-modified.yaml
@@ -1,0 +1,86 @@
+parameters:
+  enforceInfrastructureDeployment: false
+  enforceFunctionsDeployment: false
+  enforceSynapseDeployment: false
+##
+# Check which services have been modified and need to be redeployed
+##
+steps:
+- bash: |
+    sourceBranch="${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}"
+    echo "build reason ${{ variables['Build.Reason'] }}"
+    if [[ ${{ variables['Build.Reason'] }} = 'PullRequest' ]]; then
+        echo "This run has been triggered by a pull request"
+        sourceBranch="$(system.pullRequest.sourceBranch)"
+    fi
+    deployEverything=false
+    echo "Source branch is '$sourceBranch'"
+    if [[ $sourceBranch = dev ]]; then
+        targetBranch=testing
+    elif [[ $sourceBranch = testing ]]; then
+        targetBranch=main
+    elif [[ $sourceBranch = main ]]; then
+        echo "The source branch is main, so forcing a full deployment"
+        deployEverything=true
+        targetBranch=main
+    else
+        targetBranch=dev
+    fi
+    echo "Using target branch '$targetBranch'"
+    modifiedFiles="$(git diff --name-status origin/$targetBranch)"
+    echo "The following files have been modified"
+    echo "${modifiedFiles}"
+
+    # The below variables represent services that need to be deployed
+    infrastructureModified=false
+    functionsModified=false
+    synapseModified=false
+
+    if [[ $modifiedFiles == *"infrastructure/"* || $modifiedFiles == *"servicebus/"* ]]; then
+        infrastructureModified=true
+        echo "Detected an Infrastructure change under 'infrastructure/' or 'servicebus/'"
+    fi
+    if [[ $modifiedFiles == *"functionapp/"* || $modifiedFiles == *"functions/"* ]]; then
+        functionsModified=true
+        echo "Detected a Function App change under 'functionapp/' or 'functions'"
+    fi
+    if [[ $modifiedFiles == *"workspace/"* ]]; then
+        synapseModified=true
+        echo "Detected a Synapse change under 'workspace/'"
+    fi
+    if [[ $modifiedFiles == *"pipelines/"* ]]; then
+        # If CI/CD pipelines are modified, then redeploy everything to make sure the pipelines work
+        infrastructureModified=true
+        functionsModified=true
+        synapseModified=true
+        echo "Detected a change for the CI/CD process under 'pipelines/'"
+    fi
+    if [[ "$deployEverything" = true ]]; then
+        # If fullDeployment is true, then deploy everything
+        infrastructureModified=true
+        functionsModified=true
+        synapseModified=true
+        echo "Running from the main branch, so by default everything will be deployed"
+    fi
+    if [[ ${{ lower(parameters.enforceInfrastructureDeployment) }} = true ]]; then
+        infrastructureModified=true
+        echo "enforceInfrastructureDeployment=true, deploying infrastructure"
+    fi
+    if [[ ${{ lower(parameters.enforceFunctionsDeployment) }} = true ]]; then
+        functionsModified=true
+        echo "enforceFunctionsDeployment=true, deploying functions"
+    fi
+    if [[ ${{ lower(parameters.enforceSynapseDeployment) }} = true ]]; then
+        synapseModified=true
+        echo "enforceSynapseDeployment=true, deploying synapse"
+    fi
+
+    echo "infrastructureModified = ${infrastructureModified}"
+    echo "functionsModified = ${functionsModified}"
+    echo "synapseModified = ${synapseModified}"
+
+    echo "##vso[task.setvariable variable=infrastructureModified;isOutput=true]$infrastructureModified"
+    echo "##vso[task.setvariable variable=functionsModified;isOutput=true]$functionsModified"
+    echo "##vso[task.setvariable variable=synapseModified;isOutput=true]$synapseModified"
+  displayName: 'Check which components have been modified'
+  name: checkModifiedComponents

--- a/pipelines/steps/deploy_to_function_app.yaml
+++ b/pipelines/steps/deploy_to_function_app.yaml
@@ -24,14 +24,14 @@ steps:
     inlineScript: |
 
       echo "Deploying to function app with the following variables:"
-      echo "Environment: $(environment)"
-      echo "Service Connection": $(armServiceConnectionName)
-      echo "Resource Group: $(resourceGroup)"
-      echo "Function App Name: $(functionApp)"
-      echo "Zip File: $(zipFile)"
+      echo "Environment: ${{ parameters.environment }}"
+      echo "Service Connection": ${{ parameters.armServiceConnectionName }}
+      echo "Resource Group: ${{ parameters.resourceGroup }}"
+      echo "Function App Name: ${{ parameters.functionApp }}"
+      echo "Zip File: ${{ parameters.zipFile }}"
 
       az functionapp deployment source config-zip \
-      --resource-group $(resourceGroup) \
-      --name $(functionApp) \
-      --src $(zipFile) \
+      --resource-group ${{ parameters.resourceGroup }} \
+      --name ${{ parameters.functionApp }} \
+      --src ${{ parameters.zipFile }} \
       --build-remote true

--- a/pipelines/steps/get-synapse-details.yaml
+++ b/pipelines/steps/get-synapse-details.yaml
@@ -1,0 +1,17 @@
+parameters:
+  env: ''
+  pythonVersion: ''
+  failoverDeployment: false
+
+steps:
+  - script: |
+      set -x
+      python${{ parameters.pythonVersion }} --version
+      export PYTHONPATH="${PYTHONPATH}:/./"
+      python${{ parameters.pythonVersion }} $(System.DefaultWorkingDirectory)/pipelines/scripts/get_synapse_details.py --env ${{ parameters.env }} --failover_deployment ${{ parameters.failoverDeployment }}
+      if [ $? -eq 1 ]; then
+          echo "##vso[task.logissue type=error]get_synapse_details.py failed"
+          exit 1
+      fi
+    displayName: 'Set Variables'
+    name: SetVariables

--- a/pipelines/synapse-release.yaml
+++ b/pipelines/synapse-release.yaml
@@ -134,8 +134,6 @@ stages:
 
       # Set source branch
       - template: steps/branch-set-source.yaml
-        parameters:
-          branchName: $(Build.SourceBranch)
 
       # Switch to the Synapse Workspace publish branch
       - template: steps/branch-switch.yaml


### PR DESCRIPTION
* Theodw 1638 improve git cicd strategy (#1780)

* Add new CICD pipeline to deploy all components and to run tests to implement the new CI/CD process. Add github action to automatically create a dev branch and test branch when new code is merged to support the new branching strategy. Refactor existing pipeline steps to accommodate the change

* Rename main CI/CD pipeline

* Update pipeline name. Improve commenting

* Switch to using subprocess instead of os module to run cli commands

* Remove dict entry

* Add error handling around az cli

* Update pr trigger. Update syntax error

* Add github action to reject merging into main from any branch other than testing

* Add github action to reject merging into testing from any branch other than dev

* Update name of github action

* Add space

* Add missing property

* Theodw 1638 dev cron job (#1785)

* Update cron job to run the dev env every day. Update cron job time

* Add comment

* Update triggers to run on merge to the testing branch. Remove testing branch cron schedule

* Update cron schedule

* Add comment to force a ci run

* Remove comment

* Resolve red build status for github action (#1786)

* Add extra bracket

* Update condition of github action to be more consistent

* Update trigger condition

* Remove extra space

* Theodw 1638 update modification detection (#1787)

* Add fullDeployment parameter

* Update condition

* Add debug line

* Update condition. Remove debug line

* update condition

* Update condition

* Add missing parameter

* Remove debug statement

* Update logic to auto-resolve the target branch, so it is not hardcoded to be dev

* Wrap value in quotes

* Add missing quote

* Add missing brackets

* Add missing brackets

* Add space between brackets

* Update method of selecting the source branch

* Add quotes

* Update source branch name

* Update source branch name

* Add debug line

* Add debug line

* Update incorrect variable ref

* Update approach for getting the branch name

* Add override parameters to allow specific components to be deployed

* Skip unit tests in prod env due to them currently containing some integration tests (#1788)

* Update env variable definition to use compile-time expression (#1792)

* Theodw 1638 update GitHub action (#1793)

* Update logic for github action

* Add test github action to test the changes on pr rather than on merge

* Add comment to force a rerun

* Delete test github action

---------

**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
