### PR TITLE
upgrade_shir_vm_to_F8s_v2

### DIFF
--- a/infrastructure/modules/synapse-shir/variables.tf
+++ b/infrastructure/modules/synapse-shir/variables.tf
@@ -36,7 +36,7 @@ variable "runtime_vm_username" {
 }
 
 variable "runtime_vm_size" {
-  default     = "Standard_F2s_v2"
+  default     = "Standard_F8s_v2"
   description = "The size of the self-hosted integration runtime VM to be deployed"
   type        = string
 }


### PR DESCRIPTION
Upgrading VM to F8s_v2 due to insufficient resources for data processing in pre-prod and prod. 