### PR TITLE
Remove duplicate entries for triggers to activate

### DIFF
--- a/pipelines/jobs/deploy-synapse.yaml
+++ b/pipelines/jobs/deploy-synapse.yaml
@@ -20,9 +20,9 @@ jobs:
     value: 'synapse-release'
   - name: synapseTriggers 
     ${{ if eq(parameters.env , 'dev') }}: 
-      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly,tr_weekly,tr_delta_backup_daily_0800' 
+      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly,tr_delta_backup_daily_0800' 
     ${{ if eq(parameters.env , 'test') }}:
-      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly,tr_weekly,tr_delta_backup_daily_0800' 
+      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly,tr_delta_backup_daily_0800' 
     ${{ if eq(parameters.env , 'prod') }}: 
       value: 'tr_daily_7days_1800,tr_backup_daily,tr_weekly'
   steps:


### PR DESCRIPTION
There are duplicate entries in the list of triggers to activate in the ADO pipeline that are causing errors. This PR removes the duplicate entry