### PR TITLE
Updating notebook: appeals_has_curated_mipins

### DIFF
--- a/workspace/notebook/appeals_has_curated_mipins.json
+++ b/workspace/notebook/appeals_has_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ffeccea6-dd33-4ef0-a6de-8e621afc7772"
+				"spark.autotune.trackingId": "c26dad09-6cf0-450a-8d67-1b5d9504f289"
 			}
 		},
 		"metadata": {
@@ -207,6 +207,7 @@
 					"    'caseCompletedDate',\n",
 					"    'applicationDecisionDate',\n",
 					"    'caseSubmissionDueDate',\n",
+					"    'IngestionDate',\n",
 					"    'ValidTo'\n",
 					"]\n",
 					"\n",

--- a/workspace/notebook/appeals_has_curated_mipins.json
+++ b/workspace/notebook/appeals_has_curated_mipins.json
@@ -58,7 +58,7 @@
 					"from datetime import datetime, date\n",
 					"import pyspark.sql.functions as F"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/appeals_has_curated_mipins.json
+++ b/workspace/notebook/appeals_has_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c26dad09-6cf0-450a-8d67-1b5d9504f289"
+				"spark.autotune.trackingId": "709c2c02-707f-40fe-bced-f9d547afc288"
 			}
 		},
 		"metadata": {
@@ -58,7 +58,7 @@
 					"from datetime import datetime, date\n",
 					"import pyspark.sql.functions as F"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -156,7 +156,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH \n",
 					"WHERE AH.lpaCode NOT in ('Q9999', 'Q1111')"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -174,7 +174,7 @@
 				"source": [
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeals_has_curated_mipins\")"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -214,9 +214,9 @@
 					"# Apply the UTC to London conversion for each column\n",
 					"final_view_df = view_df\n",
 					"for column_name in timestamp_columns:\n",
-					"    final_view_df = final_view_df.withColumn(column_name, F.from_utc_timestamp(F.col(column_name), 'Europe/London'))"
+					"    final_view_df = final_view_df.withColumn(column_name, F.date_format(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -234,14 +234,14 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeals_has_curated_mipins;\")"
 				],
-				"execution_count": null
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"final_view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeals_has_curated_mipins\")"
 				],
-				"execution_count": null
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/appeals_has_curated_mipins.json
+++ b/workspace/notebook/appeals_has_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "709c2c02-707f-40fe-bced-f9d547afc288"
+				"spark.autotune.trackingId": "6ecb433c-64e3-4d98-8ce0-662dbdc5c59e"
 			}
 		},
 		"metadata": {
@@ -156,7 +156,7 @@
 					"FROM odw_harmonised_db.sb_appeal_has AS AH \n",
 					"WHERE AH.lpaCode NOT in ('Q9999', 'Q1111')"
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -174,7 +174,7 @@
 				"source": [
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_appeals_has_curated_mipins\")"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -216,7 +216,7 @@
 					"for column_name in timestamp_columns:\n",
 					"    final_view_df = final_view_df.withColumn(column_name, F.date_format(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -234,14 +234,14 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeals_has_curated_mipins;\")"
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"final_view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeals_has_curated_mipins\")"
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
