### PR TITLE
Fix ETL insert_count calculation to avoid recomputation

### DIFF
--- a/odw/core/etl/transformation/harmonised/service_bus_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/service_bus_harmonisation_process.py
@@ -165,6 +165,9 @@ class ServiceBusHarmonisationProcess(HarmonisationProcess):
         new_data = new_data.filter(F.col("row_state_metadata") != "delete").drop("row_state_metadata")
         new_data = new_data.union(update_rows).union(unupdated_rows).dropDuplicates()
 
+        new_data = new_data.cache()
+        insert_count = new_data.count()
+
         hrm_table_snake_case = hrm_table.replace("-", "_")
 
         data_to_write = {
@@ -188,7 +191,7 @@ class ServiceBusHarmonisationProcess(HarmonisationProcess):
                 start_execution_time=start_exec_time,
                 end_execution_time=end_exec_time,
                 table_name=harmonised_table_path,
-                insert_count=new_data.count(),
+                insert_count=insert_count,
                 update_count=0,
                 delete_count=0,
                 activity_type=self.__class__.__name__,


### PR DESCRIPTION
[THEODW-3035](https://pins-ds.atlassian.net/browse/THEODW-3035)
This change optimises how insert_count is calculated in the Service Bus Harmonisation process.
Fix ETL insert_count calculation to avoid recomputation

Cache new_data and compute insert_count once to prevent multiple Spark actions
and improve performance/stability in ETL metadata reporting.

[THEODW-3035]: https://pins-ds.atlassian.net/browse/THEODW-3035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ