### PR TITLE
Bugfix/theodw 1964 fix delta backup trigger params for harmonised layer

### DIFF
--- a/workspace/trigger/tr_delta_backup_odw_hrm_0900.json
+++ b/workspace/trigger/tr_delta_backup_odw_hrm_0900.json
@@ -12,7 +12,7 @@
 				},
 				"parameters": {
 					"target_container": "delta-backup-harmonised",
-					"container": "odw-harmonised "
+					"container": "odw-harmonised"
 				}
 			}
 		],


### PR DESCRIPTION
Trigger had a `space` in the parameter value, this has been corrected. 