### PR TITLE
Updating notebook: appeal_event_curated_mipins

### DIFF
--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "61e51462-eb20-46e4-8335-b1db557a08e4"
+				"spark.autotune.trackingId": "0c60a1a5-bbd2-4af4-ac36-ed08c4738f96"
 			}
 		},
 		"metadata": {
@@ -45,12 +45,21 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 32,
-				"automaticScaleJobs": true
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
 		"cells": [
+			{
+				"cell_type": "code",
+				"source": [
+					"from notebookutils import mssparkutils\n",
+					"from datetime import datetime, date\n",
+					"import pyspark.sql.functions as F "
+				],
+				"execution_count": null
+			},
 			{
 				"cell_type": "code",
 				"metadata": {
@@ -102,6 +111,34 @@
 			},
 			{
 				"cell_type": "code",
+				"source": [
+					"view_df = spark.sql(\"SELECT * FROM vw_Appeal_event_curated_mipins\")"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"# prepare dataframe convert UTC to Day light savings for all timestamp fields\n",
+					"\n",
+					"# List of all UTC timestamp columns to convert\n",
+					"timestamp_columns = [\n",
+					"    'eventStartDateTime',\n",
+					"    'eventEndDateTime',\n",
+					"    'NotificationOfSiteVisit',\n",
+					"    'IngestionDate',\n",
+					"    'ValidTo'\n",
+					"]\n",
+					"\n",
+					"# Apply the conversion in a loop\n",
+					"final_view_df = view_df\n",
+					"for column_name in timestamp_columns:\n",
+					"    final_view_df = final_view_df.withColumn(column_name, F.to_timestamp(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
 				"metadata": {
 					"jupyter": {
 						"source_hidden": false,
@@ -133,35 +170,7 @@
 					"collapsed": false
 				},
 				"source": [
-					"df = spark.sql(\"\"\"\n",
-					"                SELECT\n",
-					"                    eventId\n",
-					"                    ,caseReference\n",
-					"                    ,eventType\n",
-					"                    ,eventName\n",
-					"                    ,eventStatus\n",
-					"                    ,isUrgent\n",
-					"                    ,eventPublished\n",
-					"                    ,eventStartDateTime\n",
-					"                    ,eventEndDateTime\n",
-					"                    ,NotificationOfSiteVisit\n",
-					"                    ,addressLine1\n",
-					"                    ,addressLine2\n",
-					"                    ,addressTown\n",
-					"                    ,addressCounty\n",
-					"                    ,addressPostcode\n",
-					"                    ,Migrated\n",
-					"                    ,ODTSourceSystem\n",
-					"                    ,SourceSystemID\n",
-					"                    ,IngestionDate\n",
-					"                    ,ValidTo\n",
-					"                    ,RowID\n",
-					"                    ,IsActive\n",
-					"                FROM\n",
-					"                    vw_Appeal_event_curated_mipins\n",
-					"            \"\"\")\n",
-					"\n",
-					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
+					"final_view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
 				],
 				"execution_count": null
 			},


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
