### PR TITLE
Adding notebook: Curated_table_load_raw_representation

### DIFF
--- a/workspace/notebook/Curated_table_load_raw_representation.json
+++ b/workspace/notebook/Curated_table_load_raw_representation.json
@@ -1,0 +1,51 @@
+{
+	"name": "Curated_table_load_raw_representation",
+	"properties": {
+		"description": "Dummy notebook to allow the archival script to pass",
+		"folder": {
+			"name": "archive"
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+		"sessionProperties": {
+			"driverMemory": "28g",
+			"driverCores": 4,
+			"executorMemory": "28g",
+			"executorCores": 4,
+			"numExecutors": 2,
+			"conf": {
+				"spark.dynamicAllocation.enabled": "false",
+				"spark.dynamicAllocation.minExecutors": "2",
+				"spark.dynamicAllocation.maxExecutors": "2",
+				"spark.autotune.trackingId": "226b47be-8fcf-46e4-a507-c0359b8c1894"
+			}
+		},
+		"metadata": {
+			"saveOutput": true,
+			"enableDebugMode": false,
+			"kernelspec": {
+				"name": "synapse_pyspark",
+				"display_name": "python"
+			},
+			"language_info": {
+				"name": "python"
+			},
+			"sessionKeepAliveTimeout": 30
+		},
+		"cells": [
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"Dummy notebook to allow the archival script to pass. This is referenced by nsip_representation_migration, but the original notebook seems to have been deleted"
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-1749

The archival script crashes due to a broken reference in the `nsip_representation_migration` pipeline, which references a notebook called `Curated_table_load_raw_representation` which has been deleted. This PR adds in an empty notebook with the same name, so that the script can pass. The script will auto archive/delete this notebook in a subsequent PR