### PR TITLE
Revert "Feat/theodw 1920 update logging approach (#2117)"

### DIFF
--- a/odw/core/util/logging_util.py
+++ b/odw/core/util/logging_util.py
@@ -1,8 +1,14 @@
 import logging
-from azure.monitor.opentelemetry import configure_azure_monitor
 import functools
 import uuid
 from notebookutils import mssparkutils
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+from tenacity import retry, wait_exponential, stop_after_delay
+from tenacity.before_sleep import before_sleep_nothing
+import threading
 
 
 class LoggingUtil:
@@ -19,7 +25,7 @@ class LoggingUtil:
     ```
 
     This is based on
-    https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable?tabs=python#enable-azure-monitor-opentelemetry-for-net-nodejs-python-and-java-applications
+    https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/samples/logs/sample_log.py
     """
 
     _INSTANCE = None
@@ -36,19 +42,17 @@ class LoggingUtil:
 
         __init__ cannot be used because it is always called by __new__, even if cls._INSTANCE is not None
         """
+        self.LOGGER_PROVIDER = LoggerProvider()
+        self._LOGGING_INITIALISED = False
         self.pipelinejobid = (
             mssparkutils.runtime.context["pipelinejobid"] if mssparkutils.runtime.context.get("isForPipeline", False) else uuid.uuid4()
         )
-        self.logger_name_space = "odw_logs"
-        self.logger = logging.getLogger(self.logger_name_space)
-
-        app_insights_connection_string = mssparkutils.credentials.getSecretWithLS("ls_kv", "application-insights-connection-string")
-        if not app_insights_connection_string:
-            raise RuntimeError("The credential returned by mssparkutils.credentials.getSecretWithLS was blank or None")
-        configure_azure_monitor(logger_name=self.logger_name_space, connection_string=app_insights_connection_string)
-
-        self.logger.setLevel(logging.INFO)
-        self.log_info("Logging initialised.")
+        self.logger = logging.getLogger()
+        for h in list(self.logger.handlers):
+            if isinstance(h, LoggingHandler):
+                self.logger.removeHandler(h)
+        self.setup_logging()
+        self.flush_logging()
 
     def log_info(self, msg: str):
         """
@@ -67,6 +71,58 @@ class LoggingUtil:
         Log an exception
         """
         self.logger.exception(f"{self.pipelinejobid} : {ex}")
+
+    @retry(wait=wait_exponential(multiplier=1, min=2, max=10), stop=stop_after_delay(20), reraise=True, before_sleep=before_sleep_nothing)
+    def setup_logging(self, force=False):
+        """
+        Initialise logging to Azure App Insights
+        """
+        if self._LOGGING_INITIALISED and not force:
+            self.log_info("Logging already initialised.")
+            return
+        key = mssparkutils.credentials.getSecretWithLS("ls_kv", "application-insights-connection-string")
+        if not key:
+            raise RuntimeError("The credential returned by mssparkutils.credentials.getSecretWithLS was blank or None")
+        conn_string = key.split(";")[0]
+
+        set_logger_provider(self.LOGGER_PROVIDER)
+        exporter = AzureMonitorLogExporter.from_connection_string(conn_string)
+        self.LOGGER_PROVIDER.add_log_record_processor(BatchLogRecordProcessor(exporter, schedule_delay_millis=5000))
+
+        if not any(isinstance(h, LoggingHandler) for h in self.logger.handlers):
+            self.logger.addHandler(LoggingHandler())
+
+        if not any(isinstance(h, logging.StreamHandler) for h in self.logger.handlers):
+            self.logger.addHandler(logging.StreamHandler())
+
+        self.logger.setLevel(logging.INFO)
+        self._LOGGING_INITIALISED = True
+        self.log_info("Logging initialised.")
+
+    def flush_logging(self, timeout_seconds: int = 60):
+        """
+        Attempt to flush logs to Azure App Insights
+        """
+        print("Calling flush")
+        event = threading.Event()
+
+        def flush_logging_inner():
+            print("Flushing logs")
+            try:
+                self.LOGGER_PROVIDER.force_flush()
+            except Exception as e:
+                print(f"Flush failed: {e}")
+            event.set()
+
+        t = threading.Thread(target=flush_logging_inner)
+        t.daemon = True
+        t.start()
+
+        finished = event.wait(timeout=timeout_seconds)
+        if not finished:
+            print(f"force_flush() hung for >{timeout_seconds}s - continuing anyway")
+        else:
+            print("force_flush() completed")
 
     @classmethod
     def logging_to_appins(cls, func):

--- a/odw/test/integration_test/test_logging_util.py
+++ b/odw/test/integration_test/test_logging_util.py
@@ -6,7 +6,6 @@ import requests
 from uuid import uuid4
 import mock
 import pytest
-import time
 
 
 APP_INSIGHTS_TOKEN = AzureCliCredential().get_token("https://api.applicationinsights.io/.default").token
@@ -34,8 +33,7 @@ def run_logging_util():
     with mock.patch("notebookutils.mssparkutils.runtime.context", mock_mssparkutils_context):
         with mock.patch.object(notebookutils.mssparkutils.credentials, "getSecretWithLS", return_value=app_insights_connection_string):
             some_test_function("Hello", mock_arg_b="There")
-            # The logs take time to appear in app insights
-            time.sleep(60)
+            LoggingUtil().flush_logging()
 
 
 def test_logging_initialised():

--- a/odw/test/integration_test/test_table_util.py
+++ b/odw/test/integration_test/test_table_util.py
@@ -1,4 +1,5 @@
 from odw.test.util.mock.import_mock_notebook_utils import notebookutils
+from odw.core.util.logging_util import LoggingUtil
 from odw.core.util.table_util import TableUtil
 from odw.test.util.config import TEST_CONFIG
 from pyspark.sql import SparkSession
@@ -41,8 +42,8 @@ def validate_table_deleted(database_name: str, table_name: str, raw_data_path: s
         app_insights_connection_string = TEST_CONFIG["APP_INSIGHTS_CONNECTION_STRING"]
         with mock.patch("notebookutils.mssparkutils.runtime.context", mock_mssparkutils_context):
             with mock.patch.object(notebookutils.mssparkutils.credentials, "getSecretWithLS", return_value=app_insights_connection_string):
-                # Mock configure_azure_monitor to save time, since this takes 1 minute each time it is called
-                with mock.patch("odw.core.util.logging_util.configure_azure_monitor"):
+                # Mock flush_logging to save time, since this 1 minute each time it is called
+                with mock.patch.object(LoggingUtil, "flush_logging", return_value=None):
                     datetime_format = "%Y-%m-%d %H:%M:%S.%f"
                     mock_table_details = spark.createDataFrame(
                         [


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-2264

Title: Investigation and Fix: Telemetry data limit exceeded

This PR reverts commit 214eb94, which introduced updates to the logging approach. The changes caused unexpected verbose INFO-level logs when telemetry was sent to Application Insights, as described in [Azure/azure-sdk-for-python#33623](https://github.com/Azure/azure-sdk-for-python/issues/33623?utm_source=chatgpt.com)