### PR TITLE
Improvement for memory issue

### DIFF
--- a/odw/core/etl/transformation/harmonised/service_bus_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/service_bus_harmonisation_process.py
@@ -165,7 +165,6 @@ class ServiceBusHarmonisationProcess(HarmonisationProcess):
         new_data = new_data.filter(F.col("row_state_metadata") != "delete").drop("row_state_metadata")
         new_data = new_data.union(update_rows).union(unupdated_rows).dropDuplicates()
 
-        new_data = new_data.cache()
         insert_count = new_data.count()
 
         hrm_table_snake_case = hrm_table.replace("-", "_")

--- a/odw/test/unit_test/util/test_table_util.py
+++ b/odw/test/unit_test/util/test_table_util.py
@@ -3,8 +3,7 @@ from odw.core.util.logging_util import LoggingUtil
 from odw.core.util.table_util import TableUtil
 from odw.test.util.test_case import SparkTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-from pyspark.sql import SparkSession
-from pyspark.sql import Catalog
+from pyspark.sql import Catalog, SparkSession
 import pytest
 import mock
 from datetime import datetime
@@ -59,7 +58,7 @@ class TestTableUtil(SparkTestCase):
         )
 
     def test_delete_table__successful(self):
-        spark = SparkSession.builder.getOrCreate()
+        spark = PytestSparkSessionUtil().get_spark_session()
         db_name = "some_db"
         table_name = "some_table"
         storage_name = "somestorageaccount"
@@ -78,7 +77,7 @@ class TestTableUtil(SparkTestCase):
                                 notebookutils.mssparkutils.fs.rm.assert_called_once_with(table_location, True)
 
     def test_delete_table__table_does_not_exist(self):
-        spark = SparkSession.builder.getOrCreate()
+        spark = PytestSparkSessionUtil().get_spark_session()
         db_name = "some_db"
         table_name = "some_table"
         with mock.patch.object(Catalog, "tableExists", return_value=False):
@@ -92,7 +91,7 @@ class TestTableUtil(SparkTestCase):
                             assert not notebookutils.mssparkutils.fs.rm.called
 
     def test_delete_table__multiple_occurrences(self):
-        spark = SparkSession.builder.getOrCreate()
+        spark = PytestSparkSessionUtil().get_spark_session()
         db_name = "some_db"
         table_name = "some_table"
         storage_name = "somestorageaccount"
@@ -116,7 +115,7 @@ class TestTableUtil(SparkTestCase):
                                     assert not notebookutils.mssparkutils.fs.rm.called
 
     def test_delete_table_contents__successful(self):
-        spark = SparkSession.builder.getOrCreate()
+        spark = PytestSparkSessionUtil().get_spark_session()
         db_name = "some_db"
         table_name = "some_table"
         storage_name = "somestorageaccount"
@@ -134,7 +133,7 @@ class TestTableUtil(SparkTestCase):
                                 assert not notebookutils.mssparkutils.fs.rm.called
 
     def test_delete_table_contents__table_does_not_exist(self):
-        spark = SparkSession.builder.getOrCreate()
+        spark = PytestSparkSessionUtil().get_spark_session()
         db_name = "some_db"
         table_name = "some_table"
         with mock.patch.object(Catalog, "tableExists", return_value=False):
@@ -146,7 +145,7 @@ class TestTableUtil(SparkTestCase):
                         LoggingUtil.log_info.assert_has_calls([mock.call(f"Table {db_name}.{table_name} does not exist")], any_order=True)
 
     def test_delete_table_contents__multiple_occurrences(self):
-        spark = SparkSession.builder.getOrCreate()
+        spark = PytestSparkSessionUtil().get_spark_session()
         db_name = "some_db"
         table_name = "some_table"
         storage_name = "somestorageaccount"

--- a/odw/test/util/assertion.py
+++ b/odw/test/util/assertion.py
@@ -28,30 +28,39 @@ def assert_dataframes_equal(expected: DataFrame, actual: DataFrame):
     rows_to_show = 20
     # There seems to be a bug that occasionally appears in spark 3.4 that causes a crash when using exceptAll
     # The workaround is to cache before running that command
-    expected.cache()
-    actual.cache()
-    # Update column order, since column order maters when comparing the data
-    # At this stage both data frames are guaranteed to have the same schema
-    expected = expected.select(expected.schema.names)
-    actual = actual.select(expected.schema.names)
-    in_expected_but_not_actual = expected.exceptAll(actual)
-    in_actual_but_not_expected = actual.exceptAll(expected)
-    data_mismatch = not (in_expected_but_not_actual.isEmpty() and in_actual_but_not_expected.isEmpty())
-    if data_mismatch:
-        missing_data_sample = in_expected_but_not_actual._jdf.showString(rows_to_show, 20, False)
-        unexpected_data_sample = in_actual_but_not_expected._jdf.showString(rows_to_show, 20, False)
-        exception_message = (
-            "Data mismatch between expected and actual dataframe\n"
-            "In expected dataframe but not the actual dataframe\n"
-            f"{missing_data_sample}"
-            "\nIn actual dataframe but not the expected dataframe\n"
-            f"{unexpected_data_sample}"
-            "\nExpected dataframe\n"
-            f"{expected._jdf.showString(rows_to_show, 20, False)}"
-            "\nActual dataframe\n"
-            f"{actual._jdf.showString(rows_to_show, 20, False)}"
-        )
-    assert not data_mismatch, exception_message
+    expected_cached = expected.cache()
+    actual_cached = actual.cache()
+
+    try:
+        # Update column order, since column order matters when comparing the data.
+        # At this stage both dataframes are guaranteed to have the same schema.
+        expected_ordered = expected_cached.select(expected_cached.schema.names)
+        actual_ordered = actual_cached.select(expected_cached.schema.names)
+
+        in_expected_but_not_actual = expected_ordered.exceptAll(actual_ordered)
+        in_actual_but_not_expected = actual_ordered.exceptAll(expected_ordered)
+
+        data_mismatch = not (in_expected_but_not_actual.isEmpty() and in_actual_but_not_expected.isEmpty())
+
+        if data_mismatch:
+            missing_data_sample = in_expected_but_not_actual._jdf.showString(rows_to_show, 20, False)
+            unexpected_data_sample = in_actual_but_not_expected._jdf.showString(rows_to_show, 20, False)
+            exception_message = (
+                "Data mismatch between expected and actual dataframe\n"
+                "In expected dataframe but not the actual dataframe\n"
+                f"{missing_data_sample}"
+                "\nIn actual dataframe but not the expected dataframe\n"
+                f"{unexpected_data_sample}"
+                "\nExpected dataframe\n"
+                f"{expected_ordered._jdf.showString(rows_to_show, 20, False)}"
+                "\nActual dataframe\n"
+                f"{actual_ordered._jdf.showString(rows_to_show, 20, False)}"
+            )
+
+        assert not data_mismatch, exception_message
+    finally:
+        expected_cached.unpersist(blocking=True)
+        actual_cached.unpersist(blocking=True)
 
 
 def assert_etl_result_successful(etl_result: ETLResult):

--- a/odw/test/util/test_case.py
+++ b/odw/test/util/test_case.py
@@ -1,4 +1,5 @@
 from odw.test.util.session_util import PytestSparkSessionUtil
+import gc
 import pytest
 
 
@@ -47,3 +48,4 @@ class SparkTestCase(TestCase):
         # Clear the spark cache to free up some memory
         spark = PytestSparkSessionUtil().get_spark_session()
         spark.catalog.clearCache()
+        gc.collect()


### PR DESCRIPTION
[THEODW-3044](https://pins-ds.atlassian.net/browse/THEODW-3044)
Changes
- Fixed DF caching in assertion.py by properly unpersisting cached DF
- Removed unnecessary .cache() in ServiceBusHarmonisationProcess
- Improved Spark cleanup in tests (clearCache + gc.collect())
- Standardised Spark session usage via PytestSparkSessionUtil

[THEODW-3044]: https://pins-ds.atlassian.net/browse/THEODW-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ