### PR TITLE
Feat/3059 convert ut cappeal event curated mipins

### DIFF
--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "21e89f80-95a3-4698-8456-3d38082ba38e"
+				"spark.autotune.trackingId": "fd1d3712-6ba4-4400-9a1f-25ca2e98cbab"
 			}
 		},
 		"metadata": {
@@ -58,7 +58,7 @@
 					"from datetime import datetime, date\n",
 					"import pyspark.sql.functions as F"
 				],
-				"execution_count": null
+				"execution_count": 49
 			},
 			{
 				"cell_type": "code",
@@ -114,34 +114,35 @@
 					"AND (IngestionDate IS NULL OR IngestionDate >= TIMESTAMP('1900-01-01'))\n",
 					"AND (ValidTo IS NULL OR ValidTo >= TIMESTAMP('1900-01-01'))"
 				],
-				"execution_count": null
+				"execution_count": 50
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_Appeal_event_curated_mipins\")"
 				],
-				"execution_count": null
+				"execution_count": 51
 			},
 			{
 				"cell_type": "code",
 				"source": [
-					"# prepare dataframe convert UTC to Day light savings for all timestamp fields\n",
 					"\n",
-					"# List of UTC timestamp columns to convert\n",
 					"timestamp_columns = [\n",
-					"'eventStartDateTime',    \n",
-					"'eventEndDateTime', \n",
-					"'IngestionDate',\n",
-					"'ValidTo',\n",
+					"    'eventStartDateTime',\n",
+					"    'eventEndDateTime',\n",
+					"    'IngestionDate',\n",
+					"    'ValidTo',\n",
 					"]\n",
 					"\n",
-					"# Apply the UTC to London conversion for each column\n",
-					"final_view_df = view_df\n",
-					"for column_name in timestamp_columns:\n",
-					"    final_view_df = final_view_df.withColumn(column_name, F.to_timestamp(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
+					"final_view_df = view_df.withColumns({\n",
+					"    col: F.to_timestamp(\n",
+					"        F.from_utc_timestamp(F.col(col), 'Europe/London'),\n",
+					"        \"yyyy-MM-dd'T'HH:mm:ss.SSS\"\n",
+					"    )\n",
+					"    for col in timestamp_columns\n",
+					"})"
 				],
-				"execution_count": null
+				"execution_count": 52
 			},
 			{
 				"cell_type": "code",
@@ -162,7 +163,7 @@
 					"    .option(\"path\", table_path) \\\n",
 					"    .saveAsTable(table_name)"
 				],
-				"execution_count": null
+				"execution_count": 54
 			}
 		]
 	}

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "9f5074c8-9da2-4ecd-a577-05ea15c562f0"
+				"spark.autotune.trackingId": "eb86e7f8-1279-4d20-98ac-f0829b84731d"
 			}
 		},
 		"metadata": {
@@ -53,6 +53,15 @@
 		"cells": [
 			{
 				"cell_type": "code",
+				"source": [
+					"from notebookutils import mssparkutils\n",
+					"from datetime import datetime, date\n",
+					"import pyspark.sql.functions as F"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
 				"metadata": {
 					"jupyter": {
 						"source_hidden": false,
@@ -70,7 +79,7 @@
 				},
 				"source": [
 					"%%sql\n",
-					"CREATE OR REPLACE  VIEW vw_Appeal_event_curated_mipins \n",
+					"CREATE OR REPLACE  VIEW odw_curated_db.vw_Appeal_event_curated_mipins\n",
 					"AS\n",
 					"SELECT\n",
 					"    eventId\n",
@@ -110,48 +119,42 @@
 			{
 				"cell_type": "code",
 				"source": [
-					"df = spark.sql(\"\"\"\n",
-					"    SELECT\n",
-					"        eventId,\n",
-					"        caseReference,\n",
-					"        eventType,\n",
-					"        eventName,\n",
-					"        eventStatus,\n",
-					"        isUrgent,\n",
-					"        eventPublished,\n",
-					"        eventStartDateTime,\n",
-					"        eventEndDateTime,\n",
-					"        NotificationOfSiteVisit,\n",
-					"        addressLine1,\n",
-					"        addressLine2,\n",
-					"        addressTown,\n",
-					"        addressCounty,\n",
-					"        addressPostcode,\n",
-					"        Migrated,\n",
-					"        ODTSourceSystem,\n",
-					"        SourceSystemID,\n",
-					"        IngestionDate,\n",
-					"        ValidTo,\n",
-					"        RowID,\n",
-					"        IsActive\n",
-					"    FROM vw_Appeal_event_curated_mipins\n",
-					"\"\"\")\n",
+					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_Appeal_event_curated_mipins\")"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"# prepare dataframe convert UTC to Day light savings for all timestamp fields\n",
 					"\n",
-					"table_name = 'odw_curated_db.appeal_event_curated_mipins'\n",
+					"# List of UTC timestamp columns to convert\n",
+					"timestamp_columns = [\n",
+					"'eventStartDateTime',    \n",
+					"'eventEndDateTime', \n",
+					"'IngestionDate',\n",
+					"'ValidTo',\n",
 					"\n",
-					"df_table_path = spark.sql(f\"DESCRIBE EXTENDED {table_name}\")\n",
-					"table_path = (\n",
-					"    df_table_path\n",
-					"    .where(\"col_name == 'Location'\")\n",
-					"    .select(\"data_type\")\n",
-					"    .collect()[0][0]\n",
-					")\n",
+					"]\n",
 					"\n",
-					"df.write \\\n",
-					"    .format(\"parquet\") \\\n",
-					"    .mode(\"overwrite\") \\\n",
-					"    .option(\"path\", table_path) \\\n",
-					"    .saveAsTable(table_name)"
+					"# Apply the UTC to London conversion for each column\n",
+					"final_view_df = view_df\n",
+					"for column_name in timestamp_columns:\n",
+					"    final_view_df = final_view_df.withColumn(column_name, F.to_timestamp(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"spark.sql(f\"drop table if exists odw_curated_db.appeal_event_curated_mipins;\")"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"final_view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
 				],
 				"execution_count": null
 			},

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "fd1d3712-6ba4-4400-9a1f-25ca2e98cbab"
+				"spark.autotune.trackingId": "c21668c0-9e9d-4878-9e56-92a911136fbc"
 			}
 		},
 		"metadata": {
@@ -58,7 +58,7 @@
 					"from datetime import datetime, date\n",
 					"import pyspark.sql.functions as F"
 				],
-				"execution_count": 49
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -114,14 +114,14 @@
 					"AND (IngestionDate IS NULL OR IngestionDate >= TIMESTAMP('1900-01-01'))\n",
 					"AND (ValidTo IS NULL OR ValidTo >= TIMESTAMP('1900-01-01'))"
 				],
-				"execution_count": 50
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_Appeal_event_curated_mipins\")"
 				],
-				"execution_count": 51
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -142,7 +142,7 @@
 					"    for col in timestamp_columns\n",
 					"})"
 				],
-				"execution_count": 52
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -163,7 +163,7 @@
 					"    .option(\"path\", table_path) \\\n",
 					"    .saveAsTable(table_name)"
 				],
-				"execution_count": 54
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "0b20e75e-8e8a-4682-a31c-82ddd66974bd"
+				"spark.autotune.trackingId": "80c8e8a9-a825-492f-8e8a-a4c4d989c543"
 			}
 		},
 		"metadata": {
@@ -58,7 +58,7 @@
 					"from datetime import datetime, date\n",
 					"import pyspark.sql.functions as F"
 				],
-				"execution_count": 11
+				"execution_count": 28
 			},
 			{
 				"cell_type": "code",
@@ -114,14 +114,14 @@
 					"AND (IngestionDate IS NULL OR IngestionDate >= TIMESTAMP('1900-01-01'))\n",
 					"AND (ValidTo IS NULL OR ValidTo >= TIMESTAMP('1900-01-01'))"
 				],
-				"execution_count": 12
+				"execution_count": 29
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_Appeal_event_curated_mipins\")"
 				],
-				"execution_count": 13
+				"execution_count": 30
 			},
 			{
 				"cell_type": "code",
@@ -134,7 +134,6 @@
 					"'eventEndDateTime', \n",
 					"'IngestionDate',\n",
 					"'ValidTo',\n",
-					"\n",
 					"]\n",
 					"\n",
 					"# Apply the UTC to London conversion for each column\n",
@@ -142,41 +141,28 @@
 					"for column_name in timestamp_columns:\n",
 					"    final_view_df = final_view_df.withColumn(column_name, F.to_timestamp(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
 				],
-				"execution_count": 14
+				"execution_count": 31
 			},
 			{
 				"cell_type": "code",
 				"source": [
-					"spark.sql(f\"drop table if exists odw_curated_db.appeal_event_curated_mipins;\")"
+					"table_name = 'odw_curated_db.appeal_event_curated_mipins'\n",
+					"\n",
+					"df_table_path = spark.sql(f\"DESCRIBE EXTENDED {table_name}\")\n",
+					"table_path = (\n",
+					"    df_table_path\n",
+					"    .where(\"col_name == 'Location'\")\n",
+					"    .select(\"data_type\")\n",
+					"    .collect()[0][0]\n",
+					")\n",
+					"\n",
+					"final_view_df.write \\\n",
+					"    .format(\"parquet\") \\\n",
+					"    .mode(\"overwrite\") \\\n",
+					"    .option(\"path\", table_path) \\\n",
+					"    .saveAsTable(table_name)"
 				],
-				"execution_count": 15
-			},
-			{
-				"cell_type": "code",
-				"source": [
-					"final_view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
-				],
-				"execution_count": 16
-			},
-			{
-				"cell_type": "code",
-				"metadata": {
-					"jupyter": {
-						"source_hidden": false,
-						"outputs_hidden": false
-					},
-					"nteract": {
-						"transient": {
-							"deleting": false
-						}
-					},
-					"collapsed": false
-				},
-				"source": [
-					"#%%sql\n",
-					"#select * from odw_curated_db.appeal_event_curated_mipins where isactive='N'"
-				],
-				"execution_count": 17
+				"execution_count": 32
 			}
 		]
 	}

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "eb86e7f8-1279-4d20-98ac-f0829b84731d"
+				"spark.autotune.trackingId": "0b20e75e-8e8a-4682-a31c-82ddd66974bd"
 			}
 		},
 		"metadata": {
@@ -58,7 +58,7 @@
 					"from datetime import datetime, date\n",
 					"import pyspark.sql.functions as F"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -114,14 +114,14 @@
 					"AND (IngestionDate IS NULL OR IngestionDate >= TIMESTAMP('1900-01-01'))\n",
 					"AND (ValidTo IS NULL OR ValidTo >= TIMESTAMP('1900-01-01'))"
 				],
-				"execution_count": null
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_Appeal_event_curated_mipins\")"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -142,21 +142,21 @@
 					"for column_name in timestamp_columns:\n",
 					"    final_view_df = final_view_df.withColumn(column_name, F.to_timestamp(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
 				],
-				"execution_count": null
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeal_event_curated_mipins;\")"
 				],
-				"execution_count": null
+				"execution_count": 15
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"final_view_df.write.mode(\"overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
 				],
-				"execution_count": null
+				"execution_count": 16
 			},
 			{
 				"cell_type": "code",
@@ -176,7 +176,7 @@
 					"#%%sql\n",
 					"#select * from odw_curated_db.appeal_event_curated_mipins where isactive='N'"
 				],
-				"execution_count": null
+				"execution_count": 17
 			}
 		]
 	}

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "80c8e8a9-a825-492f-8e8a-a4c4d989c543"
+				"spark.autotune.trackingId": "21e89f80-95a3-4698-8456-3d38082ba38e"
 			}
 		},
 		"metadata": {
@@ -58,7 +58,7 @@
 					"from datetime import datetime, date\n",
 					"import pyspark.sql.functions as F"
 				],
-				"execution_count": 28
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -114,14 +114,14 @@
 					"AND (IngestionDate IS NULL OR IngestionDate >= TIMESTAMP('1900-01-01'))\n",
 					"AND (ValidTo IS NULL OR ValidTo >= TIMESTAMP('1900-01-01'))"
 				],
-				"execution_count": 29
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
 				"source": [
 					"view_df = spark.sql(\"SELECT * FROM odw_curated_db.vw_Appeal_event_curated_mipins\")"
 				],
-				"execution_count": 30
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -141,7 +141,7 @@
 					"for column_name in timestamp_columns:\n",
 					"    final_view_df = final_view_df.withColumn(column_name, F.to_timestamp(F.from_utc_timestamp(F.col(column_name), 'Europe/London'), \"yyyy-MM-dd'T'HH:mm:ss.SSS\"))"
 				],
-				"execution_count": 31
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -162,7 +162,7 @@
 					"    .option(\"path\", table_path) \\\n",
 					"    .saveAsTable(table_name)"
 				],
-				"execution_count": 32
+				"execution_count": null
 			}
 		]
 	}


### PR DESCRIPTION
[https://pins-ds.atlassian.net/browse/THEODW-3049](url)

Updated timestamp handling to convert UTC timestamps to Europe/London time, including Daylight Saving Time (DST).
Applied the UTC‑to‑London conversion consistently across all relevant timestamp fields:
eventStartDateTime
eventEndDateTime
IngestionDate
ValidTo
Ensured all converted columns are stored as proper timestamp types.
Updated the write logic to overwrite data in the existing curated table location instead of dropping and recreating the table.
Retrieved the table’s physical storage path dynamically using DESCRIBE EXTENDED and wrote the data back to the same location using overwrite mode.
This maintains table metadata while safely refreshing the curated data with the updated timestamp logic.
![Uploading after change.png…]()
<img width="961" height="505" alt="image" src="https://github.com/user-attachments/assets/ec3fcc8c-d4a4-4a23-aa9b-ee52728a8430" />

