### PR TITLE
chore(tooling): updating latest terraform version  reverting upgrading python 3.7->3.13 on the agents

### DIFF
--- a/infrastructure/configuration/devops-agents/build.pkr.hcl
+++ b/infrastructure/configuration/devops-agents/build.pkr.hcl
@@ -11,8 +11,8 @@ source "azure-arm" "azure-agents" {
   azure_tags = {
     Project          = "tooling"
     CreatedBy        = "packer"
-    TerraformVersion = "1.11.3"
-    pythonVersion    = "3.13"
+    TerraformVersion = "1.11.4"
+    pythonVersion    = "3.7"
   }
 
   client_id       = var.client_id

--- a/infrastructure/configuration/devops-agents/tools.sh
+++ b/infrastructure/configuration/devops-agents/tools.sh
@@ -44,24 +44,20 @@ sudo apt install -y --no-install-recommends \
   git-lfs \
   git-ftp
 
-# Checkov
+# Python
 sudo apt install -y --no-install-recommends \
-  python3-pip \
   python3.7 \
-  python3.7-distutils
-python3.7 -m pip install --force-reinstall packaging==21
-python3.7 -m pip install -U checkov==2.2.94
+  python3.7-distutils \
+  python3-pip
 
-# Python 3.13 Installation
-sudo apt install -y --no-install-recommends \
-  python3.13 \
-  python3-setuptools \
-  python3-apt
-
-# Terraform 1.9.6
+# Terraform 1.11.4
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-sudo apt-get install -y terraform=1.11.3-1
+sudo apt-get install -y terraform=1.11.4-1
+
+# Checkov
+python3.7 -m pip install --force-reinstall packaging==21
+python3.7 -m pip install -U checkov==2.2.94
 
 # TFLint
 curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
@@ -92,11 +88,3 @@ pwsh -c "& {Get-Module -ListAvailable}"
 
 # Sysprep
 /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync
-
-# python 3.13 as default
-sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
-
-# python version
-echo "==================== PYTHON DEFAULT VERSION ===================="
-python3 --version
-echo "================================================================"

--- a/pipelines/devops-agent-deploy.yaml
+++ b/pipelines/devops-agent-deploy.yaml
@@ -47,7 +47,7 @@ pr: none
 trigger: none
 
 pool:
-  vmImage: ubuntu-latest
+  vmImage: ubuntu-22.04  # Ubuntu-latest by default does not have Terraform installed
 
 stages:
   - stage: Plan


### PR DESCRIPTION
## Describe your changes

- Updating terraform to latest version 1.11.4: [Ticket](https://pins-ds.atlassian.net/browse/DEV-346)

- Reverting Python 3.7 to 3.13 changes as ImportError for package six exits as per Boot diagnostics logs

     ![image](https://github.com/user-attachments/assets/3df91e18-a67a-4e30-ae2c-4d42a465968b)
- Comparing [current change](https://github.com/Planning-Inspectorate/ODW-Service/blob/task/infra-update/infrastructure/configuration/devops-agents/tools.sh) and [Changes from OCT 2024](https://github.com/Planning-Inspectorate/ODW-Service/blob/d2d6761cc055ce9d2a75039f2840ef831e2c4430/infrastructure/configuration/devops-agents/tools.sh)
   
   ![image](https://github.com/user-attachments/assets/15b37ee2-6753-4a4f-82ef-98fdb8ca542d)


<!-- - [Image build](https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=112342&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=f07b485a-4928-5c8c-1dd5-52819906354e&l=3177)

- [Terraform plan for agent image update](https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=112359&view=logs&j=73ba6cf2-a55c-5a6d-eb3f-888082e04ae4&t=2bf3c59d-8ee2-5476-8405-92376983bc84&l=37) -->

- Updating devops-agent-deploy.yml pipeline to use ubuntu-22.04 azure agent image as with ubuntu-latest(version 24) terraform in not installed by default and pipeline fails with 'terraform command not' found error.
             - Azure agents is only used in agent deploy pipeline. Rest ODW pipeline uses ODW-agents
             -  [Ubuntu-latest terraform error in pipeline](https://dev.azure.com/planninginspectorate/operational-data-warehouse/_build/results?buildId=112355&view=logs&j=73ba6cf2-a55c-5a6d-eb3f-888082e04ae4&t=e9d7fe18-f96a-5691-d827-72eb9e3946cf&l=16)

	
 
