### PR TITLE
chore(tooling): updating latest terraform version

### DIFF
--- a/infrastructure/configuration/devops-agents/build.pkr.hcl
+++ b/infrastructure/configuration/devops-agents/build.pkr.hcl
@@ -11,7 +11,7 @@ source "azure-arm" "azure-agents" {
   azure_tags = {
     Project          = "tooling"
     CreatedBy        = "packer"
-    TerraformVersion = "1.11.3"
+    TerraformVersion = "1.11.4"
     pythonVersion    = "3.13"
   }
 

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -61,7 +61,7 @@ sudo apt install -y --no-install-recommends \
 # Terraform 1.9.6
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-sudo apt-get install -y terraform=1.11.3-1
+sudo apt-get install -y terraform=1.11.4-1
 
 # TFLint
 curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/pipelines/devops-agent-deploy.yaml
+++ b/pipelines/devops-agent-deploy.yaml
@@ -47,7 +47,7 @@ pr: none
 trigger: none
 
 pool:
-  vmImage: ubuntu-latest
+  vmImage: ubuntu-22.04  # Ubuntu-latest by default does not have Terraform installed
 
 stages:
   - stage: Plan


### PR DESCRIPTION
## Describe your changes

Updating terraform to latest version 1.11.4

- [Ticket](https://pins-ds.atlassian.net/browse/DEV-346)

<!-- - [Image build](https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=112342&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=f07b485a-4928-5c8c-1dd5-52819906354e&l=3177)

- [Terraform plan for agent image update](https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=112359&view=logs&j=73ba6cf2-a55c-5a6d-eb3f-888082e04ae4&t=2bf3c59d-8ee2-5476-8405-92376983bc84&l=37) -->


<ins>**NOTE:**</ins>

- Updating devops-agent-deploy.yml pipeline to use ubuntu-22.04 azure agent image as with ubuntu-latest(version 24) terraform in not installed by default and pipeline fails with 'terraform command not' found error.
- Azure agents is only used in agent deploy pipeline. Rest ODW pipeline uses ODW-agents
-  [Ubuntu-latest terraform error in pipeline](https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=112355&view=logs&j=73ba6cf2-a55c-5a6d-eb3f-888082e04ae4&t=e9d7fe18-f96a-5691-d827-72eb9e3946cf&l=16)


 
<!-- **PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 

-->
	
 
