### PR TITLE
bugfix(devops): Remove PE from the exclusion list that should be appr…

### DIFF
--- a/pipelines/scripts/approve_private_endpoints.py
+++ b/pipelines/scripts/approve_private_endpoints.py
@@ -12,8 +12,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 ENDPOINTS_TO_EXCLUDE = {
-    "synapse-mpe-appeals-bo--odw-prod-uks",
-    "synapse-mpe-kv--odw-prod-uks"
+    "synapse-mpe-appeals-bo--odw-prod-uks"
 }
 
 


### PR DESCRIPTION
Remove `synapse-mpe-kv--odw-prod-uks` from the private endpoint exclusion list, to ensure this endpoint is auto approved during CI/CD