### PR TITLE
Updating notebook: py_sb_horizon_harmonised_nsip_document

### DIFF
--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2156a24c-aba2-4a5d-b8aa-9014cb52d5c6"
+				"spark.autotune.trackingId": "7c4daaee-873b-4e5a-a57d-5d1b5b2bee60"
 			}
 		},
 		"metadata": {
@@ -67,7 +67,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 18
 			},
 			{
 				"cell_type": "code",
@@ -76,7 +76,7 @@
 					"from pyspark.sql import Row\n",
 					"from pyspark.sql.functions import *"
 				],
-				"execution_count": null
+				"execution_count": 19
 			},
 			{
 				"cell_type": "code",
@@ -99,7 +99,7 @@
 					"\n",
 					"primary_key = 'TEMP_PK'"
 				],
-				"execution_count": null
+				"execution_count": 20
 			},
 			{
 				"cell_type": "code",
@@ -117,7 +117,7 @@
 				"source": [
 					"spark.catalog.refreshTable(horizon_table)"
 				],
-				"execution_count": null
+				"execution_count": 21
 			},
 			{
 				"cell_type": "code",
@@ -189,7 +189,7 @@
 					"\n",
 					"                    \"\"\")"
 				],
-				"execution_count": null
+				"execution_count": 22
 			},
 			{
 				"cell_type": "code",
@@ -271,7 +271,7 @@
 					"                    Doc.expected_from = (SELECT MAX(expected_from) FROM {horizon_table})\n",
 					"            \"\"\")"
 				],
-				"execution_count": null
+				"execution_count": 23
 			},
 			{
 				"cell_type": "code",
@@ -292,7 +292,7 @@
 					"results = service_bus_data.union(horizon_data)\n",
 					"logInfo(f\"Combined data for {spark_table_final}\")"
 				],
-				"execution_count": null
+				"execution_count": 24
 			},
 			{
 				"cell_type": "code",
@@ -314,7 +314,7 @@
 					"\n",
 					"logInfo(f\"Updating {spark_table_final}\")"
 				],
-				"execution_count": null
+				"execution_count": 25
 			},
 			{
 				"cell_type": "markdown",
@@ -365,7 +365,7 @@
 					"            {spark_table_final}\n",
 					"    \"\"\")"
 				],
-				"execution_count": null
+				"execution_count": 26
 			},
 			{
 				"cell_type": "code",
@@ -405,7 +405,7 @@
 					"                    \"\"\")\n",
 					"                    "
 				],
-				"execution_count": null
+				"execution_count": 27
 			},
 			{
 				"cell_type": "code",
@@ -423,7 +423,7 @@
 				"source": [
 					"df_calcs =df_calcs.withColumnRenamed(primary_key, f\"temp_{primary_key}\").withColumnRenamed(\"IngestionDate\", \"temp_IngestionDate\")"
 				],
-				"execution_count": null
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -535,7 +535,7 @@
 					"                \"\"\")\n",
 					"    "
 				],
-				"execution_count": null
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
@@ -555,7 +555,7 @@
 					"\n",
 					"results = results.drop(\"NSIPDocumentID\", \"ValidTo\", \"Migrated\", \"IsActive\")"
 				],
-				"execution_count": null
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -574,7 +574,7 @@
 					"final_df = results.join(df_calcs, (df_calcs[f\"temp_{primary_key}\"] == results[primary_key]) & (df_calcs[\"temp_IngestionDate\"] == results[\"IngestionDate\"])).select(columns)\n",
 					"final_df = final_df.drop(primary_key).drop_duplicates()"
 				],
-				"execution_count": null
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
@@ -594,7 +594,7 @@
 					"columns_to_consider = ['documentId', 'filename', 'version', 'Migrated', 'ODTSourceSystem', 'IngestionDate', 'ValidTo', 'IsActive']\n",
 					"final_df = final_df.drop_duplicates(subset=columns_to_consider)"
 				],
-				"execution_count": null
+				"execution_count": 32
 			},
 			{
 				"cell_type": "code",
@@ -614,7 +614,7 @@
 					"final_df.write.format(\"delta\").mode(\"Overwrite\").option(\"overwriteSchema\", \"true\").partitionBy(\"IsActive\").saveAsTable(f\"{spark_table_final}\")\n",
 					"logInfo(f\"Written finalised {spark_table_final}\")"
 				],
-				"execution_count": null
+				"execution_count": 33
 			}
 		]
 	}

--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c060c1f9-adea-42b3-96a1-03c1c85aad4d"
+				"spark.autotune.trackingId": "2156a24c-aba2-4a5d-b8aa-9014cb52d5c6"
 			}
 		},
 		"metadata": {
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 32,
-				"automaticScaleJobs": true
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -67,7 +67,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -76,7 +76,7 @@
 					"from pyspark.sql import Row\n",
 					"from pyspark.sql.functions import *"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -99,7 +99,7 @@
 					"\n",
 					"primary_key = 'TEMP_PK'"
 				],
-				"execution_count": 3
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -117,7 +117,7 @@
 				"source": [
 					"spark.catalog.refreshTable(horizon_table)"
 				],
-				"execution_count": 4
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -133,63 +133,63 @@
 					}
 				},
 				"source": [
-					"# Get data out of the service bus with additional fields needed for Horizon data\r\n",
-					"service_bus_data = spark.sql(f\"\"\"\r\n",
-					"                    SELECT DISTINCT\r\n",
-					"                        MD5(CONCAT(documentId, filename, version)) AS {primary_key}\r\n",
-					"                        ,NSIPDocumentID\r\n",
-					"                        ,documentId\r\n",
-					"                        ,caseId\r\n",
-					"                        ,caseRef\r\n",
-					"                        ,documentReference\r\n",
-					"                        ,version\r\n",
-					"                        ,examinationRefNo\r\n",
-					"                        ,filename\r\n",
-					"                        ,originalFilename\r\n",
-					"                        ,size\r\n",
-					"                        ,mime\r\n",
-					"                        ,documentURI\r\n",
-					"                        ,publishedDocumentURI\r\n",
-					"                        ,path\r\n",
-					"                        ,virusCheckStatus\r\n",
-					"                        ,fileMD5\r\n",
-					"                        ,dateCreated\r\n",
-					"                        ,lastModified\r\n",
-					"                        ,caseType\r\n",
-					"                        ,redactedStatus\r\n",
-					"                        ,publishedStatus\r\n",
-					"                        ,datePublished\r\n",
-					"                        ,documentType\r\n",
-					"                        ,securityClassification\r\n",
-					"                        ,sourceSystem\r\n",
-					"                        ,origin\r\n",
-					"                        ,owner\r\n",
-					"                        ,author\r\n",
-					"                        ,authorWelsh\r\n",
-					"                        ,representative\r\n",
-					"                        ,description\r\n",
-					"                        ,descriptionWelsh\r\n",
-					"                        ,documentCaseStage\r\n",
-					"                        ,filter1\r\n",
-					"                        ,filter1Welsh\r\n",
-					"                        ,filter2\r\n",
-					"                        ,horizonFolderId\r\n",
-					"                        ,transcriptId\r\n",
-					"                        \r\n",
-					"                        ,Migrated\r\n",
-					"                        ,ODTSourceSystem\r\n",
-					"                        ,SourceSystemID\r\n",
-					"                        ,IngestionDate \r\n",
-					"                        ,NULLIF(ValidTo, '') AS ValidTo\r\n",
-					"                        ,'' as RowID\r\n",
-					"                        ,IsActive\r\n",
-					"                        \r\n",
-					"                    FROM \r\n",
-					"                        {service_bus_table}\r\n",
-					"\r\n",
+					"# Get data out of the service bus with additional fields needed for Horizon data\n",
+					"service_bus_data = spark.sql(f\"\"\"\n",
+					"                    SELECT DISTINCT\n",
+					"                        MD5(CONCAT(documentId, filename, version)) AS {primary_key}\n",
+					"                        ,NSIPDocumentID\n",
+					"                        ,documentId\n",
+					"                        ,caseId\n",
+					"                        ,caseRef\n",
+					"                        ,documentReference\n",
+					"                        ,version\n",
+					"                        ,examinationRefNo\n",
+					"                        ,filename\n",
+					"                        ,originalFilename\n",
+					"                        ,size\n",
+					"                        ,mime\n",
+					"                        ,documentURI\n",
+					"                        ,publishedDocumentURI\n",
+					"                        ,path\n",
+					"                        ,virusCheckStatus\n",
+					"                        ,fileMD5\n",
+					"                        ,dateCreated\n",
+					"                        ,lastModified\n",
+					"                        ,caseType\n",
+					"                        ,redactedStatus\n",
+					"                        ,publishedStatus\n",
+					"                        ,datePublished\n",
+					"                        ,documentType\n",
+					"                        ,securityClassification\n",
+					"                        ,sourceSystem\n",
+					"                        ,origin\n",
+					"                        ,owner\n",
+					"                        ,author\n",
+					"                        ,authorWelsh\n",
+					"                        ,representative\n",
+					"                        ,description\n",
+					"                        ,descriptionWelsh\n",
+					"                        ,documentCaseStage\n",
+					"                        ,filter1\n",
+					"                        ,filter1Welsh\n",
+					"                        ,filter2\n",
+					"                        ,horizonFolderId\n",
+					"                        ,transcriptId\n",
+					"                        \n",
+					"                        ,Migrated\n",
+					"                        ,ODTSourceSystem\n",
+					"                        ,SourceSystemID\n",
+					"                        ,IngestionDate \n",
+					"                        ,NULLIF(ValidTo, '') AS ValidTo\n",
+					"                        ,'' as RowID\n",
+					"                        ,IsActive\n",
+					"                        \n",
+					"                    FROM \n",
+					"                        {service_bus_table}\n",
+					"\n",
 					"                    \"\"\")"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -223,7 +223,7 @@
 					"                    ,CAST(Doc.version AS INTEGER) AS version\n",
 					"                    ,Aie.examinationRefNo\n",
 					"                    ,Doc.name as filename\n",
-					"                    ,Doc.name as originalFilename\n",
+					"                    ,Doc.originalFilename as originalFilename\n",
 					"                    ,CAST(Doc.dataSize AS INTEGER) AS size\n",
 					"                    ,Aie.mime\n",
 					"                    ,Aie.documentURI\n",
@@ -271,7 +271,7 @@
 					"                    Doc.expected_from = (SELECT MAX(expected_from) FROM {horizon_table})\n",
 					"            \"\"\")"
 				],
-				"execution_count": 6
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -292,7 +292,7 @@
 					"results = service_bus_data.union(horizon_data)\n",
 					"logInfo(f\"Combined data for {spark_table_final}\")"
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -314,7 +314,7 @@
 					"\n",
 					"logInfo(f\"Updating {spark_table_final}\")"
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -365,7 +365,7 @@
 					"            {spark_table_final}\n",
 					"    \"\"\")"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -405,7 +405,7 @@
 					"                    \"\"\")\n",
 					"                    "
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -423,7 +423,7 @@
 				"source": [
 					"df_calcs =df_calcs.withColumnRenamed(primary_key, f\"temp_{primary_key}\").withColumnRenamed(\"IngestionDate\", \"temp_IngestionDate\")"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -535,7 +535,7 @@
 					"                \"\"\")\n",
 					"    "
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -555,7 +555,7 @@
 					"\n",
 					"results = results.drop(\"NSIPDocumentID\", \"ValidTo\", \"Migrated\", \"IsActive\")"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -574,7 +574,7 @@
 					"final_df = results.join(df_calcs, (df_calcs[f\"temp_{primary_key}\"] == results[primary_key]) & (df_calcs[\"temp_IngestionDate\"] == results[\"IngestionDate\"])).select(columns)\n",
 					"final_df = final_df.drop(primary_key).drop_duplicates()"
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -594,7 +594,7 @@
 					"columns_to_consider = ['documentId', 'filename', 'version', 'Migrated', 'ODTSourceSystem', 'IngestionDate', 'ValidTo', 'IsActive']\n",
 					"final_df = final_df.drop_duplicates(subset=columns_to_consider)"
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -614,7 +614,7 @@
 					"final_df.write.format(\"delta\").mode(\"Overwrite\").option(\"overwriteSchema\", \"true\").partitionBy(\"IsActive\").saveAsTable(f\"{spark_table_final}\")\n",
 					"logInfo(f\"Written finalised {spark_table_final}\")"
 				],
-				"execution_count": 16
+				"execution_count": null
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**
https://pins-ds.atlassian.net/browse/THEODW-1750
 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
