### PR TITLE
Feat/theodw 2197 cicd concurrency

### DIFF
--- a/pipelines/azure-pipelines.yaml
+++ b/pipelines/azure-pipelines.yaml
@@ -48,15 +48,17 @@ resources:
     ref: main
 
 variables:
-- name: variableGroupName
+- name: adoEnvName
   ${{ if eq(parameters.env, 'prod') }}:
-    value: "Terraform Prod"
+    value: "Prod"
   ${{ elseif eq(parameters.env, 'test') }}:
-    value: "Terraform Test"
+    value: "Test"
   ${{ elseif eq(parameters.env, 'build') }}:
-    value: "Terraform Build"
+    value: "Build"
   ${{ else }}:
-    value: "Terraform Dev"
+    value: "Dev"
+- name: variableGroupName
+  value: "Terraform ${{ variables.adoEnvName }}"
 - name: agentPool
   value: 'pins-agent-pool-odw-${{ parameters.env }}-uks'
 - name: azureSubscription
@@ -83,6 +85,7 @@ stages:
     env: ${{ parameters.env }}
     armServiceConnectionName: "ODW ${{ upper(parameters.env) }} - Infrastructure"
     fullDeployment: ${{ parameters.fullDeployment }}
+    adoEnvName: ${{ variables.adoEnvName }}
 
 - ${{ if eq(parameters.runTests, true) }}:
   - template: stages/conditional-run-tests.yaml

--- a/pipelines/jobs/deploy-synapse.yaml
+++ b/pipelines/jobs/deploy-synapse.yaml
@@ -5,12 +5,13 @@ parameters:
   activateTriggers: false
   primaryWorkspace: true
   fullDeployment: false
+  adoEnvName: ''
 
 ##
 # Deploy Azure Synapse
 ##
 jobs:
-- job: DeploySynapseJob
+- deployment: DeploySynapseJob
   pool: ${{ parameters.agentPool }}
   timeoutInMinutes: 0 # Max timeout
   variables:
@@ -27,95 +28,103 @@ jobs:
       value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly,tr_delta_backup_daily_0800,tr_delta_backup_daily_0900,tr_saphr_daily_800,tr_delta_backup_odw_std_0900,tr_delta_backup_odw_hrm_0900,tr_delta_backup_odw_cur_0900,tr_delta_backup_odw_config_0900,tr_delta_backup_odw_cur_migr_0900,tr_delta_backup_odw_logging_0900'
     ${{ if eq(parameters.env , 'prod') }}: 
       value: 'tr_daily_7days_1800,tr_backup_daily,tr_weekly,tr_saphr_daily_800'
-  steps:
-  # Checkout repo
-  - checkout: self
-    displayName: 'Checkout'
-    persistCredentials: true
-    fetchDepth: 0
-  # Login to Azure using Terraform service principal
-  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-login.yaml@odw-common
-  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/get-synapse-details.yaml
-    parameters:
-      env: ${{ parameters.env }}
-      pythonVersion: 3
-      failoverDeployment: false
-  
-  # Check if the dedicated SQL pool is currently paused
-  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-check.yaml
-    parameters:
-      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
-      synapseWorkspaceName: $(synapse_workspace_name)
-  
-  # Disable triggers in the target Synapse Workspace
-  - task: AzureSynapseWorkspace.synapsecicd-deploy.toggle-trigger.toggle-triggers-dev@2
-    displayName: 'Disable Synapse Triggers'
-    inputs:
-      azureSubscription: ${{ parameters.armServiceConnectionName }}
-      ResourceGroupName: $(data_resource_group_name)
-      WorkspaceName: $(synapse_workspace_name)
-      ToggleOn: false
-  
-  # Resume the dedicated SQL pool if it was in a paused state
-  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-resume.yaml
-    parameters:
-      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
-      synapseWorkspaceName: $(synapse_workspace_name)
-  
-  - ${{ if ne(lower(parameters.fullDeployment), true) }}:
-    # Delete local Synapse workspace files to optimise the Synapse deployment
-    - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/delete-unmodified-synapse-workspace-files.yaml
-      parameters:
-        env: ${{ parameters.env }}
-        pythonVersion: 3
-  
-  # Deploy Synapse Workspace artifacts from the source Workspace to the target Workspace
-  - task: Synapse workspace deployment@2
-    continueOnError: false
-    retryCountOnTaskFailure: '2'
-    displayName: 'Deploy Workspace'
-    inputs:
-      AzureResourceManagerConnection: ${{ parameters.armServiceConnectionName }}
-      DeleteArtifactsNotInTemplate: ${{ lower(parameters.fullDeployment) }}
-      DeployManagedPrivateEndpoints: false
-      Environment: 'prod'
-      operation: 'validateDeploy'
-      ArtifactsFolder: 'workspace'
-      OverrideArmParameters: |
-        workspaceName: $(synapse_workspace_name)
-        ls_dsql_connectionString: Integrated Security=False;Encrypt=True;Connection Timeout=30;Data Source=$(synapse_dsql_endpoint);Initial Catalog=@{linkedService().db_name}
-        ls_ssql_builtin_connectionString: Integrated Security=False;Encrypt=True;Connection Timeout=30;Data Source=$(synapse_ssql_endpoint);Initial Catalog=@{linkedService().db_name}
-        ls_backup_destination_properties_typeProperties_url: $(data_lake_dfs_endpoint_failover)
-        ls_backup_source_properties_typeProperties_url: $(data_lake_dfs_endpoint)
-        ls_kv_properties_typeProperties_baseUrl: $(key_vault_uri)
-        ls_servicebus_properties_typeProperties_url: $(service_bus_namespace_name).servicebus.windows.net
-        ls_servicebus_properties_typeProperties_aadResourceId: https://servicebus.azure.net
-        ls_storage_properties_typeProperties_url: $(data_lake_dfs_endpoint)
-      ResourceGroupName: $(data_resource_group_name)
-      TargetWorkspaceName: $(synapse_workspace_name)
-  
-  # Pause the dedicated SQL pool if it was previously resumed
-  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-pause.yaml
-    parameters:
-      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
-      synapseWorkspaceName: $(synapse_workspace_name)
-  
-  # Re-enable triggers in the target Synapse Workspace
-  - task: AzureSynapseWorkspace.synapsecicd-deploy.toggle-trigger.toggle-triggers-dev@2
-    condition: and(succeededOrFailed(), ne(variables.synapseTriggers, ''))
-    displayName: 'Enable Synapse Triggers'
-    inputs:
-      azureSubscription: ${{ parameters.armServiceConnectionName }}
-      ResourceGroupName: $(data_resource_group_name)
-      WorkspaceName: $(synapse_workspace_name)
-      Triggers: ${{ variables.synapseTriggers }}
-- job: BuildDeployODWPackageJob
+  environment: ${{ parameters.adoEnvName }}
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        # Checkout repo
+        - checkout: self
+          displayName: 'Checkout'
+          persistCredentials: true
+          fetchDepth: 0
+        # Login to Azure using Terraform service principal
+        - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-login.yaml@odw-common
+        - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/get-synapse-details.yaml
+          parameters:
+            env: ${{ parameters.env }}
+            pythonVersion: 3
+            failoverDeployment: false
+        
+        # Check if the dedicated SQL pool is currently paused
+        - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-check.yaml
+          parameters:
+            armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+            synapseWorkspaceName: $(synapse_workspace_name)
+        
+        # Disable triggers in the target Synapse Workspace
+        - task: AzureSynapseWorkspace.synapsecicd-deploy.toggle-trigger.toggle-triggers-dev@2
+          displayName: 'Disable Synapse Triggers'
+          inputs:
+            azureSubscription: ${{ parameters.armServiceConnectionName }}
+            ResourceGroupName: $(data_resource_group_name)
+            WorkspaceName: $(synapse_workspace_name)
+            ToggleOn: false
+        
+        # Resume the dedicated SQL pool if it was in a paused state
+        - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-resume.yaml
+          parameters:
+            armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+            synapseWorkspaceName: $(synapse_workspace_name)
+        
+        - ${{ if ne(lower(parameters.fullDeployment), true) }}:
+          # Delete local Synapse workspace files to optimise the Synapse deployment
+          - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/delete-unmodified-synapse-workspace-files.yaml
+            parameters:
+              env: ${{ parameters.env }}
+              pythonVersion: 3
+        
+        # Deploy Synapse Workspace artifacts from the source Workspace to the target Workspace
+        - task: Synapse workspace deployment@2
+          continueOnError: false
+          retryCountOnTaskFailure: '2'
+          displayName: 'Deploy Workspace'
+          inputs:
+            AzureResourceManagerConnection: ${{ parameters.armServiceConnectionName }}
+            DeleteArtifactsNotInTemplate: ${{ lower(parameters.fullDeployment) }}
+            DeployManagedPrivateEndpoints: false
+            Environment: 'prod'
+            operation: 'validateDeploy'
+            ArtifactsFolder: 'workspace'
+            OverrideArmParameters: |
+              workspaceName: $(synapse_workspace_name)
+              ls_dsql_connectionString: Integrated Security=False;Encrypt=True;Connection Timeout=30;Data Source=$(synapse_dsql_endpoint);Initial Catalog=@{linkedService().db_name}
+              ls_ssql_builtin_connectionString: Integrated Security=False;Encrypt=True;Connection Timeout=30;Data Source=$(synapse_ssql_endpoint);Initial Catalog=@{linkedService().db_name}
+              ls_backup_destination_properties_typeProperties_url: $(data_lake_dfs_endpoint_failover)
+              ls_backup_source_properties_typeProperties_url: $(data_lake_dfs_endpoint)
+              ls_kv_properties_typeProperties_baseUrl: $(key_vault_uri)
+              ls_servicebus_properties_typeProperties_url: $(service_bus_namespace_name).servicebus.windows.net
+              ls_servicebus_properties_typeProperties_aadResourceId: https://servicebus.azure.net
+              ls_storage_properties_typeProperties_url: $(data_lake_dfs_endpoint)
+            ResourceGroupName: $(data_resource_group_name)
+            TargetWorkspaceName: $(synapse_workspace_name)
+        
+        # Pause the dedicated SQL pool if it was previously resumed
+        - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/synapse-sql-pool-pause.yaml
+          parameters:
+            armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+            synapseWorkspaceName: $(synapse_workspace_name)
+        
+        # Re-enable triggers in the target Synapse Workspace
+        - task: AzureSynapseWorkspace.synapsecicd-deploy.toggle-trigger.toggle-triggers-dev@2
+          condition: and(succeededOrFailed(), ne(variables.synapseTriggers, ''))
+          displayName: 'Enable Synapse Triggers'
+          inputs:
+            azureSubscription: ${{ parameters.armServiceConnectionName }}
+            ResourceGroupName: $(data_resource_group_name)
+            WorkspaceName: $(synapse_workspace_name)
+            Triggers: ${{ variables.synapseTriggers }}
+- deployment: BuildDeployODWPackageJob
   pool: ${{ parameters.agentPool }}
-  steps:
-  - checkout: self
-    clean: true
-  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-login.yaml@odw-common
-  - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/build-and-deploy-odw-package.yaml
-    parameters:
-      armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
-      env: ${{ lower(parameters.env) }}
+  environment: ${{ parameters.adoEnvName }}
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - checkout: self
+          clean: true
+        - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/azure-login.yaml@odw-common
+        - template: ${{variables['System.DefaultWorkingDirectory']}}/pipelines/steps/build-and-deploy-odw-package.yaml
+          parameters:
+            armServiceConnectionName: ${{ parameters.armServiceConnectionName }}
+            env: ${{ lower(parameters.env) }}

--- a/pipelines/stages/deploy-synapse-stage.yaml
+++ b/pipelines/stages/deploy-synapse-stage.yaml
@@ -3,6 +3,7 @@ parameters:
   env: ''
   armServiceConnectionName: ''
   fullDeployment: false
+  adoEnvName: ''
 
 ##
 # Deploy Azure Synapse only if a modification has been detected in the codebase
@@ -22,3 +23,4 @@ stages:
       runIntegrationTests: True
       runEndToEndTests: true
       fullDeployment: ${{ parameters.fullDeployment }}
+      adoEnvName: ${{ parameters.adoEnvName }}


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-2197

Update the Synapse deployment jobs to use the ADO environments so that stage-level exclusive locks can be applied (i.e only 1 deployment can run in the env at a time, but concurrent deployments to different environments is possible)