### PR TITLE
Add new spark pool version variable. Set old spark pool version to 3.…

### DIFF
--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -210,6 +210,7 @@ spark_pool_min_node_count  = 3
 spark_pool_node_size       = "Small"
 spark_pool_timeout_minutes = 60
 spark_pool_version         = "3.4"
+new_spark_pool_version     = "3.4"
 
 spark_pool_preview_enabled = true
 spark_pool_preview_version = "3.4"

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -210,7 +210,8 @@ spark_pool_max_node_count  = 12
 spark_pool_min_node_count  = 3
 spark_pool_node_size       = "Small"
 spark_pool_timeout_minutes = 60
-spark_pool_version         = "3.4"
+spark_pool_version         = "3.3"
+new_spark_pool_version     = "3.4"
 
 spark_pool_preview_enabled = true
 spark_pool_preview_version = "3.4"

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -212,6 +212,7 @@ spark_pool_min_node_count  = 3
 spark_pool_node_size       = "Small"
 spark_pool_timeout_minutes = 60
 spark_pool_version         = "3.4"
+new_spark_pool_version     = "3.4"
 
 spark_pool_preview_enabled = true
 spark_pool_preview_version = "3.4"

--- a/infrastructure/modules/synapse-workspace-private/synapse-spark-pool.tf
+++ b/infrastructure/modules/synapse-workspace-private/synapse-spark-pool.tf
@@ -86,7 +86,7 @@ resource "azurerm_synapse_spark_pool" "synapse34" {
   synapse_workspace_id           = azurerm_synapse_workspace.synapse.id
   node_size_family               = "MemoryOptimized"
   node_size                      = var.spark_pool_node_size
-  spark_version                  = var.spark_pool_version
+  spark_version                  = var.new_spark_pool_version
   session_level_packages_enabled = true
 
   auto_pause {

--- a/infrastructure/modules/synapse-workspace-private/variables.tf
+++ b/infrastructure/modules/synapse-workspace-private/variables.tf
@@ -146,6 +146,12 @@ variable "spark_pool_version" {
   type        = string
 }
 
+variable "new_spark_pool_version" {
+  default     = "3.2"
+  description = "The version of Spark running on the new Synapse-linked Spark pool"
+  type        = string
+}
+
 variable "sql_pool_collation" {
   default     = "SQL_Latin1_General_CP1_CI_AS"
   description = "The collation of the Synapse-linked dedicated SQL pool"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -432,6 +432,12 @@ variable "spark_pool_version" {
   type        = string
 }
 
+variable "new_spark_pool_version" {
+  default     = "2.4"
+  description = "The version of Spark running on the new Synapse-linked Spark pool"
+  type        = string
+}
+
 variable "sql_pool_collation" {
   default     = "SQL_Latin1_General_CP1_CI_AS"
   description = "The collation of the Synapse-linked dedicated SQL pool"

--- a/infrastructure/workload-synapse.tf
+++ b/infrastructure/workload-synapse.tf
@@ -26,6 +26,7 @@ module "synapse_workspace_private" {
   spark_pool_requirements               = file("${path.module}/configuration/spark-pool/requirements.txt")
   spark_pool_timeout_minutes            = var.spark_pool_timeout_minutes
   spark_pool_version                    = var.spark_pool_version
+  new_spark_pool_version                = var.new_spark_pool_version
   sql_pool_enabled                      = var.sql_pool_enabled
   sql_pool_collation                    = var.sql_pool_collation
   sql_pool_sku_name                     = var.sql_pool_sku_name
@@ -83,6 +84,7 @@ module "synapse_workspace_private_failover" {
   spark_pool_requirements               = file("${path.module}/configuration/spark-pool/requirements.txt")
   spark_pool_timeout_minutes            = var.spark_pool_timeout_minutes
   spark_pool_version                    = var.spark_pool_version
+  new_spark_pool_version                = var.new_spark_pool_version
   sql_pool_enabled                      = var.sql_pool_enabled
   sql_pool_collation                    = var.sql_pool_collation
   sql_pool_sku_name                     = var.sql_pool_sku_name


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-1785

Split usage of the `spark_pool_version` variable into two variables, to resolve issue in production caused by blocked spark pool updates