### PR TITLE
Feat/theodw 1838 fj

### DIFF
--- a/workspace/notebook/appeal_s78.json
+++ b/workspace/notebook/appeal_s78.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "132fb844-f988-4baf-9a33-14156c770ee0"
+				"spark.autotune.trackingId": "2047a1a6-fc66-4c67-b04a-3312e4317e25"
 			}
 		},
 		"metadata": {
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 32,
-				"automaticScaleJobs": true
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -314,6 +314,8 @@
 					"    ,siteViewableFromRoad\r\n",
 					"    ,siteWithinSSSI\r\n",
 					"    ,typeOfPlanningApplication\r\n",
+					"    ,preserveGrantLoan\r\n",
+					"    ,consultHistoricEngland\r\n",
 					"    \r\n",
 					"FROM\r\n",
 					"    odw_harmonised_db.sb_appeal_s78\r\n",

--- a/workspace/notebook/appeal_s78_curated_mipins.json
+++ b/workspace/notebook/appeal_s78_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "621a6fab-6fd4-4d1a-9d06-66379f6fec48"
+				"spark.autotune.trackingId": "aec803a7-3ab1-4461-8ce5-be396d1eb107"
 			}
 		},
 		"metadata": {
@@ -209,6 +209,8 @@
 					"AH.siteViewableFromRoad                      AS siteViewableFromRoad,\n",
 					"AH.siteWithinSSSI                            AS siteWithinSSSI,\n",
 					"AH.typeOfPlanningApplication                 AS typeOfPlanningApplication,\n",
+					"AH.preserveGrantLoan                         AS preserveGrantLoan,\n",
+					"AH.consultHistoricEngland                    AS consultHistoricEngland,\n",
 					"AH.IngestionDate                             AS IngestionDate,\n",
 					"AH.ValidTo                                   AS ValidTo,\n",
 					"AH.IsActive                                  AS IsActive\n",

--- a/workspace/notebook/py_hzn_standardized_s78_tables.json
+++ b/workspace/notebook/py_hzn_standardized_s78_tables.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0f20694e-7236-47f9-a409-b5bc50837b20"
+				"spark.autotune.trackingId": "a16088c6-41aa-44df-9cf0-b8826d1a9db0"
 			}
 		},
 		"metadata": {
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 32,
-				"automaticScaleJobs": true
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -144,6 +144,14 @@
 					"final_df =  final_df.join(CaseSiteStrings_df, hzn_cases_s78_df.casenodeid == CaseSiteStrings_df.casenodeid, 'left').select( final_df[\"*\"], CaseSiteStrings_df.siteviewablefromroad)\r\n",
 					"final_df = final_df.join(vw_AddAdditionalData_df, hzn_cases_s78_df.caseuniqueid == vw_AddAdditionalData_df.appealrefnumber, 'left').select( final_df[\"*\"], vw_AddAdditionalData_df.floorspaceinsquaremetres, vw_AddAdditionalData_df.costsappliedforindicator, vw_AddAdditionalData_df.procedureappellant, vw_AddAdditionalData_df.isthesitewithinanaonb, vw_AddAdditionalData_df.procedurelpa, vw_AddAdditionalData_df.inspectorneedtoentersite, vw_AddAdditionalData_df.sitegridreferenceeasting, vw_AddAdditionalData_df.sitegridreferencenorthing , vw_AddAdditionalData_df.sitewithinsssi)\r\n",
 					"final_df = final_df.join(vw_AdditionalFields_df, hzn_cases_s78_df.caseuniqueid == vw_AdditionalFields_df.appealrefnumber, 'left').select( final_df[\"*\"], vw_AdditionalFields_df.importantinformation)"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"final_df = final_df.withColumn(\"preserveGrantLoan\", F.lit(None).cast(\"boolean\"))\r\n",
+					"final_df = final_df.withColumn(\"consultHistoricEngland\", F.lit(None).cast(\"boolean\"))"
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/py_sb_horizon_harmonised_appeal_s78.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_appeal_s78.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "1adb5c0e-9d98-47be-9989-ada6e47ee6c8"
+				"spark.autotune.trackingId": "58366f45-d682-4127-a326-ea090267e86e"
 			}
 		},
 		"metadata": {
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 32,
-				"automaticScaleJobs": true
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -250,6 +250,8 @@
 					"                        ,siteViewableFromRoad\r\n",
 					"                        ,siteWithinSSSI\r\n",
 					"                        ,typeOfPlanningApplication\r\n",
+					"                        ,preserveGrantLoan\r\n",
+					"                        ,consultHistoricEngland\r\n",
 					"\r\n",
 					"               \r\n",
 					"                        ,Migrated\r\n",
@@ -620,6 +622,8 @@
 					"                        ,siteViewableFromRoad\r\n",
 					"                        ,siteWithinSSSI\r\n",
 					"                        ,typeOfPlanningApplication\r\n",
+					"                        ,preserveGrantLoan\r\n",
+					"                        ,consultHistoricEngland\r\n",
 					"                        ,Migrated\r\n",
 					"                        ,ODTSourceSystem\r\n",
 					"                        ,IngestionDate\r\n",
@@ -758,6 +762,8 @@
 					"                            ,IFNULL(CAST(siteViewableFromRoad as String), '.')\r\n",
 					"                            ,IFNULL(CAST(siteWithinSSSI as String), '.')\r\n",
 					"                            ,IFNULL(CAST(typeOfPlanningApplication as String), '.')\r\n",
+					"                            ,IFNULL(CAST(preserveGrantLoan as String), '.')\r\n",
+					"                            ,IFNULL(CAST(consultHistoricEngland as String), '.')\r\n",
 					"                            ,IFNULL(CAST(Migrated as String), '.')\r\n",
 					"                            ,IFNULL(CAST(ODTSourceSystem as String), '.')\r\n",
 					"                            ,IFNULL(CAST(IngestionDate as String), '.')\r\n",


### PR DESCRIPTION
This PR implements support for s20 case types within the existing appeal-s78 entity by adding two new nullable boolean attributes:
- preserveGrantLoan
- consultHistoricEngland

These changes follow the agreed schema extension strategy for handling multiple case types (s78 and s20) using the caseType field (W for s78, Y for s20).

https://pins-ds.atlassian.net/browse/THEODW-1838