### PR TITLE
Feat/theodw 2932 appeal representation clean

### DIFF
--- a/odw/core/etl/etl_process_factory.py
+++ b/odw/core/etl/etl_process_factory.py
@@ -21,6 +21,7 @@ from odw.core.etl.transformation.curated.nsip_representation_curated_process imp
 from odw.core.etl.transformation.curated.nsip_s51_advice_curated_process import NsipS51AdviceCuratedProcess
 from odw.core.etl.transformation.curated.nsip_meeting_curated_process import NsipMeetingCuratedProcess
 from odw.core.etl.transformation.curated.appeal_document_curated_process import AppealDocumentCuratedProcess
+from odw.core.etl.transformation.curated.appeal_representation_curated_process import AppealRepresentationCuratedProcess
 from typing import Dict, List, Set, Type
 import json
 
@@ -48,6 +49,7 @@ class ETLProcessFactory:
         NsipS51AdviceCuratedProcess,
         NsipMeetingCuratedProcess,
         AppealDocumentCuratedProcess,
+        AppealRepresentationCuratedProcess,
     }
 
     @classmethod

--- a/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
@@ -1,0 +1,103 @@
+from odw.core.etl.transformation.curated.curation_process import CurationProcess
+from odw.core.util.logging_util import LoggingUtil
+from odw.core.util.util import Util
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult, ETLResultMetadata
+from pyspark.sql import DataFrame, SparkSession
+from datetime import datetime
+from typing import Dict, Tuple
+
+
+
+class AppealRepresentationCuratedProcess(CurationProcess):
+    HARMONISED_TABLE = "odw_harmonised_db.sb_appeal_representation"
+    OUTPUT_TABLE = "odw_curated_db.appeal_representation"
+
+
+    def __init__(self, spark: SparkSession, debug: bool = False):
+        super().__init__(spark, debug)
+
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "appeal-representation-curated"
+
+
+    def load_data(self, **kwargs) -> Dict[str, DataFrame]:
+        LoggingUtil().log_info(f"Loading harmonised Appeal Representation data from {self.HARMONISED_TABLE}")
+
+
+        harmonised_representations = self.spark.sql(
+            f"""
+            SELECT
+                representationId,
+                caseId,
+                caseReference,
+                representationStatus,
+                originalRepresentation,
+                redacted,
+                redactedRepresentation,
+                redactedBy,
+                invalidOrIncompleteDetails,
+                otherInvalidOrIncompleteDetails,
+                source,
+                serviceUserId,
+                representationType,
+                dateReceived,
+                documentIds
+            FROM {self.HARMONISED_TABLE}
+            WHERE IsActive = 'Y'
+            """
+        )
+
+
+        return {
+            "harmonised_representations": harmonised_representations,
+        }
+
+
+    def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
+        start_exec_time = datetime.now()
+
+
+        source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
+        harmonised_representations: DataFrame = self.load_parameter("harmonised_representations", source_data)
+
+
+        df = harmonised_representations
+
+
+        insert_count = df.count()
+        LoggingUtil().log_info(f"Curated Appeal Representation row count: {insert_count}")
+
+
+        end_exec_time = datetime.now()
+
+
+        data_to_write = {
+            self.OUTPUT_TABLE: {
+                "data": df,
+                "storage_kind": "ADLSG2-Table",
+                "database_name": "odw_curated_db",
+                "table_name": "appeal_representation",
+                "storage_endpoint": Util.get_storage_account(),
+                "container_name": "odw-curated",
+                "blob_path": "appeal_representation",
+                "file_format": "parquet",
+                "write_mode": "overwrite",
+                "write_options": {},
+            }
+        }
+
+
+        return data_to_write, ETLSuccessResult(
+            metadata=ETLResultMetadata(
+                start_execution_time=start_exec_time,
+                end_execution_time=end_exec_time,
+                table_name=self.OUTPUT_TABLE,
+                insert_count=insert_count,
+                update_count=0,
+                delete_count=0,
+                activity_type=self.__class__.__name__,
+                duration_seconds=(end_exec_time - start_exec_time).total_seconds(),
+            )
+        )

--- a/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
@@ -1,30 +1,17 @@
-from odw.core.etl.transformation.curated.curation_process import CurationProcess
-from odw.core.util.logging_util import LoggingUtil
-from odw.core.util.util import Util
-from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
-from pyspark.sql import DataFrame, SparkSession
 from datetime import datetime
 from typing import Dict, Tuple
 
-try:
-    ETLResultMetadata  # type: ignore[name-defined]
-except NameError:
-    from pydantic import BaseModel, Field
+from pyspark.sql import DataFrame, SparkSession
 
-    class ETLResultMetadata(BaseModel):  # fallback, local definition
-        start_execution_time: datetime
-        end_execution_time: datetime
-        exception: str | None = None
-        exception_trace: str | None = None
-        table_name: str | None = None
-        insert_count: int = Field(default=0)
-        update_count: int = Field(default=0)
-        delete_count: int = Field(default=0)
-        activity_type: str
-        duration_seconds: float
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
+from odw.core.etl.transformation.curated.curation_process import CurationProcess
+from odw.core.util.logging_util import LoggingUtil
+from odw.core.util.util import Util
 
 
 class AppealRepresentationCuratedProcess(CurationProcess):
+    """Curates active harmonised appeal representation data into the curated layer."""
+
     HARMONISED_TABLE = "odw_harmonised_db.sb_appeal_representation"
     OUTPUT_TABLE = "odw_curated_db.appeal_representation"
 
@@ -36,7 +23,11 @@ class AppealRepresentationCuratedProcess(CurationProcess):
         return "appeal-representation-curated"
 
     def load_data(self, **kwargs) -> Dict[str, DataFrame]:
-        LoggingUtil().log_info(f"Loading harmonised Appeal Representation data from {self.HARMONISED_TABLE}")
+        """Load active appeal representation records from the harmonised table."""
+
+        LoggingUtil().log_info(
+            f"Loading harmonised Appeal Representation data from {self.HARMONISED_TABLE}"
+        )
 
         harmonised_representations = self.spark.sql(
             f"""
@@ -66,15 +57,21 @@ class AppealRepresentationCuratedProcess(CurationProcess):
         }
 
     def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
+        """Prepare curated appeal representation output and return ETL metadata."""
+
         start_exec_time = datetime.now()
 
         source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
-        harmonised_representations: DataFrame = self.load_parameter("harmonised_representations", source_data)
+        harmonised_representations: DataFrame = self.load_parameter(
+            "harmonised_representations", source_data
+        )
 
         df = harmonised_representations
 
         insert_count = df.count()
-        LoggingUtil().log_info(f"Curated Appeal Representation row count: {insert_count}")
+        LoggingUtil().log_info(
+            f"Curated Appeal Representation row count: {insert_count}"
+        )
 
         end_exec_time = datetime.now()
 
@@ -94,7 +91,7 @@ class AppealRepresentationCuratedProcess(CurationProcess):
         }
 
         return data_to_write, ETLSuccessResult(
-            metadata=ETLResultMetadata(
+            metadata=ETLResult.ETLResultMetadata(
                 start_execution_time=start_exec_time,
                 end_execution_time=end_exec_time,
                 table_name=self.OUTPUT_TABLE,

--- a/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
@@ -25,9 +25,7 @@ class AppealRepresentationCuratedProcess(CurationProcess):
     def load_data(self, **kwargs) -> Dict[str, DataFrame]:
         """Load active appeal representation records from the harmonised table."""
 
-        LoggingUtil().log_info(
-            f"Loading harmonised Appeal Representation data from {self.HARMONISED_TABLE}"
-        )
+        LoggingUtil().log_info(f"Loading harmonised Appeal Representation data from {self.HARMONISED_TABLE}")
 
         harmonised_representations = self.spark.sql(
             f"""
@@ -62,16 +60,12 @@ class AppealRepresentationCuratedProcess(CurationProcess):
         start_exec_time = datetime.now()
 
         source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
-        harmonised_representations: DataFrame = self.load_parameter(
-            "harmonised_representations", source_data
-        )
+        harmonised_representations: DataFrame = self.load_parameter("harmonised_representations", source_data)
 
         df = harmonised_representations
 
         insert_count = df.count()
-        LoggingUtil().log_info(
-            f"Curated Appeal Representation row count: {insert_count}"
-        )
+        LoggingUtil().log_info(f"Curated Appeal Representation row count: {insert_count}")
 
         end_exec_time = datetime.now()
 

--- a/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
@@ -1,12 +1,27 @@
 from odw.core.etl.transformation.curated.curation_process import CurationProcess
 from odw.core.util.logging_util import LoggingUtil
 from odw.core.util.util import Util
-from odw.core.etl.etl_result import ETLResult, ETLSuccessResult, ETLResultMetadata
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
 from pyspark.sql import DataFrame, SparkSession
 from datetime import datetime
 from typing import Dict, Tuple
 
+try:
+    ETLResultMetadata  # type: ignore[name-defined]
+except NameError:
+    from pydantic import BaseModel, Field
 
+    class ETLResultMetadata(BaseModel):  # fallback, local definition
+        start_execution_time: datetime
+        end_execution_time: datetime
+        exception: str | None = None
+        exception_trace: str | None = None
+        table_name: str | None = None
+        insert_count: int = Field(default=0)
+        update_count: int = Field(default=0)
+        delete_count: int = Field(default=0)
+        activity_type: str
+        duration_seconds: float
 
 class AppealRepresentationCuratedProcess(CurationProcess):
     HARMONISED_TABLE = "odw_harmonised_db.sb_appeal_representation"

--- a/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_representation_curated_process.py
@@ -23,23 +23,20 @@ except NameError:
         activity_type: str
         duration_seconds: float
 
+
 class AppealRepresentationCuratedProcess(CurationProcess):
     HARMONISED_TABLE = "odw_harmonised_db.sb_appeal_representation"
     OUTPUT_TABLE = "odw_curated_db.appeal_representation"
 
-
     def __init__(self, spark: SparkSession, debug: bool = False):
         super().__init__(spark, debug)
-
 
     @classmethod
     def get_name(cls) -> str:
         return "appeal-representation-curated"
 
-
     def load_data(self, **kwargs) -> Dict[str, DataFrame]:
         LoggingUtil().log_info(f"Loading harmonised Appeal Representation data from {self.HARMONISED_TABLE}")
-
 
         harmonised_representations = self.spark.sql(
             f"""
@@ -64,29 +61,22 @@ class AppealRepresentationCuratedProcess(CurationProcess):
             """
         )
 
-
         return {
             "harmonised_representations": harmonised_representations,
         }
 
-
     def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
         start_exec_time = datetime.now()
-
 
         source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
         harmonised_representations: DataFrame = self.load_parameter("harmonised_representations", source_data)
 
-
         df = harmonised_representations
-
 
         insert_count = df.count()
         LoggingUtil().log_info(f"Curated Appeal Representation row count: {insert_count}")
 
-
         end_exec_time = datetime.now()
-
 
         data_to_write = {
             self.OUTPUT_TABLE: {
@@ -102,7 +92,6 @@ class AppealRepresentationCuratedProcess(CurationProcess):
                 "write_options": {},
             }
         }
-
 
         return data_to_write, ETLSuccessResult(
             metadata=ETLResultMetadata(


### PR DESCRIPTION
**PR Template**

JIRA Ticket Reference :

https://pins-ds.atlassian.net/browse/THEODW-2932

Summary of the work :

appeal_representation_curated_process.py

Moved Appeal Representation curated logic into the shared ODW ETL package as a dedicated AppealRepresentationCuratedProcess class, following the standard Load → Transform → Write structure.
Added a local ETLResultMetadata Pydantic model inside the curated process as a fallback so the Synapse notebook can run without changes to the shared etl_result.py.

Changes:

odw/core/etl/etl_process_factory.py — registered new Appeal Representation curated process

odw/core/etl/transformation/curated/appeal_representation_curated_process.py — new curated process with local ETLResultMetadata fallback


Proof

py_etl_orchestrator notebook run in Synapse Dev for appeal-representation-curated completed successfully.

17,796 rows written to odw_curated_db.appeal_representation.

Pipeline logs saved successfully.

Notebook exited successfully using etl_results.model_dump_json(indent=4).