### PR TITLE
Feat/theodw 1823 release

### DIFF
--- a/workspace/notebook/manage_main_pipeline_config_entry.json
+++ b/workspace/notebook/manage_main_pipeline_config_entry.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e6a6d32a-fa26-482f-9ab7-65645f56fdb1"
+				"spark.autotune.trackingId": "7e101432-157b-4c5a-bfc1-29785d42477b"
 			}
 		},
 		"metadata": {
@@ -117,7 +117,7 @@
 					"# Set the details of the new entity below\n",
 					"\n",
 					"# Example:\n",
-					"# new_entity_key = 28\n",
+					"# new_entity_key = 29\n",
 					"# system_name = \"Service bus\"\n",
 					"# object_name = \"Appeal Event Estimate\"\n",
 					"# entity_name = \"appeal-event-estimate\"\n",
@@ -130,7 +130,7 @@
 					"entity_name = \"\"\n",
 					"is_enabled = False  # Use the update cell at the bottom to enable it once function app is deployed using true"
 				],
-				"execution_count": null
+				"execution_count": 20
 			},
 			{
 				"cell_type": "markdown",
@@ -164,7 +164,7 @@
 					"print(f\"Next available key: {next_key}\")\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 22
 			},
 			{
 				"cell_type": "markdown",
@@ -267,7 +267,7 @@
 					"# Set is_enable = true so the pipeline can pick it up\n",
 					"spark.sql(f\"\"\"\n",
 					"UPDATE odw_config_db.main_pipeline_config\n",
-					"SET is_enabled = true\n",
+					"SET is_enabled = {str(is_enabled).lower()}\n",
 					"WHERE entity_name = '{entity_name}'\n",
 					"\"\"\")"
 				],

--- a/workspace/notebook/manage_main_pipeline_config_entry.json
+++ b/workspace/notebook/manage_main_pipeline_config_entry.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7e101432-157b-4c5a-bfc1-29785d42477b"
+				"spark.autotune.trackingId": "e316dbfa-c8fa-4721-8c1f-0873843f76fa"
 			}
 		},
 		"metadata": {
@@ -130,7 +130,7 @@
 					"entity_name = \"\"\n",
 					"is_enabled = False  # Use the update cell at the bottom to enable it once function app is deployed using true"
 				],
-				"execution_count": 20
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -164,7 +164,7 @@
 					"print(f\"Next available key: {next_key}\")\n",
 					""
 				],
-				"execution_count": 22
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/pipeline/rel_12_0_0_appeal_event_estimate.json
+++ b/workspace/pipeline/rel_12_0_0_appeal_event_estimate.json
@@ -1,0 +1,53 @@
+{
+	"name": "rel_12_0_0_appeal_event_estimate",
+	"properties": {
+		"activities": [
+			{
+				"name": "add_appeal_event_estimate_entry",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "manage_main_pipeline_config_entry",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"new_entity_key": {
+							"value": "29",
+							"type": "string"
+						},
+						"system_name": {
+							"value": "Service bus",
+							"type": "string"
+						},
+						"object_name": {
+							"value": "Appeal Event Estimate",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "appeal-event-estimate",
+							"type": "string"
+						},
+						"is_enabled": {
+							"value": "false",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			}
+		],
+		"folder": {
+			"name": "Releases/12.0.0"
+		},
+		"annotations": []
+	}
+}

--- a/workspace/pipeline/rel_12_0_0_appeal_event_estimate.json
+++ b/workspace/pipeline/rel_12_0_0_appeal_event_estimate.json
@@ -22,7 +22,7 @@
 					"parameters": {
 						"new_entity_key": {
 							"value": "29",
-							"type": "string"
+							"type": "int"
 						},
 						"system_name": {
 							"value": "Service bus",
@@ -37,7 +37,124 @@
 							"type": "string"
 						},
 						"is_enabled": {
-							"value": "false",
+							"value": false,
+							"type": "bool"
+						}
+					},
+					"snapshot": true,
+					"conf": {
+						"spark.dynamicAllocation.enabled": null,
+						"spark.dynamicAllocation.minExecutors": null,
+						"spark.dynamicAllocation.maxExecutors": null
+					},
+					"numExecutors": null
+				}
+			},
+			{
+				"name": "create_standardised_table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "add_appeal_event_estimate_entry",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_standardised_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "sb_appeal_event_estimate",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "create_harmonised_table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "create_standardised_table",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_harmonised_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "sb_appeal_event_estimate",
+							"type": "string"
+						}
+					},
+					"snapshot": true
+				}
+			},
+			{
+				"name": "create_curated_table",
+				"type": "SynapseNotebook",
+				"dependsOn": [
+					{
+						"activity": "create_harmonised_table",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "create_table_from_schema",
+						"type": "NotebookReference"
+					},
+					"parameters": {
+						"db_name": {
+							"value": "odw_curated_db",
+							"type": "string"
+						},
+						"entity_name": {
+							"value": "appeal_event_estimate",
 							"type": "string"
 						}
 					},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
