### PR TITLE
Theodw 1750 fj

### DIFF
--- a/workspace/dataset/HZN_NSIP_Query.json
+++ b/workspace/dataset/HZN_NSIP_Query.json
@@ -12,7 +12,128 @@
 		},
 		"annotations": [],
 		"type": "SqlServerTable",
-		"schema": [],
+		"schema": [
+			{
+				"name": "VersionID",
+				"type": "int",
+				"precision": 10
+			},
+			{
+				"name": "DataId",
+				"type": "int",
+				"precision": 10
+			},
+			{
+				"name": "CaseNodeId",
+				"type": "int",
+				"precision": 10
+			},
+			{
+				"name": "caseReference",
+				"type": "varchar"
+			},
+			{
+				"name": "documentReference",
+				"type": "nvarchar"
+			},
+			{
+				"name": "Version",
+				"type": "int",
+				"precision": 10
+			},
+			{
+				"name": "name",
+				"type": "nvarchar"
+			},
+			{
+				"name": "originalFilename",
+				"type": "nvarchar"
+			},
+			{
+				"name": "DataSize",
+				"type": "bigint",
+				"precision": 19
+			},
+			{
+				"name": "virusCheckStatus",
+				"type": "varchar"
+			},
+			{
+				"name": "CreateDate",
+				"type": "datetime",
+				"precision": 23,
+				"scale": 3
+			},
+			{
+				"name": "ModifyDate",
+				"type": "datetime",
+				"precision": 23,
+				"scale": 3
+			},
+			{
+				"name": "caseworkType",
+				"type": "varchar"
+			},
+			{
+				"name": "publishedStatus",
+				"type": "nvarchar"
+			},
+			{
+				"name": "datePublished",
+				"type": "datetime",
+				"precision": 23,
+				"scale": 3
+			},
+			{
+				"name": "documentType",
+				"type": "nvarchar"
+			},
+			{
+				"name": "sourceSystem",
+				"type": "varchar"
+			},
+			{
+				"name": "author",
+				"type": "nvarchar"
+			},
+			{
+				"name": "authorWelsh",
+				"type": "nvarchar"
+			},
+			{
+				"name": "representative",
+				"type": "nvarchar"
+			},
+			{
+				"name": "documentDescription",
+				"type": "varchar"
+			},
+			{
+				"name": "documentDescriptionWelsh",
+				"type": "varchar"
+			},
+			{
+				"name": "documentCaseStage",
+				"type": "nvarchar"
+			},
+			{
+				"name": "filter1",
+				"type": "nvarchar"
+			},
+			{
+				"name": "filter1Welsh",
+				"type": "nvarchar"
+			},
+			{
+				"name": "filter2",
+				"type": "nvarchar"
+			},
+			{
+				"name": "ParentID",
+				"type": "int",
+				"precision": 10
+			}
+		],
 		"typeProperties": {
 			"schema": "dbo",
 			"table": {

--- a/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
+++ b/workspace/pipeline/0_Raw_Horizon_Document_Metadata.json
@@ -131,6 +131,18 @@
 							},
 							{
 								"source": {
+									"name": "originalFilename",
+									"type": "String",
+									"physicalType": "nvarchar"
+								},
+								"sink": {
+									"name": "originalFilename",
+									"type": "String",
+									"physicalType": "String"
+								}
+							},
+							{
+								"source": {
 									"name": "DataSize",
 									"type": "Int64",
 									"physicalType": "bigint"


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ X] No

 2. Have any new tables been created in Standardised?

  	- [ X] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [X ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [X ] If yes:
		- [ X] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [X ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ X] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
