### PR TITLE
Feat/theodw 1836 populate the new curated table

### DIFF
--- a/workspace/notebook/appeal_event_estimate.json
+++ b/workspace/notebook/appeal_event_estimate.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "056196ab-e5b7-4c61-8e2d-df373cb61f0f"
+				"spark.autotune.trackingId": "f32e5450-98bb-415d-b6fd-6a61ffba9dc0"
 			}
 		},
 		"metadata": {
@@ -72,14 +72,14 @@
 					"from pyspark.sql import DataFrame\n",
 					"import json"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -88,7 +88,7 @@
 					"entity_name: str = \"appeal-event-estimate\"\n",
 					"table_name: str = \"odw_curated_db.appeal_event_estimate\""
 				],
-				"execution_count": null
+				"execution_count": 15
 			},
 			{
 				"cell_type": "markdown",
@@ -120,7 +120,7 @@
 					"\"\"\"\n",
 					")"
 				],
-				"execution_count": null
+				"execution_count": 16
 			},
 			{
 				"cell_type": "markdown",
@@ -141,7 +141,7 @@
 					"schema = mssparkutils.notebook.run(\"py_create_spark_schema\", 30, {\"db_name\": db_name, \"entity_name\": entity_name})\n",
 					"spark_schema = StructType.fromJson(json.loads(schema))"
 				],
-				"execution_count": null
+				"execution_count": 17
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/appeal_event_estimate.json
+++ b/workspace/notebook/appeal_event_estimate.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "4d111b42-d49e-4c62-a92e-6f9230d6f537"
+				"spark.autotune.trackingId": "37610484-827f-42be-be78-8c2e191961a1"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/appeal_event_estimate.json
+++ b/workspace/notebook/appeal_event_estimate.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "31d67624-6dfe-431a-be62-262b44e3ab9d"
+				"spark.autotune.trackingId": "056196ab-e5b7-4c61-8e2d-df373cb61f0f"
 			}
 		},
 		"metadata": {
@@ -72,14 +72,14 @@
 					"from pyspark.sql import DataFrame\n",
 					"import json"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/appeal_event_estimate.json
+++ b/workspace/notebook/appeal_event_estimate.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f32e5450-98bb-415d-b6fd-6a61ffba9dc0"
+				"spark.autotune.trackingId": "4d111b42-d49e-4c62-a92e-6f9230d6f537"
 			}
 		},
 		"metadata": {
@@ -72,14 +72,14 @@
 					"from pyspark.sql import DataFrame\n",
 					"import json"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -88,7 +88,7 @@
 					"entity_name: str = \"appeal-event-estimate\"\n",
 					"table_name: str = \"odw_curated_db.appeal_event_estimate\""
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -120,7 +120,7 @@
 					"\"\"\"\n",
 					")"
 				],
-				"execution_count": 16
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -141,7 +141,7 @@
 					"schema = mssparkutils.notebook.run(\"py_create_spark_schema\", 30, {\"db_name\": db_name, \"entity_name\": entity_name})\n",
 					"spark_schema = StructType.fromJson(json.loads(schema))"
 				],
-				"execution_count": 17
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",

--- a/workspace/notebook/appeal_event_estimate.json
+++ b/workspace/notebook/appeal_event_estimate.json
@@ -1,0 +1,190 @@
+{
+	"name": "appeal_event_estimate",
+	"properties": {
+		"folder": {
+			"name": "odw-curated"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"bigDataPool": {
+			"referenceName": "pinssynspodw34",
+			"type": "BigDataPoolReference"
+		},
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "31d67624-6dfe-431a-be62-262b44e3ab9d"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "Synapse PySpark"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"a365ComputeOptions": {
+				"id": "/subscriptions/ff442a29-fc06-4a13-8e3e-65fd5da513b3/resourceGroups/pins-rg-data-odw-dev-uks/providers/Microsoft.Synapse/workspaces/pins-synw-odw-dev-uks/bigDataPools/pinssynspodw34",
+				"name": "pinssynspodw34",
+				"type": "Spark",
+				"endpoint": "https://pins-synw-odw-dev-uks.dev.azuresynapse.net/livyApi/versions/2019-11-01-preview/sparkPools/pinssynspodw34",
+				"auth": {
+					"type": "AAD",
+					"authResource": "https://dev.azuresynapse.net"
+				},
+				"sparkVersion": "3.4",
+				"nodeCount": 3,
+				"cores": 4,
+				"memory": 28,
+				"automaticScaleJobs": false
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Import Packages"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"from pyspark.sql.functions import *\n",
+					"from pyspark.sql.types import *\n",
+					"from pyspark.sql import DataFrame\n",
+					"import json"
+				],
+				"execution_count": 1
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"%run utils/py_logging_decorator"
+				],
+				"execution_count": 2
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"db_name: str = \"odw_curated_db\"\n",
+					"entity_name: str = \"appeal-event-estimate\"\n",
+					"table_name: str = \"odw_curated_db.appeal_event_estimate\""
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Create a view for the data, joining harmonised tables where necessary"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"df = spark.sql(\"\"\"\n",
+					"SELECT\n",
+					"id,\n",
+					"caseReference,\n",
+					"preparationTime,\n",
+					"sittingTime,\n",
+					"reportingTime\n",
+					"FROM\n",
+					"  odw_harmonised_db.sb_appeal_event_estimate\n",
+					"WHERE\n",
+					"    IsActive = 'Y'\n",
+					"\"\"\"\n",
+					")"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Define schema"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"schema = mssparkutils.notebook.run(\"py_create_spark_schema\", 30, {\"db_name\": db_name, \"entity_name\": entity_name})\n",
+					"spark_schema = StructType.fromJson(json.loads(schema))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Create DataFrame with the correct schema"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"data = spark.createDataFrame(df.rdd, schema=spark_schema)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Write DataFrame to table"
+				]
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"logInfo(f\"Writing to {table_name}\")\n",
+					"data.write.mode(\"overwrite\").format(\"parquet\").saveAsTable(table_name)\n",
+					"logInfo(f\"Written to {table_name}\")"
+				],
+				"execution_count": null
+			}
+		]
+	}
+}

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6eb0a040-fd3a-425f-9f2e-6f0476340b95"
+				"spark.autotune.trackingId": "c4cfd16a-e8e9-4425-bc82-6ae527bc67bc"
 			}
 		},
 		"metadata": {
@@ -67,7 +67,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "d35157d7-d362-4757-bac6-6bc96620f466"
+				"spark.autotune.trackingId": "6eb0a040-fd3a-425f-9f2e-6f0476340b95"
 			}
 		},
 		"metadata": {
@@ -65,9 +65,9 @@
 					}
 				},
 				"source": [
-					"#%run utils/py_logging_decorator"
+					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "333e113a-dffb-4586-8d7b-d89c21b26908"
+				"spark.autotune.trackingId": "d35157d7-d362-4757-bac6-6bc96620f466"
 			}
 		},
 		"metadata": {
@@ -65,7 +65,7 @@
 					}
 				},
 				"source": [
-					"%run utils/py_logging_decorator"
+					"#%run utils/py_logging_decorator"
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "e6051ad1-7ee7-4f59-ad31-d36b0b450d2b"
+				"spark.autotune.trackingId": "04e2915d-7cf8-4f41-84aa-8dcee34de60a"
 			}
 		},
 		"metadata": {
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 32,
-				"automaticScaleJobs": true
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -65,7 +65,7 @@
 					}
 				},
 				"source": [
-					"%run utils/py_logging_decorator"
+					"#%run utils/py_logging_decorator"
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/py_spark_df_ingestion_functions.json
+++ b/workspace/notebook/py_spark_df_ingestion_functions.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "04e2915d-7cf8-4f41-84aa-8dcee34de60a"
+				"spark.autotune.trackingId": "6cedc9d0-b214-43a4-b4d5-36dfe0d4b1b9"
 			}
 		},
 		"metadata": {
@@ -65,7 +65,7 @@
 					}
 				},
 				"source": [
-					"#%run utils/py_logging_decorator"
+					"%run utils/py_logging_decorator"
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/py_unit_tests_appeal_event_estimate.json
+++ b/workspace/notebook/py_unit_tests_appeal_event_estimate.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "573489aa-ca39-4382-81dd-707ef61715a9"
+				"spark.autotune.trackingId": "c1ccebd4-f18c-4a67-bf18-ee5b92d10b9e"
 			}
 		},
 		"metadata": {
@@ -122,7 +122,7 @@
 				"metadata": {
 					"jupyter": {
 						"source_hidden": false,
-						"outputs_hidden": true
+						"outputs_hidden": false
 					},
 					"nteract": {
 						"transient": {

--- a/workspace/notebook/py_unit_tests_appeal_event_estimate.json
+++ b/workspace/notebook/py_unit_tests_appeal_event_estimate.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c1ccebd4-f18c-4a67-bf18-ee5b92d10b9e"
+				"spark.autotune.trackingId": "654a214c-513d-4bbc-ad78-57b7ab583d05"
 			}
 		},
 		"metadata": {


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
