### PR TITLE
2922-RestructureAppealEventNotebooks

### DIFF
--- a/odw/core/etl/etl_process_factory.py
+++ b/odw/core/etl/etl_process_factory.py
@@ -15,6 +15,9 @@ from odw.core.etl.transformation.curated.nsip_exam_timetable_curated_process imp
 from odw.core.etl.transformation.curated.nsip_representation_curated_process import NsipRepresentationCuratedProcess
 from odw.core.etl.transformation.curated.nsip_s51_advice_curated_process import NsipS51AdviceCuratedProcess
 from odw.core.etl.transformation.curated.nsip_meeting_curated_process import NsipMeetingCuratedProcess
+from odw.core.etl.transformation.harmonised.appeal_event_harmonisation_process import AppealEventHarmonisationProcess
+from odw.core.etl.transformation.curated.appeal_event_curated_mipins_process import AppealEventCuratedMipinsProcess
+from odw.core.etl.transformation.curated.appeal_event_curated_process import AppealEventCuratedProcess
 from typing import Dict, List, Set, Type
 import json
 
@@ -36,6 +39,9 @@ class ETLProcessFactory:
         NsipRepresentationCuratedProcess,
         NsipS51AdviceCuratedProcess,
         NsipMeetingCuratedProcess,
+        AppealEventHarmonisationProcess,
+        AppealEventCuratedMipinsProcess,
+        AppealEventCuratedProcess
     }
 
     @classmethod

--- a/odw/core/etl/etl_process_factory.py
+++ b/odw/core/etl/etl_process_factory.py
@@ -21,7 +21,6 @@ from odw.core.etl.transformation.curated.appeal_event_curated_process import App
 from typing import Dict, List, Set, Type
 import json
 
-
 class ETLProcessFactory:
     ETL_PROCESSES: Set[Type[ETLProcess]] = {
         StandardisationProcess,

--- a/odw/core/etl/etl_process_factory.py
+++ b/odw/core/etl/etl_process_factory.py
@@ -21,6 +21,7 @@ from odw.core.etl.transformation.curated.appeal_event_curated_process import App
 from typing import Dict, List, Set, Type
 import json
 
+
 class ETLProcessFactory:
     ETL_PROCESSES: Set[Type[ETLProcess]] = {
         StandardisationProcess,
@@ -40,7 +41,7 @@ class ETLProcessFactory:
         NsipMeetingCuratedProcess,
         AppealEventHarmonisationProcess,
         AppealEventCuratedMipinsProcess,
-        AppealEventCuratedProcess
+        AppealEventCuratedProcess,
     }
 
     @classmethod

--- a/odw/core/etl/transformation/curated/appeal_event_curated_mipins_process.py
+++ b/odw/core/etl/transformation/curated/appeal_event_curated_mipins_process.py
@@ -2,10 +2,8 @@ from odw.core.etl.transformation.curated.curation_process import CurationProcess
 from odw.core.util.logging_util import LoggingUtil
 from odw.core.util.util import Util
 from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
-
 from pyspark.sql import DataFrame, SparkSession
 import pyspark.sql.functions as F
-
 from datetime import datetime
 from typing import Dict, Tuple
 

--- a/odw/core/etl/transformation/curated/appeal_event_curated_mipins_process.py
+++ b/odw/core/etl/transformation/curated/appeal_event_curated_mipins_process.py
@@ -1,0 +1,124 @@
+from odw.core.etl.transformation.curated.curation_process import CurationProcess
+from odw.core.util.logging_util import LoggingUtil
+from odw.core.util.util import Util
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
+
+from pyspark.sql import DataFrame, SparkSession
+import pyspark.sql.functions as F
+
+from datetime import datetime
+from typing import Dict, Tuple
+
+
+class AppealEventCuratedMipinsProcess(CurationProcess):
+    HARMONISED_TABLE = "odw_harmonised_db.appeal_event"
+    OUTPUT_TABLE = "odw_curated_db.appeal_event_curated_mipins"
+
+    TIMESTAMP_COLUMNS = [
+        "eventStartDateTime",
+        "eventEndDateTime",
+        "NotificationOfSiteVisit",
+        "IngestionDate",
+        "ValidTo",
+    ]
+
+    def __init__(self, spark: SparkSession, debug: bool = False):
+        super().__init__(spark, debug)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "appeal_event_curated_mipins"
+
+    def load_data(self, **kwargs) -> Dict[str, DataFrame]:
+        LoggingUtil().log_info(
+            f"Loading harmonised Appeal Event data from {self.HARMONISED_TABLE}"
+        )
+
+        df = self.spark.sql(f"""
+            SELECT
+                eventId,
+                caseReference,
+                eventType,
+                eventName,
+                eventStatus,
+                CAST(IsUrgent AS BOOLEAN) AS IsUrgent,
+                CAST(eventPublished AS BOOLEAN) AS eventPublished,
+                eventStartDateTime,
+                eventEndDateTime,
+                NotificationOfSiteVisit,
+                addressLine1,
+                addressLine2,
+                addressTown,
+                addressCounty,
+                addressPostcode,
+                Migrated,
+                ODTSourceSystem,
+                SourceSystemID,
+                IngestionDate,
+                ValidTo,
+                RowID,
+                IsActive
+            FROM {self.HARMONISED_TABLE}
+            WHERE
+                ODTSourceSystem = 'ODT'
+                AND (eventStartDateTime IS NULL OR eventStartDateTime >= TIMESTAMP('1900-01-01'))
+                AND (eventEndDateTime IS NULL OR eventEndDateTime >= TIMESTAMP('1900-01-01'))
+                AND (NotificationOfSiteVisit IS NULL OR NotificationOfSiteVisit >= TIMESTAMP('1900-01-01'))
+                AND (IngestionDate IS NULL OR IngestionDate >= TIMESTAMP('1900-01-01'))
+                AND (ValidTo IS NULL OR ValidTo >= TIMESTAMP('1900-01-01'))
+        """)
+
+        return {
+            "harmonised_appeal_event": df
+        }
+
+    def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
+        start_exec_time = datetime.now()
+
+        source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
+        df: DataFrame = self.load_parameter("harmonised_appeal_event", source_data)
+
+        for col in self.TIMESTAMP_COLUMNS:
+            if col in df.columns:
+                df = df.withColumn(
+                    col,
+                    F.to_timestamp(
+                        F.from_utc_timestamp(F.col(col), "Europe/London"),
+                        "yyyy-MM-dd'T'HH:mm:ss.SSS"
+                    )
+                )
+
+        insert_count = df.count()
+        LoggingUtil().log_info(
+            f"Curated Appeal Event (MIPINS) row count: {insert_count}"
+        )
+
+        end_exec_time = datetime.now()
+
+        data_to_write = {
+            self.OUTPUT_TABLE: {
+                "data": df,
+                "storage_kind": "ADLSG2-Table",
+                "database_name": "odw_curated_db",
+                "table_name": "appeal_event_curated_mipins",
+                "storage_endpoint": Util.get_storage_account(),
+                "container_name": "odw-curated",
+                "blob_path": "appeal_event_curated_mipins",
+                "file_format": "parquet",
+                "write_mode": "overwrite",
+                "write_options": {},
+            }
+        }
+
+        return data_to_write, ETLSuccessResult(
+            metadata=ETLResult.ETLResultMetadata(
+                start_execution_time=start_exec_time,
+                end_execution_time=end_exec_time,
+                table_name=self.OUTPUT_TABLE,
+                insert_count=insert_count,
+                update_count=0,
+                delete_count=0,
+                activity_type=self.get_name(),
+                duration_seconds=(end_exec_time - start_exec_time).total_seconds(),
+            )
+        )

--- a/odw/core/etl/transformation/curated/appeal_event_curated_mipins_process.py
+++ b/odw/core/etl/transformation/curated/appeal_event_curated_mipins_process.py
@@ -30,9 +30,7 @@ class AppealEventCuratedMipinsProcess(CurationProcess):
         return "appeal_event_curated_mipins"
 
     def load_data(self, **kwargs) -> Dict[str, DataFrame]:
-        LoggingUtil().log_info(
-            f"Loading harmonised Appeal Event data from {self.HARMONISED_TABLE}"
-        )
+        LoggingUtil().log_info(f"Loading harmonised Appeal Event data from {self.HARMONISED_TABLE}")
 
         df = self.spark.sql(f"""
             SELECT
@@ -68,9 +66,7 @@ class AppealEventCuratedMipinsProcess(CurationProcess):
                 AND (ValidTo IS NULL OR ValidTo >= TIMESTAMP('1900-01-01'))
         """)
 
-        return {
-            "harmonised_appeal_event": df
-        }
+        return {"harmonised_appeal_event": df}
 
     def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
         start_exec_time = datetime.now()
@@ -80,18 +76,10 @@ class AppealEventCuratedMipinsProcess(CurationProcess):
 
         for col in self.TIMESTAMP_COLUMNS:
             if col in df.columns:
-                df = df.withColumn(
-                    col,
-                    F.to_timestamp(
-                        F.from_utc_timestamp(F.col(col), "Europe/London"),
-                        "yyyy-MM-dd'T'HH:mm:ss.SSS"
-                    )
-                )
+                df = df.withColumn(col, F.to_timestamp(F.from_utc_timestamp(F.col(col), "Europe/London"), "yyyy-MM-dd'T'HH:mm:ss.SSS"))
 
         insert_count = df.count()
-        LoggingUtil().log_info(
-            f"Curated Appeal Event (MIPINS) row count: {insert_count}"
-        )
+        LoggingUtil().log_info(f"Curated Appeal Event (MIPINS) row count: {insert_count}")
 
         end_exec_time = datetime.now()
 

--- a/odw/core/etl/transformation/curated/appeal_event_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_event_curated_process.py
@@ -19,9 +19,7 @@ class AppealEventCuratedProcess(CurationProcess):
         return "appeal_event_curated"
 
     def load_data(self, **kwargs) -> Dict[str, DataFrame]:
-        LoggingUtil().log_info(
-            f"Loading active Appeal Event records from {self.HARMONISED_TABLE}"
-        )
+        LoggingUtil().log_info(f"Loading active Appeal Event records from {self.HARMONISED_TABLE}")
 
         df = self.spark.sql(f"""
             SELECT
@@ -44,9 +42,7 @@ class AppealEventCuratedProcess(CurationProcess):
             WHERE IsActive = 'Y'
         """)
 
-        return {
-            "harmonised_appeal_event": df
-        }
+        return {"harmonised_appeal_event": df}
 
     def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
         start_exec_time = datetime.now()
@@ -55,9 +51,7 @@ class AppealEventCuratedProcess(CurationProcess):
         df: DataFrame = self.load_parameter("harmonised_appeal_event", source_data)
 
         insert_count = df.count()
-        LoggingUtil().log_info(
-            f"Curated Appeal Event row count: {insert_count}"
-        )
+        LoggingUtil().log_info(f"Curated Appeal Event row count: {insert_count}")
 
         end_exec_time = datetime.now()
 

--- a/odw/core/etl/transformation/curated/appeal_event_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_event_curated_process.py
@@ -41,18 +41,14 @@ class AppealEventCuratedProcess(CurationProcess):
             FROM {self.HARMONISED_TABLE}
             WHERE IsActive = 'Y'
         """)
-
         return {"harmonised_appeal_event": df}
 
     def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
         start_exec_time = datetime.now()
-
         source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
         df: DataFrame = self.load_parameter("harmonised_appeal_event", source_data)
-
         insert_count = df.count()
         LoggingUtil().log_info(f"Curated Appeal Event row count: {insert_count}")
-
         end_exec_time = datetime.now()
 
         data_to_write = {

--- a/odw/core/etl/transformation/curated/appeal_event_curated_process.py
+++ b/odw/core/etl/transformation/curated/appeal_event_curated_process.py
@@ -1,0 +1,90 @@
+from odw.core.etl.transformation.curated.curation_process import CurationProcess
+from odw.core.util.logging_util import LoggingUtil
+from odw.core.util.util import Util
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
+from pyspark.sql import DataFrame, SparkSession
+from datetime import datetime
+from typing import Dict, Tuple
+
+
+class AppealEventCuratedProcess(CurationProcess):
+    HARMONISED_TABLE = "odw_harmonised_db.appeal_event"
+    OUTPUT_TABLE = "odw_curated_db.appeal_event"
+
+    def __init__(self, spark: SparkSession, debug: bool = False):
+        super().__init__(spark, debug)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "appeal_event_curated"
+
+    def load_data(self, **kwargs) -> Dict[str, DataFrame]:
+        LoggingUtil().log_info(
+            f"Loading active Appeal Event records from {self.HARMONISED_TABLE}"
+        )
+
+        df = self.spark.sql(f"""
+            SELECT
+                eventId,
+                caseReference,
+                eventType,
+                eventName,
+                eventStatus,
+                IsUrgent AS isUrgent,
+                eventPublished,
+                eventStartDateTime,
+                eventEndDateTime,
+                notificationOfSitevisit AS notificationOfSiteVisit,
+                addressLine1,
+                addressLine2,
+                addressTown,
+                addressCounty,
+                addressPostcode
+            FROM {self.HARMONISED_TABLE}
+            WHERE IsActive = 'Y'
+        """)
+
+        return {
+            "harmonised_appeal_event": df
+        }
+
+    def process(self, **kwargs) -> Tuple[Dict[str, DataFrame], ETLResult]:
+        start_exec_time = datetime.now()
+
+        source_data: Dict[str, DataFrame] = self.load_parameter("source_data", kwargs)
+        df: DataFrame = self.load_parameter("harmonised_appeal_event", source_data)
+
+        insert_count = df.count()
+        LoggingUtil().log_info(
+            f"Curated Appeal Event row count: {insert_count}"
+        )
+
+        end_exec_time = datetime.now()
+
+        data_to_write = {
+            self.OUTPUT_TABLE: {
+                "data": df,
+                "storage_kind": "ADLSG2-Table",
+                "database_name": "odw_curated_db",
+                "table_name": "appeal_event",
+                "storage_endpoint": Util.get_storage_account(),
+                "container_name": "odw-curated",
+                "blob_path": "appeal_event",
+                "file_format": "parquet",
+                "write_mode": "overwrite",
+                "write_options": {},
+            }
+        }
+
+        return data_to_write, ETLSuccessResult(
+            metadata=ETLResult.ETLResultMetadata(
+                start_execution_time=start_exec_time,
+                end_execution_time=end_exec_time,
+                table_name=self.OUTPUT_TABLE,
+                insert_count=insert_count,
+                update_count=0,
+                delete_count=0,
+                activity_type=self.get_name(),
+                duration_seconds=(end_exec_time - start_exec_time).total_seconds(),
+            )
+        )

--- a/odw/core/etl/transformation/harmonised/appeal_event_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/appeal_event_harmonisation_process.py
@@ -1,0 +1,200 @@
+from odw.core.etl.transformation.harmonised.harmonsation_process import HarmonisationProcess
+from odw.core.etl.etl_result import ETLResult, ETLSuccessResult
+from odw.core.util.util import Util
+import pyspark.sql.functions as F
+from pyspark.sql import DataFrame
+from datetime import datetime
+from typing import Dict
+
+class AppealEventHarmonisationProcess(HarmonisationProcess):
+    OUTPUT_TABLE = "appeal_event"
+    PRIMARY_KEY = "eventId"
+
+    def __init__(self, spark, debug: bool = False):
+        super().__init__(spark, debug)
+        self.spark = spark
+        self.harmonised_db = "odw_harmonised_db"
+        self.standardised_db = "odw_standardised_db"
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "appeal_event_harmonisation_process"
+
+    def load_data(self, data_to_read=None, **kwargs) -> Dict[str, DataFrame]:
+        service_bus_table = f"{self.harmonised_db}.sb_appeal_event"
+        horizon_table = f"{self.standardised_db}.horizon_appeals_event"
+
+        service_bus_df = self.spark.sql(f"""
+            SELECT DISTINCT
+                AppealsEventId,
+                eventId,
+                caseReference,
+                eventType,
+                eventName,
+                eventstatus AS eventStatus,
+                isUrgent,
+                eventPublished,
+                eventStartDatetime,
+                eventEndDatetime,
+                notificationOfSitevisit,
+                AddressLine1 AS addressLine1,
+                AddressLine2 AS addressLine2,
+                AddressTown AS addressTown,
+                AddressCounty AS addressCounty,
+                AddressPostcode AS addressPostcode,
+                Migrated,
+                ODTSourceSystem,
+                SourceSystemID,
+                IngestionDate,
+                ValidTo,
+                RowID,
+                IsActive
+            FROM {service_bus_table}
+        """)
+
+        horizon_df = self.spark.sql(f"""
+            SELECT DISTINCT
+                CAST(NULL AS LONG) AS AppealsEventId,
+                CONCAT(casenumber, '-', eventId) AS eventId,
+                caseReference,
+                eventType,
+                eventName,
+                eventStatus,
+                CAST(NULL AS BOOLEAN) AS isUrgent,
+                CAST(NULL AS BOOLEAN) AS eventPublished,
+                CAST(NULL AS STRING) AS eventStartDatetime,
+                CAST(NULL AS STRING) AS eventEndDatetime,
+                notificationOfSitevisit,
+                eventaddressline1 AS addressLine1,
+                eventaddressline2 AS addressLine2,
+                eventaddresstown AS addressTown,
+                eventaddresscounty AS addressCounty,
+                eventaddresspostcode AS addressPostcode,
+                0 AS Migrated,
+                'Horizon' AS ODTSourceSystem,
+                9 AS SourceSystemID,
+                ingested_datetime AS IngestionDate,
+                CAST(NULL AS STRING) AS ValidTo,
+                '' AS RowID,
+                'Y' AS IsActive
+            FROM {horizon_table}
+            WHERE ingested_datetime = (
+                SELECT MAX(ingested_datetime)
+                FROM {horizon_table}
+            )
+        """)
+
+        horizon_df = horizon_df.select(service_bus_df.columns)
+
+        return {
+            "service_bus": service_bus_df,
+            "horizon": horizon_df,
+        }
+
+    def process(self, source_data: Dict[str, DataFrame], **kwargs):
+        start_exec_time = datetime.now()
+
+        combined_df = source_data["service_bus"].union(source_data["horizon"])
+
+        target_table = f"{self.harmonised_db}.{self.OUTPUT_TABLE}"
+
+        combined_df.write \
+            .format("delta") \
+            .mode("overwrite") \
+            .option("overwriteSchema", "true") \
+            .saveAsTable(target_table)
+
+        combined_df = self.spark.table(target_table)
+        combined_df.createOrReplaceTempView("appeal_event_base")
+
+        self.spark.sql(f"""
+            CREATE OR REPLACE TEMP VIEW vw_appeal_event_calculations_base AS
+            SELECT
+                row_number() OVER (
+                    PARTITION BY {self.PRIMARY_KEY}
+                    ORDER BY IngestionDate DESC
+                ) AS ReverseOrderProcessed,
+                row_number() OVER (
+                    ORDER BY IngestionDate ASC, {self.PRIMARY_KEY} ASC
+                ) AS AppealsEventId,
+                {self.PRIMARY_KEY},
+                IngestionDate,
+                ValidTo,
+                '0' AS Migrated,
+                CASE
+                    WHEN row_number() OVER (
+                        PARTITION BY {self.PRIMARY_KEY}
+                        ORDER BY IngestionDate DESC
+                    ) = 1 THEN 'Y'
+                    ELSE 'N'
+                END AS IsActive
+            FROM appeal_event_base
+        """)
+
+        calcs_df = self.spark.sql(f"""
+            SELECT
+                Current.AppealsEventId,
+                Current.{self.PRIMARY_KEY} AS eventId,
+                Current.IngestionDate,
+                NextRow.IngestionDate AS ValidTo,
+                CASE
+                    WHEN Raw.{self.PRIMARY_KEY} IS NOT NULL THEN '1'
+                    ELSE '0'
+                END AS Migrated,
+                Current.IsActive
+            FROM vw_appeal_event_calculations_base Current
+            LEFT JOIN vw_appeal_event_calculations_base NextRow
+                ON Current.{self.PRIMARY_KEY} = NextRow.{self.PRIMARY_KEY}
+               AND Current.ReverseOrderProcessed - 1 = NextRow.ReverseOrderProcessed
+            LEFT JOIN (
+                SELECT DISTINCT eventId
+                FROM odw_harmonised_db.sb_appeal_event
+            ) Raw
+                ON Current.{self.PRIMARY_KEY} = Raw.{self.PRIMARY_KEY}
+        """)
+
+        final_columns = combined_df.columns
+
+        final_df = combined_df \
+            .drop("AppealsEventId", "ValidTo", "Migrated", "IsActive") \
+            .join(calcs_df, on=["eventId", "IngestionDate"], how="inner") \
+            .select(final_columns) \
+            .distinct()
+
+        final_df = final_df.withColumn(
+            "RowID",
+            F.md5(
+                F.concat_ws(
+                    "",
+                    *[F.coalesce(F.col(c).cast("string"), F.lit(".")) for c in final_df.columns]
+                )
+            )
+        )
+
+        hrm_table_snake_case = self.OUTPUT_TABLE.replace("-", "_")
+
+        data_to_write = {
+            target_table: {
+                "data": final_df,
+                "storage_kind": "ADLSG2-LegacyDelta",
+                "database_name": self.harmonised_db,
+                "table_name": self.OUTPUT_TABLE,
+                "storage_endpoint": Util.get_storage_account(),
+                "container_name": "odw-harmonised",
+                "blob_path": hrm_table_snake_case,
+                "merge_keys": [self.PRIMARY_KEY],
+            }
+        }
+
+        return data_to_write, ETLSuccessResult(
+            metadata=ETLResult.ETLResultMetadata(
+                start_execution_time=start_exec_time,
+                end_execution_time=datetime.now(),
+                table_name=target_table,
+                insert_count=final_df.count(),
+                update_count=0,
+                delete_count=0,
+                activity_type=self.get_name(),
+                duration_seconds=(datetime.now() - start_exec_time).total_seconds(),
+            )
+        )

--- a/odw/core/etl/transformation/harmonised/appeal_event_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/appeal_event_harmonisation_process.py
@@ -6,6 +6,7 @@ from pyspark.sql import DataFrame
 from datetime import datetime
 from typing import Dict
 
+
 class AppealEventHarmonisationProcess(HarmonisationProcess):
     OUTPUT_TABLE = "appeal_event"
     PRIMARY_KEY = "eventId"
@@ -98,11 +99,7 @@ class AppealEventHarmonisationProcess(HarmonisationProcess):
 
         target_table = f"{self.harmonised_db}.{self.OUTPUT_TABLE}"
 
-        combined_df.write \
-            .format("delta") \
-            .mode("overwrite") \
-            .option("overwriteSchema", "true") \
-            .saveAsTable(target_table)
+        combined_df.write.format("delta").mode("overwrite").option("overwriteSchema", "true").saveAsTable(target_table)
 
         combined_df = self.spark.table(target_table)
         combined_df.createOrReplaceTempView("appeal_event_base")
@@ -155,21 +152,14 @@ class AppealEventHarmonisationProcess(HarmonisationProcess):
 
         final_columns = combined_df.columns
 
-        final_df = combined_df \
-            .drop("AppealsEventId", "ValidTo", "Migrated", "IsActive") \
-            .join(calcs_df, on=["eventId", "IngestionDate"], how="inner") \
-            .select(final_columns) \
+        final_df = (
+            combined_df.drop("AppealsEventId", "ValidTo", "Migrated", "IsActive")
+            .join(calcs_df, on=["eventId", "IngestionDate"], how="inner")
+            .select(final_columns)
             .distinct()
-
-        final_df = final_df.withColumn(
-            "RowID",
-            F.md5(
-                F.concat_ws(
-                    "",
-                    *[F.coalesce(F.col(c).cast("string"), F.lit(".")) for c in final_df.columns]
-                )
-            )
         )
+
+        final_df = final_df.withColumn("RowID", F.md5(F.concat_ws("", *[F.coalesce(F.col(c).cast("string"), F.lit(".")) for c in final_df.columns])))
 
         hrm_table_snake_case = self.OUTPUT_TABLE.replace("-", "_")
 

--- a/odw/core/etl/transformation/harmonised/appeal_event_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/appeal_event_harmonisation_process.py
@@ -94,13 +94,9 @@ class AppealEventHarmonisationProcess(HarmonisationProcess):
 
     def process(self, source_data: Dict[str, DataFrame], **kwargs):
         start_exec_time = datetime.now()
-
         combined_df = source_data["service_bus"].union(source_data["horizon"])
-
         target_table = f"{self.harmonised_db}.{self.OUTPUT_TABLE}"
-
         combined_df.write.format("delta").mode("overwrite").option("overwriteSchema", "true").saveAsTable(target_table)
-
         combined_df = self.spark.table(target_table)
         combined_df.createOrReplaceTempView("appeal_event_base")
 


### PR DESCRIPTION
2922-Restructure Appeal event Notebooks
https://pins-ds.atlassian.net/browse/THEODW-2922

 2.  Summary of the work : 
Refactored legacy Synapse notebooks related to Appeal Event processing into the ODW ETL framework with no functional or schema changes.
- py_sb_horizon_harmonised_appeal_event
- appeal_event_curated_mipins
- appeal_event

