### PR TITLE
Updating notebook: py_create_spark_schema

### DIFF
--- a/workspace/notebook/py_create_spark_schema.json
+++ b/workspace/notebook/py_create_spark_schema.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "5dd628be-408f-4f26-b1c2-b17cf567a1c9"
+				"spark.autotune.trackingId": "75e1ac15-8b66-4573-9676-e96915910357"
 			}
 		},
 		"metadata": {
@@ -92,7 +92,7 @@
 					"is_servicebus_schema: bool = True\r\n",
 					"return_json_schema = False\r\n",
 					"odw_config_entity = ''\r\n",
-					"version = '2.37.0'"
+					"version = '2.38.1'"
 				],
 				"execution_count": null
 			},


### PR DESCRIPTION
Jira Ticket:
https://pins-ds.atlassian.net/browse/THEODW-3101
spark version changes  to get latest s78 schema.
Note book: py_create_spark_schema- version chnaged to 2.37.0 to 2.38.1