### PR TITLE
Feat/1859 monitoring of pln master refactored horizon pipeline

### DIFF
--- a/workspace/notebook/py_horizon_Refactored_log.json
+++ b/workspace/notebook/py_horizon_Refactored_log.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "2d6cf6f1-2703-4c08-a3c7-b23aeabffe86"
+				"spark.autotune.trackingId": "ba6c1d50-a63b-47f9-8815-2ee346e31caf"
 			}
 		},
 		"metadata": {
@@ -329,7 +329,7 @@
 					"\n",
 					"        elif Load_data_source == 'pln_master_Refactored_Horizon':\n",
 					"             today_str = datetime.today().strftime('%Y-%m-%d')\n",
-					"             datetime_after_6pm = f\"{today_str} 18:00:00\"\n",
+					"             datetime_after_6pm = f\"{today_str} 17:00:00\"\n",
 					"             standardised_new_count = standardised_table_df.filter(col(\"ingested_datetime\") > lit(datetime_after_6pm)).count()\n",
 					"        else:\n",
 					"            standardised_new_count = 0\n",

--- a/workspace/pipeline/pln_horizon_to_odw.json
+++ b/workspace/pipeline/pln_horizon_to_odw.json
@@ -200,8 +200,6 @@
 							"name": "Copy horizon Files",
 							"description": "Copies data from Horizon to odw-raw",
 							"type": "Copy",
-							"state": "Inactive",
-							"onInactiveMarkAs": "Failed",
 							"dependsOn": [],
 							"policy": {
 								"timeout": "0.12:00:00",


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
