### PR TITLE
Feat/theodw 1672 test nsip subscription py test nsip project notebook unit test fail

### DIFF
--- a/.github/workflows/main-merge.yaml
+++ b/.github/workflows/main-merge.yaml
@@ -21,7 +21,7 @@ jobs:
         set -e
         git fetch
         git checkout main
-        devBranches=$(git ls-remote --heads origin dev
+        devBranches=$(git ls-remote --heads origin dev)
         echo $devBranches
         if [[ -z "$devBranches" ]]; then
             git push -d origin dev

--- a/.github/workflows/main-merge.yaml
+++ b/.github/workflows/main-merge.yaml
@@ -24,9 +24,9 @@ jobs:
         devBranches=$(git ls-remote --heads origin dev)
         echo $devBranches
         if [[ -z "$devBranches" ]]; then
-            git push -d origin dev
-        else
             echo "Dev branch does not exist, nothing to delete"
+        else
+            git push -d origin dev
         fi
         git checkout -b dev
         git push --set-upstream origin dev

--- a/infrastructure/configuration/spark-pool/requirements-preview.txt
+++ b/infrastructure/configuration/spark-pool/requirements-preview.txt
@@ -5,7 +5,7 @@
 azure-servicebus==7.13.0
 
 # Logging
-azure-monitor-opentelemetry==1.6.4
+azure-monitor-opentelemetry==1.6.7
 
 # Retry
 tenacity==9.0.0

--- a/infrastructure/configuration/spark-pool/requirements.txt
+++ b/infrastructure/configuration/spark-pool/requirements.txt
@@ -5,7 +5,7 @@
 azure-servicebus==7.13.0
 
 # Logging
-azure-monitor-opentelemetry==1.6.4
+azure-monitor-opentelemetry==1.6.7
 
 # Retry
 tenacity==9.0.0

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -210,10 +210,10 @@ spark_pool_max_node_count  = 12
 spark_pool_min_node_count  = 3
 spark_pool_node_size       = "Small"
 spark_pool_timeout_minutes = 60
-spark_pool_version         = "3.3"
+spark_pool_version         = "3.4"
 
 spark_pool_preview_enabled = true
-spark_pool_preview_version = "3.3"
+spark_pool_preview_version = "3.4"
 
 sql_pool_collation = "SQL_Latin1_General_CP1_CI_AS"
 sql_pool_enabled   = false

--- a/infrastructure/modules/synapse-workspace-private/synapse-spark-pool.tf
+++ b/infrastructure/modules/synapse-workspace-private/synapse-spark-pool.tf
@@ -78,3 +78,44 @@ resource "azurerm_synapse_spark_pool" "synapse_preview" {
   tags = local.tags
 
 }
+
+resource "azurerm_synapse_spark_pool" "synapse34" {
+  count = var.spark_pool_enabled ? 1 : 0
+
+  name                           = "pinssynspodw34"
+  synapse_workspace_id           = azurerm_synapse_workspace.synapse.id
+  node_size_family               = "MemoryOptimized"
+  node_size                      = var.spark_pool_node_size
+  spark_version                  = var.spark_pool_version
+  session_level_packages_enabled = true
+
+  auto_pause {
+    delay_in_minutes = var.spark_pool_timeout_minutes
+  }
+
+  auto_scale {
+    max_node_count = var.spark_pool_max_node_count
+    min_node_count = var.spark_pool_min_node_count
+  }
+
+  dynamic "library_requirement" {
+    for_each = var.spark_pool_requirements != null ? [1] : []
+
+    content {
+      content  = var.spark_pool_requirements
+      filename = "requirements.txt"
+    }
+  }
+
+  spark_config {
+    content  = <<-EOT
+      spark.executorEnv.dataLakeAccountName ${var.data_lake_account_name}
+      spark.executorEnv.keyVaultName ${var.key_vault_name}
+      spark.sql.parquet.int96RebaseModeInWrite CORRECTED
+      spark.sql.constraintPropagation.enabled false
+      EOT
+    filename = "configuration.txt"
+  }
+
+  tags = local.tags
+}

--- a/workspace/notebook/py_unit_tests_nsip_subscription.json
+++ b/workspace/notebook/py_unit_tests_nsip_subscription.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d328f4ee-881e-44db-bc9e-cbc8d7712029"
+				"spark.autotune.trackingId": "7969abdf-c3fa-49b4-b548-2e68ca72f515"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/py_unit_tests_nsip_subscription.json
+++ b/workspace/notebook/py_unit_tests_nsip_subscription.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "087ebb90-6fa2-4530-b74e-a5f5e693a80b"
+				"spark.autotune.trackingId": "533f9c3d-7a10-4f65-80cb-82619ce99eef"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"from pyspark.sql import DataFrame\r\n",
 					"from pyspark.sql import functions as F"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -94,7 +94,7 @@
 					"hrm_table_name: str = 'sb_nsip_subscription'\r\n",
 					"curated_table_name: str = 'nsip_subscription'"
 				],
-				"execution_count": null
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -112,7 +112,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -131,7 +131,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\r\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": null
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -164,7 +164,7 @@
 					"\t\"input_file\"\r\n",
 					"]"
 				],
-				"execution_count": null
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
@@ -189,7 +189,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\r\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": null
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\r\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": null
+				"execution_count": 17
 			},
 			{
 				"cell_type": "code",
@@ -242,7 +242,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\r\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": null
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -262,7 +262,14 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\r\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": null
+				"execution_count": 19
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"mssparkutils.notebook.exit(exitCode)"
+				],
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_nsip_subscription.json
+++ b/workspace/notebook/py_unit_tests_nsip_subscription.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "533f9c3d-7a10-4f65-80cb-82619ce99eef"
+				"spark.autotune.trackingId": "d328f4ee-881e-44db-bc9e-cbc8d7712029"
 			}
 		},
 		"metadata": {
@@ -69,7 +69,7 @@
 					"from pyspark.sql import DataFrame\r\n",
 					"from pyspark.sql import functions as F"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -94,7 +94,7 @@
 					"hrm_table_name: str = 'sb_nsip_subscription'\r\n",
 					"curated_table_name: str = 'nsip_subscription'"
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -112,7 +112,7 @@
 				"source": [
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -131,7 +131,7 @@
 					"#keep track of the exitCodes, if the exit code is not zero then we've had failures, we flip the boolean\r\n",
 					"exitCode: int = 0"
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -164,7 +164,7 @@
 					"\t\"input_file\"\r\n",
 					"]"
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -189,7 +189,7 @@
 					"curated_schema = create_spark_schema(curated_db_name, entity_name)\r\n",
 					"curated_table_schema = spark.table(f\"{curated_db_name}.{curated_table_name}\").schema"
 				],
-				"execution_count": 16
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -218,7 +218,7 @@
 					"print(f\"Curated schema correct: {cur_schema_correct}\\nTable: {curated_db_name}.{curated_table_name}\\nDifferences shown above (if any)\")\r\n",
 					"exitCode += int(not cur_schema_correct)"
 				],
-				"execution_count": 17
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -242,7 +242,7 @@
 					"    print(f\"{standardised_count - harmonised_count} rows from Standardised are missing in Harmonised.\" )\r\n",
 					"    differentiate_std_and_hrm(f\"{std_db_name}.{std_table_name}\", f\"{hrm_db_name}.{hrm_table_name}\", data_model_columns)"
 				],
-				"execution_count": 18
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -262,14 +262,14 @@
 					"print(f\"Harmonised Final Count: {harmonised_final_count: ,}\\nCurated Count: {curated_count: ,}\\nCounts match: {counts_match}\")\r\n",
 					"exitCode += int(not counts_match)"
 				],
-				"execution_count": 19
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"mssparkutils.notebook.exit(exitCode)"
 				],
-				"execution_count": 20
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_unit_tests_nsip_subscription.json
+++ b/workspace/notebook/py_unit_tests_nsip_subscription.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c9efae0d-a3a7-4ca7-8f43-a8d70772e9e9"
+				"spark.autotune.trackingId": "087ebb90-6fa2-4530-b74e-a5f5e693a80b"
 			}
 		},
 		"metadata": {
@@ -45,7 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -109,7 +110,6 @@
 					}
 				},
 				"source": [
-					"# import the create_spark_schema function\r\n",
 					"%run /utils/unit-tests/py_unit_tests_functions"
 				],
 				"execution_count": null
@@ -318,6 +318,9 @@
 			{
 				"cell_type": "code",
 				"metadata": {
+					"microsoft": {
+						"language": "sparksql"
+					},
 					"collapsed": false
 				},
 				"source": [

--- a/workspace/sparkConfiguration/sparkConfiguration34.json
+++ b/workspace/sparkConfiguration/sparkConfiguration34.json
@@ -1,0 +1,20 @@
+{
+	"name": "sparkConfiguration34",
+	"properties": {
+		"configs": {
+			"park.executorEnv.dataLakeAccountName": "pinsstodwdevuks9h80mb",
+			"spark.executorEnv.keyVaultName": "pinskvsynwodwdevuks",
+			"spark.sql.parquet.int96RebaseModeInWrite": "CORRECTED",
+			"spark.sql.constraintPropagation.enabled": "false"
+		},
+		"created": "2025-04-11T14:34:14.9160000+01:00",
+		"createdBy": "susdeliglia@pinso365.onmicrosoft.com",
+		"annotations": [],
+		"configMergeRule": {
+			"artifact.currentOperation.park.executorEnv.dataLakeAccountName": "replace",
+			"artifact.currentOperation.spark.executorEnv.keyVaultName": "replace",
+			"artifact.currentOperation.spark.sql.parquet.int96RebaseModeInWrite": "replace",
+			"artifact.currentOperation.spark.sql.constraintPropagation.enabled": "replace"
+		}
+	}
+}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
