### PR TITLE
3087-pln_rest_api pipeline incorrectly marked as failed

### DIFF
--- a/workspace/pipeline/pln_all_horizon_data.json
+++ b/workspace/pipeline/pln_all_horizon_data.json
@@ -5,6 +5,8 @@
 			{
 				"name": "Horizon data load",
 				"type": "ExecutePipeline",
+				"state": "Inactive",
+				"onInactiveMarkAs": "Succeeded",
 				"dependsOn": [
 					{
 						"activity": "Record loading relevant reps data_copy1",

--- a/workspace/pipeline/pln_all_horizon_data.json
+++ b/workspace/pipeline/pln_all_horizon_data.json
@@ -5,8 +5,6 @@
 			{
 				"name": "Horizon data load",
 				"type": "ExecutePipeline",
-				"state": "Inactive",
-				"onInactiveMarkAs": "Succeeded",
 				"dependsOn": [
 					{
 						"activity": "Record loading relevant reps data_copy1",

--- a/workspace/pipeline/pln_rest_api.json
+++ b/workspace/pipeline/pln_rest_api.json
@@ -143,7 +143,7 @@
 							"type": "Expression"
 						},
 						"ErrorMessage": {
-							"value": "@{if(or(equals(activity('Listed Building Main')?.Error?.Message, ''), equals(activity('Listed Building Main')?.Error?.Message, null)), ' ', activity('Listed Building Main')?.Error?.Message)}\n",
+							"value": "@{if(or(equals(activity('Listed Building Main')?.Error?.Message, ''), equals(activity('Listed Building Main')?.Error?.Message, null)), '', activity('Listed Building Main')?.Error?.Message)}\n",
 							"type": "Expression"
 						},
 						"StatusMessage": {
@@ -499,7 +499,7 @@
 							"type": "Expression"
 						},
 						"ErrorMessage": {
-							"value": "@{if(or(equals(activity('Horizon EntraID')?.Error?.Message, ''), equals(activity('Horizon EntraID')?.Error?.Message, null)), ' ', activity('Horizon EntraID')?.Error?.Message)}\n",
+							"value": "@{if(or(equals(activity('Horizon EntraID')?.Error?.Message, ''), equals(activity('Horizon EntraID')?.Error?.Message, null)), '', activity('Horizon EntraID')?.Error?.Message)}\n",
 							"type": "Expression"
 						},
 						"StatusMessage": {
@@ -573,7 +573,7 @@
 							"type": "Expression"
 						},
 						"ErrorMessage": {
-							"value": "@{if(or(equals(activity('AIE document metadata')?.Error?.Message, ''), equals(activity('AIE document metadata')?.Error?.Message, null)), ' ', activity('AIE document metadata')?.Error?.Message)}\n",
+							"value": "@{if(or(equals(activity('AIE document metadata')?.Error?.Message, ''), equals(activity('AIE document metadata')?.Error?.Message, null)), '', activity('AIE document metadata')?.Error?.Message)}\n",
 							"type": "Expression"
 						},
 						"StatusMessage": {
@@ -711,7 +711,7 @@
 							"type": "Expression"
 						},
 						"ErrorMessage": {
-							"value": "@{if(or(equals(activity('PINS Inspector Main')?.Error?.Message, ''), equals(activity('PINS Inspector Main')?.Error?.Message, null)), ' ', activity('PINS Inspector Main')?.Error?.Message)}\n",
+							"value": "@{if(or(equals(activity('PINS Inspector Main')?.Error?.Message, ''), equals(activity('PINS Inspector Main')?.Error?.Message, null)), '', activity('PINS Inspector Main')?.Error?.Message)}\n",
 							"type": "Expression"
 						},
 						"StatusMessage": {


### PR DESCRIPTION
3087-pln_rest_api pipeline incorrectly marked as failed
    https://pins-ds.atlassian.net/browse/THEODW-3087

 2.  Summary of the work : 
        The pipeline runs in ODW kept showing as failed in the dashboard and when investigated it was found that this was happening due to a space issue in certain activities in the pln_rest_api pipeline. So i removed all those spaces, ran it manually and made sure that the space wasn't appearing in the ErrorMessage column anymore. 

3. Proof of change: 
<img width="2324" height="332" alt="Screenshot 2026-05-05 115526" src="https://github.com/user-attachments/assets/7c069be9-f046-4ec2-b302-985bde765ce0" />
<img width="2051" height="491" alt="Screenshot 2026-05-05 115636" src="https://github.com/user-attachments/assets/b60b0200-44f3-456e-902b-afc8a3de5830" />

