### PR TITLE
Disable Synapse Triggers in Dev, Test, Prod Environments

### DIFF
--- a/pipelines/jobs/deploy-synapse.yaml
+++ b/pipelines/jobs/deploy-synapse.yaml
@@ -23,11 +23,11 @@ jobs:
     ${{ if eq(parameters.env , 'build') }}: 
       value: ''
     ${{ if eq(parameters.env , 'dev') }}: 
-      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly,tr_delta_backup_daily_0800,tr_delta_backup_daily_0900,tr_saphr_daily_800,tr_delta_backup_odw_std_0900,tr_delta_backup_odw_hrm_0900,tr_delta_backup_odw_cur_0900,tr_delta_backup_odw_config_0900,tr_delta_backup_odw_cur_migr_0900,tr_delta_backup_odw_logging_0900'
+      value: 'tr_daily_weekdays_1500,tr_weekly,tr_saphr_daily_800'
     ${{ if eq(parameters.env , 'test') }}:
-      value: 'tr_daily_weekdays_1500,tr_backup_daily,tr_weekly,tr_delta_backup_daily_0800,tr_delta_backup_daily_0900,tr_saphr_daily_800,tr_delta_backup_odw_std_0900,tr_delta_backup_odw_hrm_0900,tr_delta_backup_odw_cur_0900,tr_delta_backup_odw_config_0900,tr_delta_backup_odw_cur_migr_0900,tr_delta_backup_odw_logging_0900'
+      value: 'tr_daily_weekdays_1500,tr_weekly,tr_saphr_daily_800'
     ${{ if eq(parameters.env , 'prod') }}: 
-      value: 'tr_daily_7days_1800,tr_backup_daily,tr_weekly,tr_saphr_daily_800'
+      value: 'tr_daily_7days_1800,tr_weekly,tr_saphr_daily_800'
   environment: ${{ parameters.adoEnvName }}
   strategy:
     runOnce:


### PR DESCRIPTION
-Disable all the backup triggers from Dev, Test, Prod - as GRS is enabled in Test, Prod. 
-This activity was previously done but not  been merged to main
