### PR TITLE
Reducing pytest parallelism + optimising Spark test config

### DIFF
--- a/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
+++ b/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
@@ -111,10 +111,15 @@ def test__service_bus_standardisation__process_applies_anonymisation_in_non_prod
     assert kwargs["source_folder"] == "ServiceBus"
 
     written_df = data_to_write["odw_standardised_db.sb_service_user"]["data"]
-    rows = written_df.select("full_name", "emailAddress").collect()
+    rows = {
+        (row["full_name"], row["emailAddress"])
+        for row in written_df.select("full_name", "emailAddress").collect()
+    }
 
-    assert rows[0]["full_name"] == "J*** **e"
-    assert rows[0]["emailAddress"] == "j******e@example.com"
+    assert rows == {
+        ("J*** **e", "j******e@example.com"),
+        ("J*** ****h", "j********h@example.com"),
+    }
     assert etl_result.metadata.table_name == "sb_service_user"
 
 
@@ -149,10 +154,15 @@ def test__service_bus_standardisation__process_skips_anonymisation_in_production
     mock_apply.assert_not_called()
 
     written_df = data_to_write["odw_standardised_db.sb_service_user"]["data"]
-    rows = written_df.select("full_name", "emailAddress").collect()
+    rows = {
+        (row["full_name"], row["emailAddress"])
+        for row in written_df.select("full_name", "emailAddress").collect()
+    }
 
-    assert rows[0]["full_name"] == "John Doe"
-    assert rows[0]["emailAddress"] == "john.doe@example.com"
+    assert rows == {
+        ("John Doe", "john.doe@example.com"),
+        ("Jane Smith", "jane.smith@example.com"),
+    }
     assert etl_result.metadata.table_name == "sb_service_user"
 
 

--- a/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
+++ b/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
@@ -111,10 +111,7 @@ def test__service_bus_standardisation__process_applies_anonymisation_in_non_prod
     assert kwargs["source_folder"] == "ServiceBus"
 
     written_df = data_to_write["odw_standardised_db.sb_service_user"]["data"]
-    rows = {
-        (row["full_name"], row["emailAddress"])
-        for row in written_df.select("full_name", "emailAddress").collect()
-    }
+    rows = {(row["full_name"], row["emailAddress"]) for row in written_df.select("full_name", "emailAddress").collect()}
 
     assert rows == {
         ("J*** **e", "j******e@example.com"),
@@ -154,10 +151,7 @@ def test__service_bus_standardisation__process_skips_anonymisation_in_production
     mock_apply.assert_not_called()
 
     written_df = data_to_write["odw_standardised_db.sb_service_user"]["data"]
-    rows = {
-        (row["full_name"], row["emailAddress"])
-        for row in written_df.select("full_name", "emailAddress").collect()
-    }
+    rows = {(row["full_name"], row["emailAddress"]) for row in written_df.select("full_name", "emailAddress").collect()}
 
     assert rows == {
         ("John Doe", "john.doe@example.com"),

--- a/odw/test/util/session_util.py
+++ b/odw/test/util/session_util.py
@@ -10,33 +10,43 @@ import shutil
 
 class PytestSparkSessionUtil(metaclass=Singleton):
     """
-    Class to manage the testing session itself. This initiallises a single spark context per worker thread,
-    alongside a separate DB/filesystem per thread. This class is a singleton, so only one instance can ever
-    be created
+    Class to manage the testing session itself. This initialises a single Spark session per
+    worker thread, alongside a separate DB/filesystem per thread. This class is a singleton,
+    so only one instance can ever be created.
 
-    # Usage
-    - `PytestSessionUtil().get_spark_session()`
-    - `PytestSessionUtil().get_thread_id()`
-    - `PytestSessionUtil().get_spark_warehouse_name()`
+    Usage
+    - `PytestSparkSessionUtil().get_spark_session()`
+    - `PytestSparkSessionUtil().get_thread_id()`
+    - `PytestSparkSessionUtil().get_spark_warehouse_name()`
     """
 
     DATABASE_NAMES = ["odw_standardised_db", "odw_harmonised_db", "odw_curated_db"]
 
     def __init__(self, *args, **kwargs):
         self._THREAD_ID = str(uuid4())[:8]
-        self._SPARK_SESSION = configure_spark_with_delta_pip(
-            SparkSession.builder.config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        self._WAREHOUSE_DIR = os.path.abspath(f"spark-warehouse-{self.get_thread_id()}")
+
+        builder = (
+            SparkSession.builder.master("local[1]")
+            .appName(f"pytest-spark-{self.get_thread_id()}")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             .config("spark.sql.warehouse.dir", self.get_spark_warehouse_name())
             .config("spark.ui.enabled", False)
-        ).getOrCreate()
+            .config("spark.driver.memory", "1g")
+            .config("spark.sql.shuffle.partitions", "4")
+            .config("spark.default.parallelism", "2")
+            .config("spark.sql.adaptive.enabled", "false")
+        )
+
+        self._SPARK_SESSION = configure_spark_with_delta_pip(builder).getOrCreate()
         self._initialise_file_system(self._SPARK_SESSION)
 
     def get_thread_id(self):
         return self._THREAD_ID
 
     def get_spark_warehouse_name(self):
-        return f"spark-warehouse-{self.get_thread_id()}"
+        return self._WAREHOUSE_DIR
 
     def get_spark_session(self):
         return self._SPARK_SESSION
@@ -52,15 +62,23 @@ class PytestSparkSessionUtil(metaclass=Singleton):
         for file_system in file_systems:
             shutil.rmtree(file_system, ignore_errors=True)
 
+    def stop_spark_session(self):
+        if getattr(self, "_SPARK_SESSION", None) is not None:
+            try:
+                self._SPARK_SESSION.stop()
+            except Exception:
+                pass
+
     def _create_empty_orchestration_file(self):
         orchestration_path = os.path.join(self.get_spark_warehouse_name(), "odw-config", "orchestration")
         os.makedirs(orchestration_path, exist_ok=True)
-        with open(os.path.join(self.get_spark_warehouse_name(), "odw-config", "orchestration", "orchestration.json"), "w") as f:
+        with open(os.path.join(orchestration_path, "orchestration.json"), "w") as f:
             content = {"definitions": []}
             json.dump(content, f, indent=4)
 
     def _create_main_source_system_fact_table(self, spark: SparkSession):
         shutil.rmtree(os.path.join(self.get_spark_warehouse_name(), "odw_harmonised_db.db", "main_sourcesystem_fact"), ignore_errors=True)
+
         data = spark.createDataFrame(
             (("1", "Casework", "", None, "", "Y"),),
             T.StructType(
@@ -74,10 +92,11 @@ class PytestSparkSessionUtil(metaclass=Singleton):
                 ]
             ),
         )
+
         database_name = "odw_harmonised_db"
         table_name = "main_sourcesystem_fact"
-        spark.sql(f"DROP TABLE IF EXISTS {database_name}.{table_name}")
-        write_mode = "overwrite"
         table_path = f"{database_name}.{table_name}"
-        writer = data.write.format("parquet").mode(write_mode)
-        writer.saveAsTable(table_path)
+
+        spark.sql(f"DROP TABLE IF EXISTS {table_path}")
+
+        data.write.format("parquet").mode("overwrite").saveAsTable(table_path)

--- a/odw/test/util/session_util.py
+++ b/odw/test/util/session_util.py
@@ -12,9 +12,9 @@ class PytestSparkSessionUtil(metaclass=Singleton):
     """
     Class to manage the testing session itself. This initialises a single Spark session per
     worker thread, alongside a separate DB/filesystem per thread. This class is a singleton,
-    so only one instance can ever be created.
+    so only one instance can ever be created
 
-    Usage
+    # Usage
     - `PytestSparkSessionUtil().get_spark_session()`
     - `PytestSparkSessionUtil().get_thread_id()`
     - `PytestSparkSessionUtil().get_spark_warehouse_name()`

--- a/pipelines/jobs/run-odw-package-integrationtests.yaml
+++ b/pipelines/jobs/run-odw-package-integrationtests.yaml
@@ -24,5 +24,5 @@ jobs:
       export CREDENTIAL_NAME="${{ format('https://dev.azuresynapse.net/.default', lower(parameters.env)) }}"
       echo $SYNAPSE_ENDPOINT 
       echo $CREDENTIAL_NAME
-      python3 -m pytest $(Build.SourcesDirectory)/odw/test/integration_test -vv -rP -n 4
+      python3 -m pytest $(Build.SourcesDirectory)/odw/test/integration_test -vv -rP -n 1
     displayName: 'pytest'

--- a/pipelines/jobs/run-odw-package-unittests.yaml
+++ b/pipelines/jobs/run-odw-package-unittests.yaml
@@ -25,5 +25,5 @@ jobs:
       export PYSPARK_SUBMIT_ARGS="--conf spark.ui.showConsoleProgress=false --conf spark.sql.shuffle.partitions=4 pyspark-shell"
       echo $SYNAPSE_ENDPOINT 
       echo $CREDENTIAL_NAME
-      python3 -m pytest $(Build.SourcesDirectory)/odw/test/unit_test -vv -rP -n 2 --dist loadscope --maxfail=1
+      python3 -m pytest $(Build.SourcesDirectory)/odw/test/unit_test -vv -rP -n 2 --dist loadscope
     displayName: 'pytest'

--- a/pipelines/jobs/run-odw-package-unittests.yaml
+++ b/pipelines/jobs/run-odw-package-unittests.yaml
@@ -22,7 +22,8 @@ jobs:
       sudo curl -fsSL https://aka.ms/install-azd.sh | bash
       export SYNAPSE_ENDPOINT="${{ format('https://pins-synw-odw-{0}-uks.dev.azuresynapse.net/', lower(parameters.env)) }}"
       export CREDENTIAL_NAME="${{ format('https://dev.azuresynapse.net/.default', lower(parameters.env)) }}"
+      export PYSPARK_SUBMIT_ARGS="--conf spark.ui.showConsoleProgress=false --conf spark.sql.shuffle.partitions=4 pyspark-shell"
       echo $SYNAPSE_ENDPOINT 
       echo $CREDENTIAL_NAME
-      python3 -m pytest $(Build.SourcesDirectory)/odw/test/unit_test -vv -rP -n 4
+      python3 -m pytest $(Build.SourcesDirectory)/odw/test/unit_test -vv -rP -n 2 --dist loadscope --maxfail=1
     displayName: 'pytest'


### PR DESCRIPTION
[THEODW-3044](https://pins-ds.atlassian.net/browse/THEODW-3044)
What this PR does : 

- Reduce unit test parallelism from -n 4 to -n 2
- Run integration tests with -n 1 to avoid multiple concurrent Spark sessions
- Add --dist loadscope and --maxfail=1 to improve test execution behaviour
- Tune PySpark test configuration to reduce memory pressure and shuffle overhead
- Optimise test Spark session setup in session_util.py

[THEODW-3044]: https://pins-ds.atlassian.net/browse/THEODW-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ