### PR TITLE
2919-Restructure_Appeal_Attribute_Matrix_Notebooks

### DIFF
--- a/odw/core/etl/etl_process_factory.py
+++ b/odw/core/etl/etl_process_factory.py
@@ -1,6 +1,6 @@
 from odw.core.etl.etl_process import ETLProcess
-from odw.core.exceptions import DuplicateETLProcessNameException, ETLProcessNameNotFoundException
 from odw.core.etl.transformation.standardised.standardisation_process import StandardisationProcess
+from odw.core.exceptions import DuplicateETLProcessNameException, ETLProcessNameNotFoundException
 from odw.core.etl.transformation.standardised.service_bus_standardisation_process import ServiceBusStandardisationProcess
 from odw.core.etl.transformation.standardised.horizon_standardisation_process import HorizonStandardisationProcess
 from odw.core.etl.transformation.harmonised.service_bus_harmonisation_process import ServiceBusHarmonisationProcess
@@ -15,14 +15,20 @@ from odw.core.etl.transformation.curated.nsip_exam_timetable_curated_process imp
 from odw.core.etl.transformation.curated.nsip_representation_curated_process import NsipRepresentationCuratedProcess
 from odw.core.etl.transformation.curated.nsip_s51_advice_curated_process import NsipS51AdviceCuratedProcess
 from odw.core.etl.transformation.curated.nsip_meeting_curated_process import NsipMeetingCuratedProcess
+from odw.core.etl.transformation.standardised.appeal_attribute_matrix_standardisation_process import AppealAttributeMatrixStandardisationProcess
+from odw.core.etl.transformation.harmonised.appeal_attribute_matrix_harmonisation_process import AppealAttributeMatrixHarmonisationProcess
+from odw.core.etl.transformation.curated.appeal_attribute_matrix_curated_process import AppealAttributeMatrixCuratedProcess
 from typing import Dict, List, Set, Type
 import json
 
 
 class ETLProcessFactory:
     ETL_PROCESSES: Set[Type[ETLProcess]] = {
-        StandardisationProcess,
         ServiceBusStandardisationProcess,
+        StandardisationProcess,
+        AppealAttributeMatrixStandardisationProcess,
+        AppealAttributeMatrixHarmonisationProcess,
+        AppealAttributeMatrixCuratedProcess,
         HorizonStandardisationProcess,
         ServiceBusHarmonisationProcess,
         NsipDocumentHarmonisationProcess,

--- a/odw/core/etl/transformation/curated/appeal_attribute_matrix_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_attribute_matrix_curated_process.py
@@ -1,19 +1,93 @@
+from typing import Dict, Tuple
+from datetime import datetime
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
 from odw.core.etl.transformation.curated.curation_process import CurationProcess
-from typing import Any
-
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
+from odw.core.util.util import Util
+from odw.core.util.logging_util import LoggingUtil
 
 class AppealAttributeMatrixCuratedProcess(CurationProcess):
-    OUTPUT_TABLE = "ref_appeal_attribute_matrix"
+    STANDARDISED_TABLE = "odw_standardised_db.appeal_attribute_matrix"
+    HARMONISED_TABLE = "odw_harmonised_db.ref_appeal_attribute_matrix"
+    OUTPUT_TABLE = "odw_curated_db.ref_appeal_attribute_matrix"
 
-    def __init__(self, spark):
-        super().__init__(spark)
-        self.spark = spark
+    def __init__(self, spark: SparkSession, debug: bool = False):
+        super().__init__(spark, debug)
 
-    def get_name(self) -> str:
+    @classmethod
+    def get_name(cls) -> str:
         return "appeal_attribute_matrix_curated_process"
 
-    def load_data(self) -> dict[str, Any]:
-        raise NotImplementedError("AppealAttributeMatrixCuratedProcess.load_data() has not been implemented yet.")
+    def load_data(self, **kwargs) -> Dict[str, DataFrame]:
+        LoggingUtil().log_info("Loading harmonised and standardised Appeal Attribute Matrix data")
 
-    def process(self, source_data: dict[str, Any]):
-        raise NotImplementedError("AppealAttributeMatrixCuratedProcess.process() has not been implemented yet.")
+        harmonised_df = self.spark.table(self.HARMONISED_TABLE)
+        standardised_df = self.spark.table(self.STANDARDISED_TABLE)
+
+        return {"harmonised_data": harmonised_df, "standardised_schema": standardised_df}
+
+    def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
+        start_exec_time = datetime.now()
+
+        source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
+        df_h: DataFrame = source_data["harmonised_data"]
+        df_std: DataFrame = source_data["standardised_schema"]
+
+        std_cols = df_std.columns
+
+        if "IsActive" in df_h.columns:
+            df = df_h.filter(F.col("IsActive") == "Y")
+
+        elif {"TEMP_PK", "IngestionDate"}.issubset(set(df_h.columns)):
+            latest = df_h.groupBy("TEMP_PK").agg(F.max("IngestionDate").alias("IngestionDate"))
+            df = df_h.join(latest, on=["TEMP_PK", "IngestionDate"], how="inner")
+
+        else:
+            df = df_h
+
+        for c in std_cols:
+            if c not in df.columns:
+                df = df.withColumn(c, F.lit(None).cast("string"))
+
+        extras = [c for c in df.columns if c not in std_cols]
+        ordered_cols = std_cols + extras
+        df = df.select(*[F.col(c) for c in ordered_cols])
+
+        if "s78" in df.columns:
+            df = df.withColumn("s78", F.col("s78").cast(T.StringType()))
+
+        insert_count = df.count()
+
+        LoggingUtil().log_info(f"Curated Appeal Attribute Matrix row count: {insert_count}")
+
+        end_exec_time = datetime.now()
+
+        data_to_write = {
+            self.OUTPUT_TABLE: {
+                "data": df,
+                "storage_kind": "ADLSG2-Table",
+                "database_name": "odw_curated_db",
+                "table_name": "ref_appeal_attribute_matrix",
+                "storage_endpoint": Util.get_storage_account(),
+                "container_name": "odw-curated",
+                "blob_path": "AppealAttributeMatrix/appeal_attribute_matrix",
+                "file_format": "delta",
+                "write_mode": "overwrite",
+                "write_options": {"overwriteSchema": "true"},
+            }
+        }
+
+        return data_to_write, ETLSuccessResult(
+            metadata=ETLResult.ETLResultMetadata(
+                start_execution_time=start_exec_time,
+                end_execution_time=end_exec_time,
+                table_name=self.OUTPUT_TABLE,
+                insert_count=insert_count,
+                update_count=0,
+                delete_count=0,
+                activity_type=self.get_name(),
+                duration_seconds=(end_exec_time - start_exec_time).total_seconds(),
+            )
+        )

--- a/odw/core/etl/transformation/curated/appeal_attribute_matrix_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_attribute_matrix_curated_process.py
@@ -8,6 +8,7 @@ from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
 from odw.core.util.util import Util
 from odw.core.util.logging_util import LoggingUtil
 
+
 class AppealAttributeMatrixCuratedProcess(CurationProcess):
     STANDARDISED_TABLE = "odw_standardised_db.appeal_attribute_matrix"
     HARMONISED_TABLE = "odw_harmonised_db.ref_appeal_attribute_matrix"

--- a/odw/core/etl/transformation/harmonised/appeal_attribute_matrix_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/appeal_attribute_matrix_harmonisation_process.py
@@ -1,19 +1,88 @@
 from odw.core.etl.transformation.harmonised.harmonsation_process import HarmonisationProcess
-from typing import Any
-
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
+from odw.core.util.util import Util
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+from datetime import datetime
+from typing import Dict
 
 class AppealAttributeMatrixHarmonisationProcess(HarmonisationProcess):
     OUTPUT_TABLE = "ref_appeal_attribute_matrix"
 
-    def __init__(self, spark):
-        super().__init__(spark)
-        self.spark = spark
+    def __init__(self, spark, debug: bool = False):
+        super().__init__(spark, debug)
 
-    def get_name(self) -> str:
+    @classmethod
+    def get_name(cls) -> str:
         return "appeal_attribute_matrix_harmonisation_process"
 
-    def load_data(self) -> dict[str, Any]:
-        raise NotImplementedError("AppealAttributeMatrixHarmonisationProcess.load_data() has not been implemented yet.")
+    def load_data(self, **kwargs) -> Dict[str, DataFrame]:
+        df = self.spark.table("odw_standardised_db.appeal_attribute_matrix")
+        return {"standardised_data": df}
 
-    def process(self, source_data: dict[str, Any]):
-        raise NotImplementedError("AppealAttributeMatrixHarmonisationProcess.process() has not been implemented yet.")
+    def process(self, **kwargs):
+        start_exec_time = datetime.now()
+
+        source_data = self.load_parameter("source_data", kwargs)
+        df: DataFrame = self.load_parameter("standardised_data", source_data)
+
+        std_cols = df.columns[:]
+
+        for f in df.schema.fields:
+            if isinstance(f.dataType, T.StringType):
+                df = df.withColumn(f.name, F.trim(F.col(f.name)))
+
+        df = df.withColumn("attribute", F.trim(F.lower(F.col("attribute"))))
+
+        df = df.withColumn("TEMP_PK", F.sha2(F.to_json(F.struct(F.col("attribute"))), 256))
+
+        if "ODTSourceSystem" not in df.columns:
+            df = df.withColumn("ODTSourceSystem", F.lit("AppealAttributeMatrix"))
+
+        if "IngestionDate" in df.columns:
+            df = df.withColumn("IngestionDate", F.to_timestamp("IngestionDate"))
+        else:
+            df = df.withColumn("IngestionDate", F.current_timestamp())
+
+        if "IsActive" not in df.columns:
+            df = df.withColumn("IsActive", F.lit("Y"))
+
+        extras = ["TEMP_PK", "ODTSourceSystem", "IngestionDate", "IsActive"]
+        ordered_cols = [c for c in std_cols if c in df.columns] + extras
+        df = df.select(*ordered_cols)
+
+        if "s78" in df.columns:
+            df = df.withColumn("s78", F.col("s78").cast("string"))
+
+        data_to_write = {
+            self.OUTPUT_TABLE: {
+                "data": df,
+                "storage_kind": "ADLSG2-Table",
+                "database_name": "odw_harmonised_db",
+                "table_name": "ref_appeal_attribute_matrix",
+                "storage_endpoint": Util.get_storage_account(),
+                "container_name": "odw-harmonised",
+                "blob_path": "ref_appeal_attribute_matrix",
+                "file_format": "delta",
+                "write_mode": "overwrite",
+                "write_options": {"overwriteSchema": "true"},
+            }
+        }
+
+        end_exec_time = datetime.now()
+
+        result = ETLSuccessResult(
+            metadata=ETLResult.ETLResultMetadata(
+                start_execution_time=start_exec_time,
+                end_execution_time=end_exec_time,
+                table_name=self.OUTPUT_TABLE,
+                insert_count=df.count(),
+                update_count=0,
+                delete_count=0,
+                activity_type=self.get_name(),
+                duration_seconds=(end_exec_time - start_exec_time).total_seconds(),
+            )
+        )
+
+        return data_to_write, result

--- a/odw/core/etl/transformation/harmonised/appeal_attribute_matrix_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/appeal_attribute_matrix_harmonisation_process.py
@@ -7,6 +7,7 @@ from pyspark.sql import types as T
 from datetime import datetime
 from typing import Dict
 
+
 class AppealAttributeMatrixHarmonisationProcess(HarmonisationProcess):
     OUTPUT_TABLE = "ref_appeal_attribute_matrix"
 

--- a/odw/core/etl/transformation/standardised/appeal_attribute_matrix_standardisation_process.py
+++ b/odw/core/etl/transformation/standardised/appeal_attribute_matrix_standardisation_process.py
@@ -1,19 +1,108 @@
 from odw.core.etl.transformation.standardised.standardisation_process import StandardisationProcess
-from typing import Any
-
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
+from odw.core.util.util import Util
+from notebookutils import mssparkutils
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import col
+from datetime import datetime
+from typing import Dict
+import re
 
 class AppealAttributeMatrixStandardisationProcess(StandardisationProcess):
     OUTPUT_TABLE = "appeal_attribute_matrix"
 
-    def __init__(self, spark):
-        super().__init__(spark)
-        self.spark = spark
+    def __init__(self, spark, debug: bool = False):
+        super().__init__(spark, debug)
 
-    def get_name(self) -> str:
+    @classmethod
+    def get_name(cls) -> str:
         return "appeal_attribute_matrix_standardisation_process"
 
-    def load_data(self) -> dict[str, Any]:
-        raise NotImplementedError("AppealAttributeMatrixStandardisationProcess.load_data() has not been implemented yet.")
+    def load_data(self, **kwargs) -> Dict[str, DataFrame]:
+        storage_account = mssparkutils.notebook.run("/utils/py_utils_get_storage_account")
 
-    def process(self, source_data: dict[str, Any]):
-        raise NotImplementedError("AppealAttributeMatrixStandardisationProcess.process() has not been implemented yet.")
+        base_dir = f"abfss://odw-raw@{storage_account}AppealAttributeMatrix/"
+        entries = mssparkutils.fs.ls(base_dir)
+
+        date_dirs = [
+            e.name.strip("/").split("/")[-1]
+            for e in entries
+            if re.fullmatch(
+                r"\d{4}-\d{2}-\d{2}",
+                e.name.strip("/").split("/")[-1],
+            )
+        ]
+
+        if not date_dirs:
+            raise FileNotFoundError(f"No YYYY-MM-DD folders found under {base_dir}")
+
+        ingestion_date = max(date_dirs)
+
+        file_path = f"{base_dir}{ingestion_date}/appeal-attribute-matrix.csv"
+
+        raw_df = (
+            self.spark.read.option("header", True)
+            .option("inferSchema", True)
+            .option("ignoreLeadingWhiteSpace", True)
+            .option("ignoreTrailingWhiteSpace", True)
+            .option("columnNameOfCorruptRecord", "_corrupt_record")
+            .csv(file_path)
+        )
+
+        return {"raw_data": raw_df}
+
+    def process(self, **kwargs):
+        start_exec_time = datetime.now()
+
+        source_data = self.load_parameter("source_data", kwargs)
+        raw_df: DataFrame = self.load_parameter("raw_data", source_data)
+
+        valid_columns = [
+            field.name for field in raw_df.schema.fields if field.name and field.name.strip() != "" and not field.name.strip().startswith("_c")
+        ]
+
+        df = raw_df.select(*valid_columns)
+
+        df = df.filter(~(col("attribute").isNull() | col("attribute").rlike(r'^\s*["\']?\s*$')))
+
+        def to_camel_case(colname: str) -> str:
+            parts = re.split(r"\s+", colname.strip())
+            return parts[0].lower() + "".join(p.capitalize() for p in parts[1:])
+
+        for colname in df.columns:
+            df = df.withColumnRenamed(colname, to_camel_case(colname))
+
+        if "s78" in df.columns:
+            df = df.withColumn("s78", col("s78").cast("string"))
+
+        data_to_write = {
+            self.OUTPUT_TABLE: {
+                "data": df,
+                "storage_kind": "ADLSG2-Table",
+                "database_name": "odw_standardised_db",
+                "table_name": "appeal_attribute_matrix",
+                "storage_endpoint": Util.get_storage_account(),
+                "container_name": "odw-standardised",
+                "blob_path": "appeal_attribute_matrix",
+                "file_format": "delta",
+                "write_mode": "overwrite",
+                "write_options": {"overwriteSchema": "true"},
+            }
+        }
+
+        end_exec_time = datetime.now()
+
+        result = ETLSuccessResult(
+            metadata=ETLResult.ETLResultMetadata(
+                start_execution_time=start_exec_time,
+                end_execution_time=end_exec_time,
+                table_name=self.OUTPUT_TABLE,
+                insert_count=df.count(),
+                update_count=0,
+                delete_count=0,
+                activity_type=self.get_name(),
+                duration_seconds=(end_exec_time - start_exec_time).total_seconds(),
+            )
+        )
+
+        return data_to_write, result

--- a/odw/core/etl/transformation/standardised/appeal_attribute_matrix_standardisation_process.py
+++ b/odw/core/etl/transformation/standardised/appeal_attribute_matrix_standardisation_process.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Dict
 import re
 
+
 class AppealAttributeMatrixStandardisationProcess(StandardisationProcess):
     OUTPUT_TABLE = "appeal_attribute_matrix"
 

--- a/odw/test/integration_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
+++ b/odw/test/integration_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
@@ -4,6 +4,7 @@ from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
 from unittest import mock
 
+
 class TestRefAppealAttributeMatrixCurationProcess(ETLTestCase):
     def test__appeal_attribute_matrix_curated_process__run__filters_active_and_matches_legacy(self):
         spark = PytestSparkSessionUtil().get_spark_session()

--- a/odw/test/integration_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
+++ b/odw/test/integration_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
@@ -1,12 +1,8 @@
-import pytest
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.curated.appeal_attribute_matrix_curated_process import AppealAttributeMatrixCuratedProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-import mock
-
-pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
-
+from unittest import mock
 
 class TestRefAppealAttributeMatrixCurationProcess(ETLTestCase):
     def test__appeal_attribute_matrix_curated_process__run__filters_active_and_matches_legacy(self):

--- a/odw/test/integration_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
+++ b/odw/test/integration_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
@@ -5,6 +5,7 @@ from odw.test.util.session_util import PytestSparkSessionUtil
 from unittest import mock
 from pyspark.sql import functions as F
 
+
 class TestRefAppealAttributeMatrixHarmonisationProcess(ETLTestCase):
     def test__appeal_attribute_matrix_harmonisation_process__run__end_to_end_matches_legacy(self):
         spark = PytestSparkSessionUtil().get_spark_session()

--- a/odw/test/integration_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
+++ b/odw/test/integration_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
@@ -1,13 +1,9 @@
-import pytest
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.harmonised.appeal_attribute_matrix_harmonisation_process import AppealAttributeMatrixHarmonisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-import mock
+from unittest import mock
 from pyspark.sql import functions as F
-
-pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
-
 
 class TestRefAppealAttributeMatrixHarmonisationProcess(ETLTestCase):
     def test__appeal_attribute_matrix_harmonisation_process__run__end_to_end_matches_legacy(self):

--- a/odw/test/integration_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
+++ b/odw/test/integration_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
@@ -5,6 +5,7 @@ from odw.test.util.session_util import PytestSparkSessionUtil
 from unittest import mock
 import pyspark.sql.types as T
 
+
 class TestRefAppealAttributeMatrixStandardisationProcess(ETLTestCase):
     def test__appeal_attribute_matrix_standardisation_process__run__standardises_end_to_end_and_matches_legacy(self):
         spark = PytestSparkSessionUtil().get_spark_session()

--- a/odw/test/integration_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
+++ b/odw/test/integration_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
@@ -1,13 +1,9 @@
-import pytest
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.standardised.appeal_attribute_matrix_standardisation_process import AppealAttributeMatrixStandardisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-import mock
+from unittest import mock
 import pyspark.sql.types as T
-
-pytestmark = pytest.mark.xfail(reason="Standardisation logic not implemented yet")
-
 
 class TestRefAppealAttributeMatrixStandardisationProcess(ETLTestCase):
     def test__appeal_attribute_matrix_standardisation_process__run__standardises_end_to_end_and_matches_legacy(self):

--- a/odw/test/unit_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
+++ b/odw/test/unit_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
@@ -3,6 +3,7 @@ from odw.test.util.test_case import SparkTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
 from unittest import mock
 
+
 class TestRefAppealAttributeMatrixCurationProcess(SparkTestCase):
     def test__appeal_attribute_matrix_curated_process__process__filters_only_active_records_when_isactive_present(self):
         spark = PytestSparkSessionUtil().get_spark_session()

--- a/odw/test/unit_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
+++ b/odw/test/unit_test/etl/curated/test_ref_appeal_attribute_matrix_curated_process.py
@@ -1,11 +1,7 @@
-import pytest
 from odw.core.etl.transformation.curated.appeal_attribute_matrix_curated_process import AppealAttributeMatrixCuratedProcess
 from odw.test.util.test_case import SparkTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-import mock
-
-pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
-
+from unittest import mock
 
 class TestRefAppealAttributeMatrixCurationProcess(SparkTestCase):
     def test__appeal_attribute_matrix_curated_process__process__filters_only_active_records_when_isactive_present(self):

--- a/odw/test/unit_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
+++ b/odw/test/unit_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
@@ -1,12 +1,8 @@
-import pytest
 from odw.core.etl.transformation.harmonised.appeal_attribute_matrix_harmonisation_process import AppealAttributeMatrixHarmonisationProcess
 from odw.test.util.test_case import SparkTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-import mock
+from unittest import mock
 from pyspark.sql import functions as F
-
-pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
-
 
 class TestRefAppealAttributeMatrixHarmonisationProcess(SparkTestCase):
     def test__appeal_attribute_matrix_harmonisation_process__process__trims_all_string_columns_and_normalises_attribute(self):

--- a/odw/test/unit_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
+++ b/odw/test/unit_test/etl/harmonised/test_ref_appeal_attribute_matrix_harmonisation_process.py
@@ -4,6 +4,7 @@ from odw.test.util.session_util import PytestSparkSessionUtil
 from unittest import mock
 from pyspark.sql import functions as F
 
+
 class TestRefAppealAttributeMatrixHarmonisationProcess(SparkTestCase):
     def test__appeal_attribute_matrix_harmonisation_process__process__trims_all_string_columns_and_normalises_attribute(self):
         spark = PytestSparkSessionUtil().get_spark_session()

--- a/odw/test/unit_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
+++ b/odw/test/unit_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
@@ -2,12 +2,8 @@ from types import SimpleNamespace
 from odw.core.etl.transformation.standardised.appeal_attribute_matrix_standardisation_process import AppealAttributeMatrixStandardisationProcess
 from odw.test.util.test_case import SparkTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-import mock
+from unittest import mock
 import pyspark.sql.types as T
-import pytest
-
-pytestmark = pytest.mark.xfail(reason="Standardisation logic not implemented yet")
-
 
 class TestRefAppealAttributeMatrixStandardisationProcess(SparkTestCase):
     def test__appeal_attribute_matrix_standardisation_process__get_latest_ingestion_date__returns_latest_valid_date(self):

--- a/odw/test/unit_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
+++ b/odw/test/unit_test/etl/standardised/test_ref_appeal_attribute_matrix_standardisation_process.py
@@ -5,6 +5,7 @@ from odw.test.util.session_util import PytestSparkSessionUtil
 from unittest import mock
 import pyspark.sql.types as T
 
+
 class TestRefAppealAttributeMatrixStandardisationProcess(SparkTestCase):
     def test__appeal_attribute_matrix_standardisation_process__get_latest_ingestion_date__returns_latest_valid_date(self):
         spark = PytestSparkSessionUtil().get_spark_session()


### PR DESCRIPTION
JIRA Ticket Reference :
2919-Restructure Appeal Attribute Matrix Notebooks std-hmz-curated
https://pins-ds.atlassian.net/browse/THEODW-2919

Summary of the work :
Refactored the Appeal Attribute Matrix processing across the Standardised, Harmonised, and Curated layers by migrating the existing notebook logic into the central ODW Python ETL framework.

The refactor follows the standard Load → Transform → Write pattern, removes all transformation logic from notebooks, and preserves existing behaviour and outputs. Notebooks are now thin entry points that invoke the shared ETL processes, improving maintainability, consistency, and testability with no changes to business rules.
Proof: py_etl_orchestrator ran successfully in Synapse for all three notebooks