### PR TITLE
Theodw 1781 logic error in py create spark schema notebook

### DIFF
--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "c23bd562-fc83-4e5e-a8fb-972addb24885"
+				"spark.autotune.trackingId": "6e93ce0b-cb49-4080-a606-d93658a20e87"
 			}
 		},
 		"metadata": {
@@ -67,7 +67,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "6e93ce0b-cb49-4080-a606-d93658a20e87"
+				"spark.autotune.trackingId": "95aecb31-279a-4ea1-8e6b-cd20bb63c85b"
 			}
 		},
 		"metadata": {

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "95aecb31-279a-4ea1-8e6b-cd20bb63c85b"
+				"spark.autotune.trackingId": "cf17f6cd-cf4b-4242-8c80-8b3138a58f4a"
 			}
 		},
 		"metadata": {
@@ -93,7 +93,7 @@
 					"return_json_schema = False\r\n",
 					"version = '1.10.2'"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -104,7 +104,7 @@
 					"import json\r\n",
 					"import requests"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -122,7 +122,7 @@
 				"source": [
 					"%run service-bus/py_spark_df_ingestion_functions"
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -147,7 +147,7 @@
 					"    'date-time': TimestampType()\r\n",
 					"    }"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -203,7 +203,7 @@
 					"if is_servicebus_schema:\r\n",
 					"    harmonised_fields = StructType(harmonised_fields.fields + [StructField(\"message_id\", StringType(), True)])"
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -231,7 +231,7 @@
 					"    except requests.exceptions.RequestException as e:\r\n",
 					"        logException(e)"
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -266,7 +266,7 @@
 					"        logException(e)\r\n",
 					"        raise ValueError(f\"Unsupported type: {json_type}\")"
 				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -292,7 +292,7 @@
 					"            fields.append(StructField(field_name, spark_type, field_nullable))\r\n",
 					"    return StructType(fields)"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -322,7 +322,7 @@
 					"    else:\r\n",
 					"        return schema"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -341,7 +341,7 @@
 					"@logging_to_appins\r\n",
 					"def add_master_columns_to_schema(db_name: str) -> StructType:\r\n",
 					"    if not db_name:\r\n",
-					"        raise ValueError(\"Missing required parameter: db_name\")\r\n",
+					"        raise ValueError(\"Missing db_name\")\r\n",
 					"\r\n",
 					"    if db_name == \"odw_standardised_db\":\r\n",
 					"        master_fields: StructType = standardised_fields\r\n",
@@ -363,7 +363,7 @@
 					"\r\n",
 					"    return final_schema"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -386,7 +386,7 @@
 					"    logError(f\"Invalid schema retrieved from {url}\")\r\n",
 					"    mssparkutils.notebook.exit('')"
 				],
-				"execution_count": null
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cf17f6cd-cf4b-4242-8c80-8b3138a58f4a"
+				"spark.autotune.trackingId": "b4afd566-bbc4-4e3e-b596-9d385b715b36"
 			}
 		},
 		"metadata": {
@@ -67,7 +67,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -93,7 +93,7 @@
 					"return_json_schema = False\r\n",
 					"version = '1.10.2'"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -104,7 +104,7 @@
 					"import json\r\n",
 					"import requests"
 				],
-				"execution_count": 3
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -122,7 +122,7 @@
 				"source": [
 					"%run service-bus/py_spark_df_ingestion_functions"
 				],
-				"execution_count": 4
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -147,7 +147,7 @@
 					"    'date-time': TimestampType()\r\n",
 					"    }"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -203,7 +203,7 @@
 					"if is_servicebus_schema:\r\n",
 					"    harmonised_fields = StructType(harmonised_fields.fields + [StructField(\"message_id\", StringType(), True)])"
 				],
-				"execution_count": 6
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -231,7 +231,7 @@
 					"    except requests.exceptions.RequestException as e:\r\n",
 					"        logException(e)"
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -266,7 +266,7 @@
 					"        logException(e)\r\n",
 					"        raise ValueError(f\"Unsupported type: {json_type}\")"
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -292,7 +292,7 @@
 					"            fields.append(StructField(field_name, spark_type, field_nullable))\r\n",
 					"    return StructType(fields)"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -322,7 +322,7 @@
 					"    else:\r\n",
 					"        return schema"
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -363,7 +363,7 @@
 					"\r\n",
 					"    return final_schema"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -386,7 +386,7 @@
 					"    logError(f\"Invalid schema retrieved from {url}\")\r\n",
 					"    mssparkutils.notebook.exit('')"
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "cba975b7-fd96-48c3-8d0e-1527705ae3a7"
+				"spark.autotune.trackingId": "c23bd562-fc83-4e5e-a8fb-972addb24885"
 			}
 		},
 		"metadata": {
@@ -340,6 +340,9 @@
 				"source": [
 					"@logging_to_appins\r\n",
 					"def add_master_columns_to_schema(db_name: str) -> StructType:\r\n",
+					"    if not db_name:\r\n",
+					"        raise ValueError(\"Missing required parameter: db_name\")\r\n",
+					"\r\n",
 					"    if db_name == \"odw_standardised_db\":\r\n",
 					"        master_fields: StructType = standardised_fields\r\n",
 					"        all_fields: list = spark_schema.fields + master_fields.fields\r\n",
@@ -352,6 +355,9 @@
 					"\r\n",
 					"    elif db_name == \"odw_curated_db\" or db_name == \"odw_curated_migration_db\":\r\n",
 					"        all_fields: list = spark_schema.fields\r\n",
+					"\r\n",
+					"    else:\r\n",
+					"        raise ValueError(f\"Unrecognized db_name: {db_name}\") \r\n",
 					"\r\n",
 					"    final_schema = StructType(all_fields)\r\n",
 					"\r\n",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
