### PR TITLE
Feat/new 1859 monitoring of pln master refactored horizon pipeline

### DIFF
--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "72db9579-78d6-4fe8-a603-f28883d8394e"
+				"spark.autotune.trackingId": "088dc736-4fe2-4e3a-af95-eed7c0429269"
 			}
 		},
 		"metadata": {
@@ -90,7 +90,7 @@
 					"from pyspark.sql.types import StringType, DateType, TimestampType, IntegerType, FloatType, StructType, StructField\n",
 					"from delta import DeltaTable"
 				],
-				"execution_count": null
+				"execution_count": 59
 			},
 			{
 				"cell_type": "markdown",
@@ -127,7 +127,7 @@
 					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
 					"Load_data_source=''"
 				],
-				"execution_count": null
+				"execution_count": 60
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 					"# print(ingestion_log_schema_loc)\n",
 					"# print(ingestion_log_table_location)"
 				],
-				"execution_count": null
+				"execution_count": 61
 			},
 			{
 				"cell_type": "markdown",
@@ -169,7 +169,7 @@
 				"source": [
 					"# df = spark.sql(\"Drop Table logging.horizon_refactored_log\")"
 				],
-				"execution_count": null
+				"execution_count": 62
 			},
 			{
 				"cell_type": "code",
@@ -215,7 +215,7 @@
 					"# print(f\"Delta table '{database_name}.{table_name}' created and registered successfully.\")\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 63
 			},
 			{
 				"cell_type": "code",
@@ -235,7 +235,7 @@
 					"else:\n",
 					"    print(\"No folders found in the specified directory.\")"
 				],
-				"execution_count": null
+				"execution_count": 64
 			},
 			{
 				"cell_type": "markdown",
@@ -259,7 +259,7 @@
 					"horizon_files\n",
 					" # comment this during the full execution"
 				],
-				"execution_count": null
+				"execution_count": 65
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"        print(f\"Failed to process {file}: {e}\")\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 66
 			},
 			{
 				"cell_type": "code",
@@ -380,7 +380,7 @@
 					"loop = asyncio.get_event_loop()\n",
 					"loop.run_until_complete(load_horizon_async())"
 				],
-				"execution_count": null
+				"execution_count": 67
 			}
 		]
 	}

--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "59d1c76c-b005-49c0-a1f9-78e2d17c424c"
+				"spark.autotune.trackingId": "a5b7aaa0-3bd1-4e5b-8dab-3f5732005f94"
 			}
 		},
 		"metadata": {
@@ -56,7 +56,7 @@
 				"source": [
 					"%run /utils/py_mount_storage"
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "markdown",
@@ -90,7 +90,7 @@
 					"from pyspark.sql.types import StringType, DateType, TimestampType, IntegerType, FloatType, StructType, StructField\n",
 					"from delta import DeltaTable"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -127,7 +127,7 @@
 					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
 					"Load_data_source=''"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 					"# print(ingestion_log_schema_loc)\n",
 					"# print(ingestion_log_table_location)"
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "markdown",
@@ -169,7 +169,7 @@
 				"source": [
 					"#   df = spark.sql(\"Drop Table logging.horizon_refactored_log\")"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "code",
@@ -215,7 +215,7 @@
 					"# print(f\"Delta table '{database_name}.{table_name}' created and registered successfully.\")\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -235,7 +235,7 @@
 					"else:\n",
 					"    print(\"No folders found in the specified directory.\")"
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "markdown",
@@ -259,7 +259,7 @@
 					"horizon_files\n",
 					" # comment this during the full execution"
 				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -367,7 +367,7 @@
 					"        print(f\"Failed to process {file}: {e}\")\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -382,7 +382,7 @@
 					"loop = asyncio.get_event_loop()\n",
 					"loop.run_until_complete(load_horizon_async())"
 				],
-				"execution_count": null
+				"execution_count": 10
 			}
 		]
 	}

--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8c0cf7a7-ad12-499f-9ccb-a9f66be13f49"
+				"spark.autotune.trackingId": "bce467d2-8f13-4aff-8690-a95f651574fa"
 			}
 		},
 		"metadata": {
@@ -125,7 +125,7 @@
 					"date_folder=''\n",
 					"source_folder='Horizon' #need change\n",
 					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
-					"Load_data_source='pln_master_Refactored_Horizon'"
+					"Load_data_source=''"
 				],
 				"execution_count": 50
 			},
@@ -332,8 +332,8 @@
 					"            today = datetime.strptime(latest_folder, \"%Y-%m-%d\").replace(hour=17, minute=0, second=0, microsecond=0)\n",
 					"            datetime_after_5pm = today.isoformat()\n",
 					"            standardised_new_count = standardised_table_df.filter(col(\"ingested_datetime\") > lit(datetime_after_5pm)).count()\n",
-					"            print(datetime_after_5pm)\n",
-					"            print(standardised_new_count)\n",
+					"            # print(datetime_after_5pm)\n",
+					"            # print(standardised_new_count)\n",
 					"        else:\n",
 					"            standardised_new_count = 0\n",
 					"\n",

--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a5b7aaa0-3bd1-4e5b-8dab-3f5732005f94"
+				"spark.autotune.trackingId": "8c0cf7a7-ad12-499f-9ccb-a9f66be13f49"
 			}
 		},
 		"metadata": {
@@ -56,7 +56,7 @@
 				"source": [
 					"%run /utils/py_mount_storage"
 				],
-				"execution_count": 1
+				"execution_count": 48
 			},
 			{
 				"cell_type": "markdown",
@@ -90,7 +90,7 @@
 					"from pyspark.sql.types import StringType, DateType, TimestampType, IntegerType, FloatType, StructType, StructField\n",
 					"from delta import DeltaTable"
 				],
-				"execution_count": 2
+				"execution_count": 49
 			},
 			{
 				"cell_type": "markdown",
@@ -125,9 +125,9 @@
 					"date_folder=''\n",
 					"source_folder='Horizon' #need change\n",
 					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
-					"Load_data_source=''"
+					"Load_data_source='pln_master_Refactored_Horizon'"
 				],
-				"execution_count": 3
+				"execution_count": 50
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 					"# print(ingestion_log_schema_loc)\n",
 					"# print(ingestion_log_table_location)"
 				],
-				"execution_count": 4
+				"execution_count": 51
 			},
 			{
 				"cell_type": "markdown",
@@ -167,9 +167,9 @@
 					"collapsed": false
 				},
 				"source": [
-					"#   df = spark.sql(\"Drop Table logging.horizon_refactored_log\")"
+					"# df = spark.sql(\"Drop Table logging.horizon_refactored_log\")"
 				],
-				"execution_count": 5
+				"execution_count": 52
 			},
 			{
 				"cell_type": "code",
@@ -215,7 +215,7 @@
 					"# print(f\"Delta table '{database_name}.{table_name}' created and registered successfully.\")\n",
 					""
 				],
-				"execution_count": 6
+				"execution_count": 53
 			},
 			{
 				"cell_type": "code",
@@ -235,7 +235,7 @@
 					"else:\n",
 					"    print(\"No folders found in the specified directory.\")"
 				],
-				"execution_count": 7
+				"execution_count": 54
 			},
 			{
 				"cell_type": "markdown",
@@ -259,7 +259,7 @@
 					"horizon_files\n",
 					" # comment this during the full execution"
 				],
-				"execution_count": 8
+				"execution_count": 55
 			},
 			{
 				"cell_type": "code",
@@ -328,11 +328,12 @@
 					"            ).count()\n",
 					"\n",
 					"        elif Load_data_source == 'pln_master_Refactored_Horizon':\n",
-					"             today_str = datetime.today().strftime('%Y-%m-%d')\n",
-					"             datetime_after_6pm = f\"{today_str} 17:00:00\"\n",
-					"             standardised_new_count = standardised_table_df.filter(col(\"ingested_datetime\") > lit(datetime_after_6pm)).count()\n",
-					"             print(datetime_after_6pm)\n",
-					"             print(standardised_new_count)\n",
+					"            # today = datetime.today().replace(hour=17, minute=0, second=0, microsecond=0)       \n",
+					"            today = datetime.strptime(latest_folder, \"%Y-%m-%d\").replace(hour=17, minute=0, second=0, microsecond=0)\n",
+					"            datetime_after_5pm = today.isoformat()\n",
+					"            standardised_new_count = standardised_table_df.filter(col(\"ingested_datetime\") > lit(datetime_after_5pm)).count()\n",
+					"            print(datetime_after_5pm)\n",
+					"            print(standardised_new_count)\n",
 					"        else:\n",
 					"            standardised_new_count = 0\n",
 					"\n",
@@ -367,7 +368,7 @@
 					"        print(f\"Failed to process {file}: {e}\")\n",
 					""
 				],
-				"execution_count": 9
+				"execution_count": 56
 			},
 			{
 				"cell_type": "code",
@@ -382,7 +383,7 @@
 					"loop = asyncio.get_event_loop()\n",
 					"loop.run_until_complete(load_horizon_async())"
 				],
-				"execution_count": 10
+				"execution_count": 57
 			}
 		]
 	}

--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "bce467d2-8f13-4aff-8690-a95f651574fa"
+				"spark.autotune.trackingId": "72db9579-78d6-4fe8-a603-f28883d8394e"
 			}
 		},
 		"metadata": {
@@ -56,7 +56,7 @@
 				"source": [
 					"%run /utils/py_mount_storage"
 				],
-				"execution_count": 48
+				"execution_count": 58
 			},
 			{
 				"cell_type": "markdown",
@@ -90,7 +90,7 @@
 					"from pyspark.sql.types import StringType, DateType, TimestampType, IntegerType, FloatType, StructType, StructField\n",
 					"from delta import DeltaTable"
 				],
-				"execution_count": 49
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -127,7 +127,7 @@
 					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
 					"Load_data_source=''"
 				],
-				"execution_count": 50
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 					"# print(ingestion_log_schema_loc)\n",
 					"# print(ingestion_log_table_location)"
 				],
-				"execution_count": 51
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -169,7 +169,7 @@
 				"source": [
 					"# df = spark.sql(\"Drop Table logging.horizon_refactored_log\")"
 				],
-				"execution_count": 52
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -215,7 +215,7 @@
 					"# print(f\"Delta table '{database_name}.{table_name}' created and registered successfully.\")\n",
 					""
 				],
-				"execution_count": 53
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -235,7 +235,7 @@
 					"else:\n",
 					"    print(\"No folders found in the specified directory.\")"
 				],
-				"execution_count": 54
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -259,7 +259,7 @@
 					"horizon_files\n",
 					" # comment this during the full execution"
 				],
-				"execution_count": 55
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -327,13 +327,10 @@
 					"                to_date(col(\"ingested_datetime\")) == lit(max_ingested_date)\n",
 					"            ).count()\n",
 					"\n",
-					"        elif Load_data_source == 'pln_master_Refactored_Horizon':\n",
-					"            # today = datetime.today().replace(hour=17, minute=0, second=0, microsecond=0)       \n",
+					"        elif Load_data_source == 'pln_master_Refactored_Horizon':       \n",
 					"            today = datetime.strptime(latest_folder, \"%Y-%m-%d\").replace(hour=17, minute=0, second=0, microsecond=0)\n",
 					"            datetime_after_5pm = today.isoformat()\n",
 					"            standardised_new_count = standardised_table_df.filter(col(\"ingested_datetime\") > lit(datetime_after_5pm)).count()\n",
-					"            # print(datetime_after_5pm)\n",
-					"            # print(standardised_new_count)\n",
 					"        else:\n",
 					"            standardised_new_count = 0\n",
 					"\n",
@@ -368,7 +365,7 @@
 					"        print(f\"Failed to process {file}: {e}\")\n",
 					""
 				],
-				"execution_count": 56
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -383,7 +380,7 @@
 					"loop = asyncio.get_event_loop()\n",
 					"loop.run_until_complete(load_horizon_async())"
 				],
-				"execution_count": 57
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2d479108-4350-4bd5-b89d-10875e62af9a"
+				"spark.autotune.trackingId": "59d1c76c-b005-49c0-a1f9-78e2d17c424c"
 			}
 		},
 		"metadata": {
@@ -331,6 +331,8 @@
 					"             today_str = datetime.today().strftime('%Y-%m-%d')\n",
 					"             datetime_after_6pm = f\"{today_str} 17:00:00\"\n",
 					"             standardised_new_count = standardised_table_df.filter(col(\"ingested_datetime\") > lit(datetime_after_6pm)).count()\n",
+					"             print(datetime_after_6pm)\n",
+					"             print(standardised_new_count)\n",
 					"        else:\n",
 					"            standardised_new_count = 0\n",
 					"\n",

--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "088dc736-4fe2-4e3a-af95-eed7c0429269"
+				"spark.autotune.trackingId": "1a54f4b2-e336-46ad-bb1d-f341ce5acccd"
 			}
 		},
 		"metadata": {
@@ -56,7 +56,7 @@
 				"source": [
 					"%run /utils/py_mount_storage"
 				],
-				"execution_count": 58
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -90,7 +90,7 @@
 					"from pyspark.sql.types import StringType, DateType, TimestampType, IntegerType, FloatType, StructType, StructField\n",
 					"from delta import DeltaTable"
 				],
-				"execution_count": 59
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -127,7 +127,7 @@
 					"specific_file='' # if not provided, it will ingest all files in the date_folder\n",
 					"Load_data_source=''"
 				],
-				"execution_count": 60
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -146,7 +146,7 @@
 					"# print(ingestion_log_schema_loc)\n",
 					"# print(ingestion_log_table_location)"
 				],
-				"execution_count": 61
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -169,7 +169,7 @@
 				"source": [
 					"# df = spark.sql(\"Drop Table logging.horizon_refactored_log\")"
 				],
-				"execution_count": 62
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -215,7 +215,7 @@
 					"# print(f\"Delta table '{database_name}.{table_name}' created and registered successfully.\")\n",
 					""
 				],
-				"execution_count": 63
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -235,7 +235,7 @@
 					"else:\n",
 					"    print(\"No folders found in the specified directory.\")"
 				],
-				"execution_count": 64
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -259,7 +259,7 @@
 					"horizon_files\n",
 					" # comment this during the full execution"
 				],
-				"execution_count": 65
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -365,7 +365,7 @@
 					"        print(f\"Failed to process {file}: {e}\")\n",
 					""
 				],
-				"execution_count": 66
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -380,7 +380,7 @@
 					"loop = asyncio.get_event_loop()\n",
 					"loop.run_until_complete(load_horizon_async())"
 				],
-				"execution_count": 67
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/pipeline/pln_horizon_to_odw.json
+++ b/workspace/pipeline/pln_horizon_to_odw.json
@@ -194,7 +194,7 @@
 						"type": "Expression"
 					},
 					"isSequential": false,
-					"batchCount": 30,
+					"batchCount": 24,
 					"activities": [
 						{
 							"name": "Copy horizon Files",

--- a/workspace/pipeline/pln_horizon_to_odw.json
+++ b/workspace/pipeline/pln_horizon_to_odw.json
@@ -194,7 +194,7 @@
 						"type": "Expression"
 					},
 					"isSequential": false,
-					"batchCount": 10,
+					"batchCount": 30,
 					"activities": [
 						{
 							"name": "Copy horizon Files",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
