### PR TITLE
Remove steps that copy the old testing folder, which has since been m…

### DIFF
--- a/pipelines/scripts/test/test_remove_unmodified_synapse_files.py
+++ b/pipelines/scripts/test/test_remove_unmodified_synapse_files.py
@@ -16,7 +16,6 @@ class MockSynapseWorkspaceUtil():
 
 def copy_workspace():
     shutil.copytree("workspace_copy", "my_local_workspace", dirs_exist_ok=True)
-    shutil.rmtree("my_local_workspace/testing")
     shutil.rmtree("my_local_workspace/integrationRuntime")
     os.remove("my_local_workspace/template-parameters-definition.json")
     os.remove("my_local_workspace/publish_config.json")
@@ -24,7 +23,6 @@ def copy_workspace():
 
 def initialise_workspace_folder_for_testing():
     shutil.copytree("workspace_copy", "workspace", dirs_exist_ok=True)
-    shutil.rmtree("workspace/testing")
     shutil.rmtree("workspace/integrationRuntime")
     os.remove("workspace/template-parameters-definition.json")
     os.remove("workspace/publish_config.json")


### PR DESCRIPTION
No ticket since this is a small fix, but update a broken CICD unit tests which was caused by a reference to the `workspace/testing` folder, which has since been moved to a dedicated location