### PR TITLE
Fix : Update notebook: py_sb_horizon_harmonised_nsip_document

### DIFF
--- a/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
+++ b/workspace/notebook/py_sb_horizon_harmonised_nsip_document.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3b627b41-a829-4ee7-ad07-695008096a08"
+				"spark.autotune.trackingId": "a20be4f8-5e7a-4373-bccf-07aa873addec"
 			}
 		},
 		"metadata": {
@@ -591,7 +591,7 @@
 					"collapsed": false
 				},
 				"source": [
-					"columns_to_consider = ['documentId', 'filename', 'version', 'Migrated', 'ODTSourceSystem', 'IngestionDate', 'ValidTo', 'IsActive']\n",
+					"columns_to_consider = ['documentId', 'filename', 'version', 'Migrated', 'originalFilename', 'ODTSourceSystem', 'IngestionDate', 'ValidTo', 'IsActive']\n",
 					"final_df = final_df.drop_duplicates(subset=columns_to_consider)"
 				],
 				"execution_count": null


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-1902
Summary: This is to include originalFilename in the columns to consider in deduplication at the harmonised layer via the 'py_sb_horizon_harmonised_nsip_document' notebook, so that the discrepancies in odw_curated_migration_db.nsip_document table can be resolved.