### PR TITLE
Define spark config as a constant. Update spark config references to …

### DIFF
--- a/workspace/testing/tests/constants.py
+++ b/workspace/testing/tests/constants.py
@@ -1,3 +1,4 @@
+from typing import Dict, Union
 NOTEBOOK_SUCCESS_STATUS:str = "Succeeded"
 PIPELINE_SUCCESS_STATUS:str = "Succeeded"
 NOTEBOOK_EXIT_CODE_SUCCESS:str = '0'
@@ -5,3 +6,14 @@ SYNAPSE_ENDPOINT_ENVIRONMENT_VARIABLE:str = "SYNAPSE_ENDPOINT"
 SYNAPSE_ENDPOINT_DEFAULT:str = "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/"
 CREDENTIAL_ENVIRONMENT_NAME:str = "CREDENTIAL_NAME"
 CREDENTIAL_ENVIRONMENT_DEFAULT:str = "https://dev.azuresynapse.net/.default"
+SPARK_POOL_CONFIG: Dict[str, Union[str, Dict[str, str]]] = {
+    "sparkPool": "pinssynspodw34",
+    "sessionOptions": {
+        "driverMemory": "28g",
+        "driverCores": 4,
+        "executorMemory": "28g",
+        "executorCores": 4,
+        "numExecutors": 2,
+        "runAsWorkspaceSystemIdentity": False
+    }
+}

--- a/workspace/testing/tests/test_appeal_document.py
+++ b/workspace/testing/tests/test_appeal_document.py
@@ -10,16 +10,7 @@ def test_appeal_document_notebook(credential_name, azure_credential, synapse_end
     # run the testing notebook
     notebookname: str = "py_unit_tests_appeal_document"
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -55,6 +46,7 @@ def test_appeal_document_notebook(credential_name, azure_credential, synapse_end
             }
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_appeals_event.py
+++ b/workspace/testing/tests/test_appeals_event.py
@@ -11,16 +11,7 @@ def test_appeal_event_notebook(credential_name, azure_credential, synapse_endpoi
     notebookname: str = "py_unit_tests_appeals_events"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -52,6 +43,7 @@ def test_appeal_event_notebook(credential_name, azure_credential, synapse_endpoi
             }
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_appeals_has.py
+++ b/workspace/testing/tests/test_appeals_has.py
@@ -11,16 +11,7 @@ def test_appeal_appeals_has(credential_name, azure_credential, synapse_endpoint:
     notebookname: str = "py_unit_tests_has_appeals"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -52,6 +43,7 @@ def test_appeal_appeals_has(credential_name, azure_credential, synapse_endpoint:
             }
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_entraid.py
+++ b/workspace/testing/tests/test_entraid.py
@@ -13,17 +13,9 @@ def test_entraid_pipeline(credential_name, azure_credential, synapse_endpoint: s
     pipelinename: str = "rel_1262_entra_id"
     
     pipeline_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "pipeline": pipelinename,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        }
     }
+    pipeline_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the pipeline
     pipeline_run_result = pipelineutils.run_and_observe_pipeline(credential_name, azure_credential, synapse_endpoint, pipelinename, pipeline_raw_params)
@@ -40,16 +32,7 @@ def test_entraid_notebook(credential_name, azure_credential, synapse_endpoint: s
     
     # Trigger the Master Pipeline for Landing to Raw Zone
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -81,6 +64,7 @@ def test_entraid_notebook(credential_name, azure_credential, synapse_endpoint: s
             },
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_nsip_document.py
+++ b/workspace/testing/tests/test_nsip_document.py
@@ -11,16 +11,7 @@ def test_nsip_document_notebook(credential_name, azure_credential, synapse_endpo
     notebookname: str = "py_unit_tests_nsip_document"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                 "type": "String",
@@ -76,6 +67,7 @@ def test_nsip_document_notebook(credential_name, azure_credential, synapse_endpo
             },
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_nsip_exam_timetable.py
+++ b/workspace/testing/tests/test_nsip_exam_timetable.py
@@ -11,16 +11,7 @@ def test_nsip_exam_timetable_notebook(credential_name, azure_credential, synapse
     notebookname: str = "py_unit_tests_nsip_exam_timetable"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                 "type": "String",
@@ -76,6 +67,7 @@ def test_nsip_exam_timetable_notebook(credential_name, azure_credential, synapse
             },
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_nsip_project.py
+++ b/workspace/testing/tests/test_nsip_project.py
@@ -11,16 +11,7 @@ def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoi
     notebookname: str = "py_unit_tests_nsip_project"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -72,6 +63,7 @@ def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoi
             }
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_nsip_s51_advice.py
+++ b/workspace/testing/tests/test_nsip_s51_advice.py
@@ -11,16 +11,7 @@ def test_nsip_s51_advice_notebook(credential_name, azure_credential, synapse_end
     notebookname: str = "py_unit_tests_nsip_s51_advice"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                 "type": "String",
@@ -76,6 +67,7 @@ def test_nsip_s51_advice_notebook(credential_name, azure_credential, synapse_end
             },
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_nsip_subscription.py
+++ b/workspace/testing/tests/test_nsip_subscription.py
@@ -1,6 +1,6 @@
 import pytest
 import pipelineutils
-from constants import NOTEBOOK_EXIT_CODE_SUCCESS, NOTEBOOK_SUCCESS_STATUS
+from constants import NOTEBOOK_EXIT_CODE_SUCCESS, NOTEBOOK_SUCCESS_STATUS, SPARK_POOL_CONFIG
 from warnings import filterwarnings
 
 def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoint: str):
@@ -11,16 +11,7 @@ def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoi
     notebookname: str = "py_unit_tests_nsip_subscription"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": { "type": "String", "value": "nsip-subscription" },
             "std_db_name": { "type": "String", "value": "odw_standardised_db" },
@@ -31,6 +22,7 @@ def test_nsip_project_notebook(credential_name, azure_credential, synapse_endpoi
             "curated_table_name": { "type": "String", "value": "nsip_subscription" },
         }
     }
+    notebook_raw_params.update(SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_pins_lpa_curated.py
+++ b/workspace/testing/tests/test_pins_lpa_curated.py
@@ -11,16 +11,7 @@ def test_pins_lpa_curated(credential_name, azure_credential, synapse_endpoint: s
     notebookname: str = "py_unit_tests_pins_lpa_curated"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -52,6 +43,7 @@ def test_pins_lpa_curated(credential_name, azure_credential, synapse_endpoint: s
             },
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_relevant_representation.py
+++ b/workspace/testing/tests/test_relevant_representation.py
@@ -11,16 +11,7 @@ def test_relevant_representation_notebook(credential_name, azure_credential, syn
     notebookname: str = "py_unit_tests_relevant_representation"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -68,6 +59,7 @@ def test_relevant_representation_notebook(credential_name, azure_credential, syn
             }
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)

--- a/workspace/testing/tests/test_service_user.py
+++ b/workspace/testing/tests/test_service_user.py
@@ -11,16 +11,7 @@ def test_appeal_service_user(credential_name, azure_credential, synapse_endpoint
     notebookname: str = "py_unit_tests_service_user"
     
     notebook_raw_params = {
-        "sparkPool": "pinssynspodw34",
         "notebook": notebookname,
-        "sessionOptions": {
-            "driverMemory": "28g",
-            "driverCores": 4,
-            "executorMemory": "28g",
-            "executorCores": 4,
-            "numExecutors": 2,
-            "runAsWorkspaceSystemIdentity": False
-        },
         "parameters": {
             "entity_name": {
                "type": "String",
@@ -64,6 +55,7 @@ def test_appeal_service_user(credential_name, azure_credential, synapse_endpoint
             }
         }
     }
+    notebook_raw_params.update(constants.SPARK_POOL_CONFIG)
 
     #run the notebook
     (notebook_run_result, exitMessage) = pipelineutils.run_and_observe_notebook(credential_name, azure_credential, synapse_endpoint, notebookname, notebook_raw_params)


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-1778

Define spark config as a constant in the tests, to reduce code duplication and simplify the process of updating the spark config (e.g if we need to delete a deprecated spark pool)