### PR TITLE
Feat/theodw 3103 refine integration tests

### DIFF
--- a/odw/test/integration_test/etl/curated/test_listed_building_curated_process.py
+++ b/odw/test/integration_test/etl/curated/test_listed_building_curated_process.py
@@ -6,8 +6,33 @@ from pyspark.sql.types import LongType, StringType, StructField, StructType
 from odw.core.etl.transformation.curated.listed_building_curated_process import ListedBuildingCuratedProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.test.util.assertion import assert_dataframes_equal, assert_etl_result_successful
 
 pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
+
+
+def _harmonised_row(**overrides):
+    base = {
+        "dataset": "listed-building",
+        "endDate": None,
+        "entity": "1001",
+        "entryDate": "2024-01-01",
+        "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
+        "listedBuildingGrade": "II",
+        "name": "Building One",
+        "organisationEntity": "org-1",
+        "point": "POINT(1 1)",
+        "prefix": "listed-building",
+        "reference": "LB-001",
+        "startDate": "2020-01-01",
+        "typology": "grade-ii",
+        "documentationUrl": "https://example.com/lb-001",
+        "dateReceived": "2025-01-01",
+        "rowID": "row-1",
+        "validTo": "None",
+        "isActive": "Y",
+    }
+    return base | overrides
 
 
 def _harmonised_schema():
@@ -46,358 +71,64 @@ def _curated_schema():
     )
 
 
-def _harmonised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "II",
-                "Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "2025-01-01",
-                "row-1",
-                None,
-                "Y",
-            ),
-            (
-                "listed-building",
-                None,
-                "1002",
-                "2024-02-01",
-                None,
-                "I",
-                "Building Two",
-                "org-2",
-                None,
-                "listed-building",
-                "LB-002",
-                "2021-01-01",
-                "grade-i",
-                None,
-                "2025-01-01",
-                "row-2",
-                None,
-                "Y",
-            ),
-            (
-                "listed-building",
-                None,
-                "1003",
-                "2024-03-01",
-                None,
-                "II*",
-                "Inactive Building",
-                "org-3",
-                None,
-                "listed-building",
-                "LB-003",
-                "2022-01-01",
-                "grade-ii-star",
-                None,
-                "2025-01-01",
-                "row-3",
-                None,
-                "N",
-            ),
-        ],
-        schema=_harmonised_schema(),
-    )
-
-
-def _changed_harmonised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "II",
-                "Building One Updated",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "2025-01-01",
-                "row-9",
-                None,
-                "Y",
-            ),
-        ],
-        schema=_harmonised_schema(),
-    )
-
-
-def _duplicate_harmonised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "II",
-                "Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "2025-01-01",
-                "row-1",
-                None,
-                "Y",
-            ),
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "II",
-                "Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "2025-01-01",
-                "row-2",
-                None,
-                "Y",
-            ),
-        ],
-        schema=_harmonised_schema(),
-    )
-
-
-def _empty_harmonised_df(spark):
-    return spark.createDataFrame([], schema=_harmonised_schema())
-
-
-def _existing_curated_df(spark):
-    return spark.createDataFrame(
-        [
-            (1001, "LB-001", "Building One", "II"),
-        ],
-        schema=_curated_schema(),
-    )
-
-
 class TestListedBuildingCuratedProcess(ETLTestCase):
-    def test__listed_building_curated_process__run__initial_load_matches_legacy(self):
+    def test__listed_building_curated_process__run__with_no_existing_data(self):
         spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _harmonised_df(spark),
-            "target_exists": False,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
-        assert df.count() == 2
-        assert result.metadata.insert_count == 2
-        assert result.metadata.update_count == 0
-
-        assert df.columns == ["entity", "reference", "name", "listedBuildingGrade"]
-
-        entity_ids = {row["entity"] for row in df.select("entity").collect()}
-        assert entity_ids == {1001, 1002}
-        assert df.where(F.col("entity") == 1003).count() == 0
-
-    def test__listed_building_curated_process__run__updates_existing_entity_when_non_key_fields_change(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _changed_harmonised_df(spark),
-            "target_data": _existing_curated_df(spark),
-            "target_exists": True,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        row = df.where(F.col("entity") == 1001).collect()[0]
-
-        assert row["name"] == "Building One Updated"
-        assert result.metadata.insert_count == 0
-        assert result.metadata.update_count == 1
-
-    def test__listed_building_curated_process__run__does_not_duplicate_identical_existing_entity(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        identical_source = spark.createDataFrame(
-            [
-                (
-                    "listed-building",
-                    None,
-                    "1001",
-                    "2024-01-01",
-                    "POLYGON((1 1,2 2,3 3,1 1))",
-                    "II",
-                    "Building One",
-                    "org-1",
-                    "POINT(1 1)",
-                    "listed-building",
-                    "LB-001",
-                    "2020-01-01",
-                    "grade-ii",
-                    "https://example.com/lb-001",
-                    "2025-01-01",
-                    "row-1",
-                    None,
-                    "Y",
-                ),
-            ],
+        test_case = "t_lbcpr_wned"
+        harmonised_data = spark.createDataFrame(
+            (
+                _harmonised_row(name="Building One", entity="1001", reference="LB-001", listedBuildingGrade="I"),
+                _harmonised_row(name="Building Two", entity="1002", reference="LB-002", listedBuildingGrade="I"),
+            ),
             schema=_harmonised_schema(),
         )
-
-        source_data = {
-            "source_data": identical_source,
-            "target_data": _existing_curated_df(spark),
-            "target_exists": True,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
+        table_name = f"{test_case}_listed_building"
+        self.write_existing_table(spark, harmonised_data, table_name, "odw_harmonised_db", "odw-harmonised", table_name, "overwrite")
+        expected_curated_data_after_writing = spark.createDataFrame(
+            (
+                {"entity": 1001, "reference": "LB-001", "name": "Building One", "listedBuildingGrade": "I"},
+                {"entity": 1002, "reference": "LB-002", "name": "Building Two", "listedBuildingGrade": "I"},
+            ),
+            schema=_curated_schema(),
+        )
+        with mock.patch.object(ListedBuildingCuratedProcess, "OUTPUT_TABLE", table_name):
             inst = ListedBuildingCuratedProcess(spark)
+            result = inst.run()
+            assert_etl_result_successful(result)
+            actual_table_data = spark.table(f"odw_curated_db.{table_name}")
+            assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
 
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert df.count() == 1
-        assert df.where(F.col("entity") == 1001).count() == 1
-        assert result.metadata.insert_count == 0
-        assert result.metadata.update_count == 0
-
-    def test__listed_building_curated_process__run__drops_duplicate_source_rows(
-        self,
-    ):
+    def test__listed_building_curated_process__run__with_existing_data(self):
         spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _duplicate_harmonised_df(spark),
-            "target_exists": False,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
+        test_case = "t_lbcpr_wed"
+        harmonised_data = spark.createDataFrame(
+            (
+                _harmonised_row(
+                    name="Building One Renamed", entity="1001", reference="LB-001 Updated", listedBuildingGrade="I Updated"
+                ),  # Should be updated
+                _harmonised_row(name="Building Two", entity="1002", reference="LB-002", listedBuildingGrade="I"),
+            ),
+            schema=_harmonised_schema(),
+        )
+        table_name = f"{test_case}_listed_building"
+        self.write_existing_table(spark, harmonised_data, table_name, "odw_harmonised_db", "odw-harmonised", table_name, "overwrite")
+        curated_data = spark.createDataFrame(
+            (
+                {"entity": 1001, "reference": "LB-001", "name": "Building One", "listedBuildingGrade": "I"},  # Should be updated
+            ),
+            schema=_curated_schema(),
+        )
+        self.write_existing_table(spark, curated_data, table_name, "odw_curated_db", "odw-curated", table_name, "overwrite")
+        expected_curated_data_after_writing = spark.createDataFrame(
+            (
+                {"entity": 1001, "reference": "LB-001 Updated", "name": "Building One Renamed", "listedBuildingGrade": "I Updated"},  # Updated
+                {"entity": 1002, "reference": "LB-002", "name": "Building Two", "listedBuildingGrade": "I"},
+            ),
+            schema=_curated_schema(),
+        )
+        with mock.patch.object(ListedBuildingCuratedProcess, "OUTPUT_TABLE", table_name):
             inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert df.count() == 1
-        assert df.where(F.col("entity") == 1001).count() == 1
-        assert result.metadata.insert_count == 1
-        assert result.metadata.update_count == 0
-
-    def test__listed_building_curated_process__run__empty_source_returns_empty_output(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _empty_harmonised_df(spark),
-            "target_exists": False,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
-        assert df.count() == 0
-        assert result.metadata.insert_count == 0
-        assert result.metadata.update_count == 0
+            result = inst.run()
+            assert_etl_result_successful(result)
+            actual_table_data = spark.table(f"odw_curated_db.{table_name}")
+            assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)

--- a/odw/test/integration_test/etl/curated/test_listed_building_curated_process.py
+++ b/odw/test/integration_test/etl/curated/test_listed_building_curated_process.py
@@ -1,7 +1,6 @@
 import mock
 import pytest
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
-from pyspark.sql import functions as F
 from pyspark.sql.types import LongType, StringType, StructField, StructType
 from odw.core.etl.transformation.curated.listed_building_curated_process import ListedBuildingCuratedProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase

--- a/odw/test/integration_test/etl/harmonised/test_listed_building_harmonisation_process.py
+++ b/odw/test/integration_test/etl/harmonised/test_listed_building_harmonisation_process.py
@@ -1,7 +1,6 @@
 import mock
 import pytest
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
-from pyspark.sql import functions as F
 from pyspark.sql.types import StringType, StructField, StructType
 from pyspark.sql import DataFrame
 from odw.core.etl.transformation.harmonised.listed_building_harmonisation_process import ListedBuildingHarmonisationProcess

--- a/odw/test/integration_test/etl/harmonised/test_listed_building_harmonisation_process.py
+++ b/odw/test/integration_test/etl/harmonised/test_listed_building_harmonisation_process.py
@@ -3,11 +3,35 @@ import pytest
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from pyspark.sql import functions as F
 from pyspark.sql.types import StringType, StructField, StructType
+from pyspark.sql import DataFrame
 from odw.core.etl.transformation.harmonised.listed_building_harmonisation_process import ListedBuildingHarmonisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
+from datetime import date
 
 pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
+
+
+def _standardised_row(**overrides):
+    row = {
+        "dataset": "listed-building",
+        "end-date": None,
+        "entity": None,
+        "entry-date": "2024-01-01",
+        "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
+        "name": None,
+        "organisation-entity": "org-1",
+        "point": "POINT(1 1)",
+        "prefix": "listed-building",
+        "reference": "LB-001",
+        "start-date": "2020-01-01",
+        "typology": "grade-ii",
+        "documentation-url": "https://example.com/lb-001",
+        "listed-building-grade": "II",
+    }
+    row.update(overrides)
+    return row
 
 
 def _standardised_schema():
@@ -29,6 +53,31 @@ def _standardised_schema():
             StructField("listed-building-grade", StringType(), True),
         ]
     )
+
+
+def _harmonised_row(**overrides):
+    row = {
+        "dataset": "listed-building",
+        "endDate": None,
+        "entity": "1",
+        "entryDate": "2024-01-01",
+        "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
+        "listedBuildingGrade": "II",
+        "name": "Building One",
+        "organisationEntity": "org-1",
+        "point": "POINT(1 1)",
+        "prefix": "listed-building",
+        "reference": "LB-001",
+        "startDate": "2020-01-01",
+        "typology": "grade-ii",
+        "documentationUrl": "https://example.com/lb-001",
+        "dateReceived": date(2026, 5, 8),
+        "rowID": "4413ab3eda0f2857bfed7731cde4729c",
+        "validTo": None,
+        "isActive": "Y",
+    }
+    row.update(overrides)
+    return row
 
 
 def _harmonised_schema():
@@ -56,485 +105,96 @@ def _harmonised_schema():
     )
 
 
-def _standardised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "II",
-            ),
-            (
-                "listed-building",
-                None,
-                "1002",
-                "2024-02-01",
-                None,
-                "Building Two",
-                "org-2",
-                None,
-                "listed-building",
-                "LB-002",
-                "2021-01-01",
-                "grade-i",
-                None,
-                "I",
-            ),
-        ],
-        schema=_standardised_schema(),
-    )
-
-
-def _changed_standardised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "Building One Updated",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "II",
-            ),
-        ],
-        schema=_standardised_schema(),
-    )
-
-
-def _unchanged_standardised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "Old Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "II",
-            ),
-        ],
-        schema=_standardised_schema(),
-    )
-
-
-def _duplicate_standardised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "II",
-            ),
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "II",
-            ),
-        ],
-        schema=_standardised_schema(),
-    )
-
-
-def _same_reference_different_entity_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "9999",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "Different Entity Same Reference",
-                "org-9",
-                "POINT(9 9)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-999",
-                "II",
-            ),
-        ],
-        schema=_standardised_schema(),
-    )
-
-
-def _empty_standardised_df(spark):
-    return spark.createDataFrame([], schema=_standardised_schema())
-
-
-def _existing_harmonised_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                "listed-building",
-                None,
-                "1001",
-                "2024-01-01",
-                "POLYGON((1 1,2 2,3 3,1 1))",
-                "II",
-                "Old Building One",
-                "org-1",
-                "POINT(1 1)",
-                "listed-building",
-                "LB-001",
-                "2020-01-01",
-                "grade-ii",
-                "https://example.com/lb-001",
-                "2025-01-01",
-                "old-row-id",
-                None,
-                "Y",
-            ),
-        ],
-        schema=_harmonised_schema(),
-    )
-
-
 class TestListedBuildingHarmonisationProcess(ETLTestCase):
-    def test__listed_building_harmonisation_process__run__initial_load_matches_legacy(self):
+    def compare_harmonised_data(expected_data: DataFrame, actual_data: DataFrame):
+        uncomparable_cols = "dateReceived"
+        expected_data_cleaned = expected_data.drop(*uncomparable_cols)
+        actual_data_cleaned = actual_data.drop(*uncomparable_cols)
+        assert_dataframes_equal(expected_data_cleaned, actual_data_cleaned)
+
+    def test__listed_building_harmonisation_process__run__with_no_existing_data(self):
         spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _standardised_df(spark),
-            "target_exists": False,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert df.count() == 2
-        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
-        assert result.metadata.insert_count == 2
-        assert result.metadata.update_count == 0
-
-        expected_columns = [
-            "dataset",
-            "endDate",
-            "entity",
-            "entryDate",
-            "geometry",
-            "listedBuildingGrade",
-            "name",
-            "organisationEntity",
-            "point",
-            "prefix",
-            "reference",
-            "startDate",
-            "typology",
-            "documentationUrl",
-            "dateReceived",
-            "rowID",
-            "validTo",
-            "isActive",
-        ]
-        assert df.columns == expected_columns
-
-        row = (
-            df.where(F.col("entity") == "1001")
-            .select(
-                "dataset",
-                "endDate",
-                "entryDate",
-                "listedBuildingGrade",
-                "organisationEntity",
-                "documentationUrl",
-                "dateReceived",
-                "isActive",
-                "validTo",
-                "rowID",
-            )
-            .collect()[0]
+        test_case = "t_lbhp_r_wned"
+        listed_building = spark.createDataFrame(
+            [
+                _standardised_row(entity=1, name="Building One"),
+                _standardised_row(entity=2, name="Building Two"),
+                _standardised_row(entity=3, name="Building Three"),
+            ],
+            schema=_standardised_schema(),
         )
-
-        assert row["dataset"] == "listed-building"
-        assert row["endDate"] is None
-        assert row["entryDate"] == "2024-01-01"
-        assert row["listedBuildingGrade"] == "II"
-        assert row["organisationEntity"] == "org-1"
-        assert row["documentationUrl"] == "https://example.com/lb-001"
-        assert row["dateReceived"] is not None
-        assert row["isActive"] == "Y"
-        assert row["validTo"] is None
-        assert row["rowID"]
-
-        assert df.where(F.col("dateReceived").isNull()).count() == 0
-
-    def test__listed_building_harmonisation_process__run__deactivates_old_version_and_inserts_new_version_like_legacy(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _changed_standardised_df(spark),
-            "target_data": _existing_harmonised_df(spark),
-            "target_exists": True,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
+        listed_building_table_name = f"{test_case}_listed_building"
+        self.write_existing_table(
+            spark, listed_building, listed_building_table_name, "odw_standardised_db", "odw-standardised", listed_building_table_name, "overwrite"
+        )
+        expected_harmonised_listed_building = spark.createDataFrame(
+            [
+                _harmonised_row(entity=1, name="Building One"),
+                _harmonised_row(entity=2, name="Building Two"),
+                _harmonised_row(entity=3, name="Building Three"),
+            ],
+            schema=_harmonised_schema(),
+        )
+        with mock.patch.object(ListedBuildingHarmonisationProcess, "OUTPUT_TABLE", listed_building_table_name):
             inst = ListedBuildingHarmonisationProcess(spark)
+            result = inst.run()
+            assert_etl_result_successful(result)
+            actual_table_data = spark.table(f"odw_harmonised_db.{listed_building_table_name}")
+            self.compare_harmonised_data(expected_harmonised_listed_building, actual_table_data)
 
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        old_row = df.where((F.col("entity") == "1001") & (F.col("isActive") == "N")).select("name", "validTo", "rowID").collect()[0]
-        new_row = df.where((F.col("entity") == "1001") & (F.col("isActive") == "Y")).select("name", "validTo", "rowID").collect()[0]
-
-        assert old_row["name"] == "Old Building One"
-        assert old_row["validTo"] is not None
-        assert new_row["name"] == "Building One Updated"
-        assert new_row["validTo"] is None
-        assert old_row["rowID"] != new_row["rowID"]
-
-        assert df.where((F.col("entity") == "1001") & (F.col("isActive") == "N")).count() == 1
-        assert df.where((F.col("entity") == "1001") & (F.col("isActive") == "Y")).count() == 1
-        assert result.metadata.insert_count == 0
-        assert result.metadata.update_count == 1
-
-    def test__listed_building_harmonisation_process__run__inserts_new_reference_and_keeps_existing_active_row(
-        self,
-    ):
+    def test__listed_building_harmonisation_process__run__with_existing_data(self):
         spark = PytestSparkSessionUtil().get_spark_session()
-
-        new_only_source = _standardised_df(spark).where(F.col("entity") == "1002")
-
-        source_data = {
-            "source_data": new_only_source,
-            "target_data": _existing_harmonised_df(spark),
-            "target_exists": True,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
+        test_case = "t_lbhp_r_wed"
+        listed_building = spark.createDataFrame(
+            [
+                _standardised_row(entity=1, name="Building One"),  # Should be updated
+                _standardised_row(entity=2, name="Building Two"),  # Should not be modified
+                _standardised_row(entity=3, name="Building Three"),  # Should be inserted
+            ],
+            schema=_standardised_schema(),
+        )
+        listed_building_table_name = f"{test_case}_listed_building"
+        self.write_existing_table(
+            spark,
+            listed_building,
+            listed_building_table_name,
+            "odw_standardised_db",
+            "odw-standardised",
+            listed_building_table_name,
+            "overwrite",
+        )
+        existing_harmonised_data = spark.createDataFrame(
+            (
+                _harmonised_row(entity=1, name="Building Old Name", rowID="4413ab3eda0f2857bfed7731cde4729c"),  # Should be updated
+                _harmonised_row(entity=2, name="Building Two", rowID="390b65b99f173831af260bef26accc90"),  # Should not be modified
+                _harmonised_row(entity=4, name="Building Four", rowID="someGuid"),  # Should be marked as inactive
+            ),
+            schema=_harmonised_schema(),
+        )
+        self.write_existing_table(
+            spark,
+            existing_harmonised_data,
+            listed_building_table_name,
+            "odw_harmonised_db",
+            "odw-harmonised",
+            listed_building_table_name,
+            "overwrite",
+        )
+        # Note: The existing notebook logic does not seem to handle deactivating existing records. I.e. We should expected entity=4
+        #       to be deactivated, but this does not seem to happen in the legacy notebook. This should be reviewed
+        # Generated by running the original notebook
+        expected_harmonised_listed_building = spark.createDataFrame(
+            [
+                _harmonised_row(entity=1, name="Building One", rowID="4413ab3eda0f2857bfed7731cde4729c"),  # Should be updated
+                _harmonised_row(entity=2, name="Building Two", rowID="390b65b99f173831af260bef26accc90"),  # Should not be modified
+                _harmonised_row(entity=3, name="Building Three", rowID="d31d10cb03b0a874acfc8bac9a1f0397"),  # Should be inserted
+                _harmonised_row(entity=4, name="Building Four", rowID="someGuid"),  # Should not be modified
+            ],
+            schema=_harmonised_schema(),
+        )
+        with mock.patch.object(ListedBuildingHarmonisationProcess, "OUTPUT_TABLE", listed_building_table_name):
             inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert df.where((F.col("reference") == "LB-001") & (F.col("isActive") == "Y")).count() == 1
-        assert df.where((F.col("reference") == "LB-002") & (F.col("isActive") == "Y")).count() == 1
-        assert result.metadata.insert_count == 1
-        assert result.metadata.update_count == 0
-
-    def test__listed_building_harmonisation_process__run__does_not_duplicate_identical_active_row(self):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _unchanged_standardised_df(spark),
-            "target_data": _existing_harmonised_df(spark),
-            "target_exists": True,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        entity_rows = df.where(F.col("entity") == "1001")
-        assert entity_rows.count() == 1
-        assert entity_rows.where(F.col("isActive") == "Y").count() == 1
-        assert entity_rows.where(F.col("isActive") == "N").count() == 0
-        assert result.metadata.insert_count == 0
-        assert result.metadata.update_count == 0
-
-    def test__listed_building_harmonisation_process__run__empty_source_returns_empty_output_on_initial_load(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _empty_standardised_df(spark),
-            "target_exists": False,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert df.count() == 0
-        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
-        assert result.metadata.insert_count == 0
-        assert result.metadata.update_count == 0
-
-    def test__listed_building_harmonisation_process__run__preserves_duplicate_source_rows_on_initial_load_like_legacy(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _duplicate_standardised_df(spark),
-            "target_exists": False,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        assert df.count() == 2
-        assert df.where(F.col("reference") == "LB-001").count() == 2
-        assert result.metadata.insert_count == 2
-        assert result.metadata.update_count == 0
-
-    def test__listed_building_harmonisation_process__run__same_reference_different_entity_follows_legacy_join_and_count_behaviour(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "source_data": _same_reference_different_entity_df(spark),
-            "target_data": _existing_harmonised_df(spark),
-            "target_exists": True,
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        # Legacy Notebook behaviour: the harmonisation merge/deactivation logic is keyed on entity, not reference
-        # So when entity 9999 reuses reference LB-001 existing entity 1001 remains untouched
-        assert df.where((F.col("entity") == "1001") & (F.col("isActive") == "Y")).count() == 1
-        assert df.where((F.col("entity") == "9999") & (F.col("isActive") == "Y")).count() == 1
-        assert result.metadata.insert_count == 0
-        assert result.metadata.update_count == 1
+            result = inst.run()
+            assert_etl_result_successful(result)
+            actual_table_data = spark.table(f"odw_harmonised_db.{listed_building_table_name}")
+            self.compare_harmonised_data(expected_harmonised_listed_building, actual_table_data)

--- a/odw/test/integration_test/etl/standardised/test_listed_building_standardisation_process.py
+++ b/odw/test/integration_test/etl/standardised/test_listed_building_standardisation_process.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
-from pyspark.sql.types import ArrayType, StringType, StructField, StructType
+from pyspark.sql.types import StringType, StructField, StructType
 from odw.core.etl.transformation.standardised.listed_building_standardisation_process import ListedBuildingStandardisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil

--- a/odw/test/integration_test/etl/standardised/test_listed_building_standardisation_process.py
+++ b/odw/test/integration_test/etl/standardised/test_listed_building_standardisation_process.py
@@ -5,12 +5,46 @@ from pyspark.sql.types import ArrayType, StringType, StructField, StructType
 from odw.core.etl.transformation.standardised.listed_building_standardisation_process import ListedBuildingStandardisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
 
 pytestmark = pytest.mark.xfail(reason="Standardisation logic not implemented yet")
 
 
-LISTED_BUILDING_OUTPUT_TABLE = "listed_building"
-LISTED_BUILDING_OUTLINE_OUTPUT_TABLE = "listed_building_outline"
+def _listed_building_rows():
+    return [
+        {
+            "dataset": "listed-building",
+            "end-date": None,
+            "entity": "1001",
+            "entry-date": "2024-01-01",
+            "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
+            "name": "Building One",
+            "organisation-entity": "org-1",
+            "point": "POINT(1 1)",
+            "prefix": "listed-building",
+            "reference": "LB-001",
+            "start-date": "2025-01-01",
+            "typology": "grade-ii",
+            "documentation-url": "https://example.com/lb-001",
+            "listed-building-grade": "II",
+        },
+        {
+            "dataset": "listed-building",
+            "end-date": "2025-01-01",
+            "entity": "1002",
+            "entry-date": "2024-02-01",
+            "geometry": None,
+            "name": "Building Two",
+            "organisation-entity": "org-2",
+            "point": None,
+            "prefix": "listed-building",
+            "reference": "LB-002",
+            "start-date": "2025-01-01",
+            "typology": "grade-i",
+            "documentation-url": None,
+            "listed-building-grade": "I",
+        },
+    ]
 
 
 def _listed_building_entity_schema():
@@ -32,6 +66,51 @@ def _listed_building_entity_schema():
             StructField("listed-building-grade", StringType(), True),
         ]
     )
+
+
+def _listed_building_outline_entity_rows():
+    return [
+        {
+            "address": "1 High Street",
+            "address-text": "1 High Street, Town",
+            "dataset": "listed-building-outline",
+            "document-url": "https://example.com/doc-1",
+            "documentation-url": "https://example.com/outline-1",
+            "end-date": None,
+            "entity": "2001",
+            "entry-date": "2025-01-01",
+            "geometry": "POLYGON((4 4,5 5,6 6,4 4))",
+            "listed-building": "1001",
+            "name": "Outline One",
+            "notes": "Some notes",
+            "organisation-entity": "org-1",
+            "point": "POINT(4 4)",
+            "prefix": "listed-building-outline",
+            "reference": "LBO-001",
+            "start-date": "2025-01-01",
+            "typology": "outline",
+        },
+        {
+            "address": None,
+            "address-text": None,
+            "dataset": "listed-building-outline",
+            "document-url": None,
+            "documentation-url": None,
+            "end-date": "2025-06-01",
+            "entity": "2002",
+            "entry-date": "2024-04-01",
+            "geometry": None,
+            "listed-building": "1002",
+            "name": "Outline Two",
+            "notes": None,
+            "organisation-entity": "org-2",
+            "point": None,
+            "prefix": "listed-building-outline",
+            "reference": "LBO-002",
+            "start-date": "2023-01-01",
+            "typology": "outline",
+        },
+    ]
 
 
 def _listed_building_outline_entity_schema():
@@ -59,662 +138,81 @@ def _listed_building_outline_entity_schema():
     )
 
 
-def _raw_listed_building_schema():
-    return StructType(
-        [
-            StructField(
-                "entities",
-                ArrayType(_listed_building_entity_schema()),
-                True,
-            )
-        ]
-    )
-
-
-def _raw_listed_building_outline_schema():
-    return StructType(
-        [
-            StructField(
-                "entities",
-                ArrayType(_listed_building_outline_entity_schema()),
-                True,
-            )
-        ]
-    )
-
-
-def _listed_building_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                [
-                    {
-                        "dataset": "listed-building",
-                        "end-date": None,
-                        "entity": "1001",
-                        "entry-date": "2024-01-01",
-                        "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
-                        "name": "Building One",
-                        "organisation-entity": "org-1",
-                        "point": "POINT(1 1)",
-                        "prefix": "listed-building",
-                        "reference": "LB-001",
-                        "start-date": "2020-01-01",
-                        "typology": "grade-ii",
-                        "documentation-url": "https://example.com/lb-001",
-                        "listed-building-grade": "II",
-                    },
-                    {
-                        "dataset": "listed-building",
-                        "end-date": "2025-01-01",
-                        "entity": "1002",
-                        "entry-date": "2024-02-01",
-                        "geometry": None,
-                        "name": "Building Two",
-                        "organisation-entity": "org-2",
-                        "point": None,
-                        "prefix": "listed-building",
-                        "reference": "LB-002",
-                        "start-date": "2021-01-01",
-                        "typology": "grade-i",
-                        "documentation-url": None,
-                        "listed-building-grade": "I",
-                    },
-                ],
-            )
-        ],
-        schema=_raw_listed_building_schema(),
-    )
-
-
-def _listed_building_outline_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                [
-                    {
-                        "address": "1 High Street",
-                        "address-text": "1 High Street, Town",
-                        "dataset": "listed-building-outline",
-                        "document-url": "https://example.com/doc-1",
-                        "documentation-url": "https://example.com/outline-1",
-                        "end-date": None,
-                        "entity": "2001",
-                        "entry-date": "2024-03-01",
-                        "geometry": "POLYGON((4 4,5 5,6 6,4 4))",
-                        "listed-building": "1001",
-                        "name": "Outline One",
-                        "notes": "Some notes",
-                        "organisation-entity": "org-1",
-                        "point": "POINT(4 4)",
-                        "prefix": "listed-building-outline",
-                        "reference": "LBO-001",
-                        "start-date": "2022-01-01",
-                        "typology": "outline",
-                    },
-                    {
-                        "address": None,
-                        "address-text": None,
-                        "dataset": "listed-building-outline",
-                        "document-url": None,
-                        "documentation-url": None,
-                        "end-date": "2025-06-01",
-                        "entity": "2002",
-                        "entry-date": "2024-04-01",
-                        "geometry": None,
-                        "listed-building": "1002",
-                        "name": "Outline Two",
-                        "notes": None,
-                        "organisation-entity": "org-2",
-                        "point": None,
-                        "prefix": "listed-building-outline",
-                        "reference": "LBO-002",
-                        "start-date": "2023-01-01",
-                        "typology": "outline",
-                    },
-                ],
-            )
-        ],
-        schema=_raw_listed_building_outline_schema(),
-    )
-
-
-def _listed_building_multirow_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                [
-                    {
-                        "dataset": "listed-building",
-                        "end-date": None,
-                        "entity": "1001",
-                        "entry-date": "2024-01-01",
-                        "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
-                        "name": "Building One",
-                        "organisation-entity": "org-1",
-                        "point": "POINT(1 1)",
-                        "prefix": "listed-building",
-                        "reference": "LB-001",
-                        "start-date": "2020-01-01",
-                        "typology": "grade-ii",
-                        "documentation-url": "https://example.com/lb-001",
-                        "listed-building-grade": "II",
-                    },
-                ],
-            ),
-            (
-                [
-                    {
-                        "dataset": "listed-building",
-                        "end-date": None,
-                        "entity": "1002",
-                        "entry-date": "2024-02-01",
-                        "geometry": None,
-                        "name": "Building Two",
-                        "organisation-entity": "org-2",
-                        "point": None,
-                        "prefix": "listed-building",
-                        "reference": "LB-002",
-                        "start-date": "2021-01-01",
-                        "typology": "grade-i",
-                        "documentation-url": None,
-                        "listed-building-grade": "I",
-                    },
-                    {
-                        "dataset": "listed-building",
-                        "end-date": None,
-                        "entity": "1003",
-                        "entry-date": "2024-03-01",
-                        "geometry": "POLYGON((7 7,8 8,9 9,7 7))",
-                        "name": "Building Three",
-                        "organisation-entity": "org-3",
-                        "point": "POINT(7 7)",
-                        "prefix": "listed-building",
-                        "reference": "LB-003",
-                        "start-date": "2022-01-01",
-                        "typology": "grade-ii-star",
-                        "documentation-url": "https://example.com/lb-003",
-                        "listed-building-grade": "II*",
-                    },
-                ],
-            ),
-        ],
-        schema=_raw_listed_building_schema(),
-    )
-
-
-def _listed_building_outline_multirow_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                [
-                    {
-                        "address": "1 High Street",
-                        "address-text": "1 High Street, Town",
-                        "dataset": "listed-building-outline",
-                        "document-url": "https://example.com/doc-1",
-                        "documentation-url": "https://example.com/outline-1",
-                        "end-date": None,
-                        "entity": "2001",
-                        "entry-date": "2024-03-01",
-                        "geometry": "POLYGON((4 4,5 5,6 6,4 4))",
-                        "listed-building": "1001",
-                        "name": "Outline One",
-                        "notes": "Some notes",
-                        "organisation-entity": "org-1",
-                        "point": "POINT(4 4)",
-                        "prefix": "listed-building-outline",
-                        "reference": "LBO-001",
-                        "start-date": "2022-01-01",
-                        "typology": "outline",
-                    },
-                ],
-            ),
-            (
-                [
-                    {
-                        "address": None,
-                        "address-text": None,
-                        "dataset": "listed-building-outline",
-                        "document-url": None,
-                        "documentation-url": None,
-                        "end-date": "2025-06-01",
-                        "entity": "2002",
-                        "entry-date": "2024-04-01",
-                        "geometry": None,
-                        "listed-building": "1002",
-                        "name": "Outline Two",
-                        "notes": None,
-                        "organisation-entity": "org-2",
-                        "point": None,
-                        "prefix": "listed-building-outline",
-                        "reference": "LBO-002",
-                        "start-date": "2023-01-01",
-                        "typology": "outline",
-                    },
-                    {
-                        "address": "3 Low Street",
-                        "address-text": "3 Low Street, Village",
-                        "dataset": "listed-building-outline",
-                        "document-url": "https://example.com/doc-3",
-                        "documentation-url": "https://example.com/outline-3",
-                        "end-date": None,
-                        "entity": "2003",
-                        "entry-date": "2024-05-01",
-                        "geometry": "POLYGON((10 10,11 11,12 12,10 10))",
-                        "listed-building": "1003",
-                        "name": "Outline Three",
-                        "notes": "Another outline",
-                        "organisation-entity": "org-3",
-                        "point": "POINT(10 10)",
-                        "prefix": "listed-building-outline",
-                        "reference": "LBO-003",
-                        "start-date": "2024-01-01",
-                        "typology": "outline",
-                    },
-                ],
-            ),
-        ],
-        schema=_raw_listed_building_outline_schema(),
-    )
-
-
-def _empty_listed_building_df(spark):
-    return spark.createDataFrame([], schema=_raw_listed_building_schema())
-
-
-def _empty_listed_building_outline_df(spark):
-    return spark.createDataFrame([], schema=_raw_listed_building_outline_schema())
-
-
-def _listed_building_empty_entities_df(spark):
-    return spark.createDataFrame(
-        [
-            ([],),
-        ],
-        schema=_raw_listed_building_schema(),
-    )
-
-
-def _listed_building_outline_empty_entities_df(spark):
-    return spark.createDataFrame(
-        [
-            ([],),
-        ],
-        schema=_raw_listed_building_outline_schema(),
-    )
-
-
-def _duplicate_listed_building_df(spark):
-    return spark.createDataFrame(
-        [
-            (
-                [
-                    {
-                        "dataset": "listed-building",
-                        "end-date": None,
-                        "entity": "1001",
-                        "entry-date": "2024-01-01",
-                        "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
-                        "name": "Building One",
-                        "organisation-entity": "org-1",
-                        "point": "POINT(1 1)",
-                        "prefix": "listed-building",
-                        "reference": "LB-001",
-                        "start-date": "2020-01-01",
-                        "typology": "grade-ii",
-                        "documentation-url": "https://example.com/lb-001",
-                        "listed-building-grade": "II",
-                    },
-                    {
-                        "dataset": "listed-building",
-                        "end-date": None,
-                        "entity": "1001",
-                        "entry-date": "2024-01-01",
-                        "geometry": "POLYGON((1 1,2 2,3 3,1 1))",
-                        "name": "Building One",
-                        "organisation-entity": "org-1",
-                        "point": "POINT(1 1)",
-                        "prefix": "listed-building",
-                        "reference": "LB-001",
-                        "start-date": "2020-01-01",
-                        "typology": "grade-ii",
-                        "documentation-url": "https://example.com/lb-001",
-                        "listed-building-grade": "II",
-                    },
-                ],
-            )
-        ],
-        schema=_raw_listed_building_schema(),
-    )
-
-
 class TestListedBuildingStandardisationProcess(ETLTestCase):
-    def test__listed_building_standardisation_process__run__writes_both_outputs_end_to_end_like_legacy(
-        self,
-    ):
+    def assert_run(self, test_case: str):
         spark = PytestSparkSessionUtil().get_spark_session()
+        listed_building_table_name = f"{test_case}_listed_building"
+        listed_building_outline_table_name = f"{listed_building_table_name}_outline"
+        data_folder = "2025-01-01"
+        # Write raw listed building data
+        listed_building_file_name = f"{listed_building_table_name}.json"
+        listed_building = [{"entities": _listed_building_rows()}]
+        self.write_json(listed_building, ["odw-raw", "ListedBuildings", data_folder, listed_building_file_name])
+        # Write raw listed building outline data
+        listed_building_outline_file_name = f"{listed_building_outline_table_name}.json"
+        listed_building_outline = [{"entities": _listed_building_outline_entity_rows()}]
+        self.write_json(listed_building_outline, ["odw-raw", "ListedBuildings", data_folder, listed_building_outline_file_name])
 
-        source_data = {
-            "listed_building_data": _listed_building_df(spark),
-            "listed_building_outline_data": _listed_building_outline_df(spark),
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-
-        assert LISTED_BUILDING_OUTPUT_TABLE in data_to_write
-        assert LISTED_BUILDING_OUTLINE_OUTPUT_TABLE in data_to_write
-
-        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
-        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
-
-        assert listed_building_df.count() == 2
-        assert listed_building_outline_df.count() == 2
-
-        assert data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["write_mode"] == "overwrite"
-        assert data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["write_mode"] == "overwrite"
-
-        assert listed_building_df.columns == [
-            "dataset",
-            "end-date",
-            "entity",
-            "entry-date",
-            "geometry",
-            "name",
-            "organisation-entity",
-            "point",
-            "prefix",
-            "reference",
-            "start-date",
-            "typology",
-            "documentation-url",
-            "listed-building-grade",
-        ]
-
-        assert listed_building_outline_df.columns == [
-            "address",
-            "address-text",
-            "dataset",
-            "document-url",
-            "documentation-url",
-            "end-date",
-            "entity",
-            "entry-date",
-            "geometry",
-            "listed-building",
-            "name",
-            "notes",
-            "organisation-entity",
-            "point",
-            "prefix",
-            "reference",
-            "start-date",
-            "typology",
-        ]
-
-    def test__listed_building_standardisation_process__run__preserves_flattened_values_and_nulls_like_legacy(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "listed_building_data": _listed_building_df(spark),
-            "listed_building_outline_data": _listed_building_outline_df(spark),
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-
-        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
-        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
-
-        lb_row = (
-            listed_building_df.where("entity = '1001'")
-            .select(
-                "name",
-                "reference",
-                "listed-building-grade",
-                "geometry",
-                "documentation-url",
-            )
-            .collect()[0]
+        expected_standardised_listed_bulding = spark.createDataFrame(_listed_building_rows(), schema=_listed_building_entity_schema())
+        expected_standardised_listed_bulding_outline = spark.createDataFrame(
+            _listed_building_outline_entity_rows(), schema=_listed_building_outline_entity_schema()
         )
-        lb_null_row = listed_building_df.where("entity = '1002'").select("geometry", "point", "documentation-url").collect()[0]
-        lbo_row = (
-            listed_building_outline_df.where("entity = '2001'")
-            .select("address", "listed-building", "reference", "document-url", "notes")
-            .collect()[0]
+        with mock.patch.object(ListedBuildingStandardisationProcess, "OUTPUT_TABLE", listed_building_table_name):
+            inst = ListedBuildingStandardisationProcess(spark)
+            result = inst.run()
+            assert_etl_result_successful(result)
+            actual_standardised_listed_building = spark.table(f"odw_standardised_db.{listed_building_table_name}")
+            assert_dataframes_equal(expected_standardised_listed_bulding, actual_standardised_listed_building)
+            actual_standardised_listed_building_outline = spark.table(f"odw_standardised_db.{listed_building_outline_table_name}")
+            assert_dataframes_equal(expected_standardised_listed_bulding_outline, actual_standardised_listed_building_outline)
+
+    def test__listed_building_standardisation_process__run__with_no_existing_data(self):
+        """
+        - Given I have raw listed building and listed building outline data
+        - When I call ListedBuildingStandardisationProcess.run
+        - Then the listed_building and listed_building_outline tables should be created in the standardised layer
+        """
+        self.assert_run("t_lbsp_r_wned")
+
+    def test__listed_building_standardisation_process__run__with_existing_data(self):
+        """
+        - Given I have raw listed building and listed building outline data and I have some existing standardised data
+        - When I call ListedBuildingStandardisationProcess.run
+        - Then the listed_building and listed_building_outline tables should overwrite the existing standardised data
+        """
+        spark = PytestSparkSessionUtil().get_spark_session()
+        test_case = "t_lbsp_r_wned"
+        listed_building_table_name = f"{test_case}_listed_building"
+        listed_building_outline_table_name = f"{listed_building_table_name}_outline"
+        existing_standardised_listed_bulding = spark.createDataFrame(
+            (
+                dict(),  # A row that is all null
+            ),
+            schema=_listed_building_entity_schema(),
         )
-        lbo_null_row = (
-            listed_building_outline_df.where("entity = '2002'")
-            .select(
-                "address",
-                "address-text",
-                "document-url",
-                "documentation-url",
-                "geometry",
-                "notes",
-                "point",
-            )
-            .collect()[0]
+        existing_standardised_listed_bulding.show()
+        self.write_existing_table(
+            spark,
+            existing_standardised_listed_bulding,
+            listed_building_table_name,
+            "odw_standardised_db",
+            "odw-standardised",
+            listed_building_table_name,
+            "overwrite",
         )
-
-        assert lb_row["name"] == "Building One"
-        assert lb_row["reference"] == "LB-001"
-        assert lb_row["listed-building-grade"] == "II"
-        assert lb_row["geometry"] == "POLYGON((1 1,2 2,3 3,1 1))"
-        assert lb_row["documentation-url"] == "https://example.com/lb-001"
-
-        assert lb_null_row["geometry"] is None
-        assert lb_null_row["point"] is None
-        assert lb_null_row["documentation-url"] is None
-
-        assert lbo_row["address"] == "1 High Street"
-        assert lbo_row["listed-building"] == "1001"
-        assert lbo_row["reference"] == "LBO-001"
-        assert lbo_row["document-url"] == "https://example.com/doc-1"
-        assert lbo_row["notes"] == "Some notes"
-
-        assert lbo_null_row["address"] is None
-        assert lbo_null_row["address-text"] is None
-        assert lbo_null_row["document-url"] is None
-        assert lbo_null_row["documentation-url"] is None
-        assert lbo_null_row["geometry"] is None
-        assert lbo_null_row["notes"] is None
-        assert lbo_null_row["point"] is None
-
-    def test__listed_building_standardisation_process__run__explodes_entities_from_multiple_raw_rows(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "listed_building_data": _listed_building_multirow_df(spark),
-            "listed_building_outline_data": _listed_building_outline_multirow_df(spark),
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
-        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
-
-        assert listed_building_df.count() == 3
-        assert listed_building_outline_df.count() == 3
-
-        listed_building_entities = {row["entity"] for row in listed_building_df.select("entity").collect()}
-        listed_building_outline_entities = {row["entity"] for row in listed_building_outline_df.select("entity").collect()}
-
-        assert listed_building_entities == {"1001", "1002", "1003"}
-        assert listed_building_outline_entities == {"2001", "2002", "2003"}
-
-    def test__listed_building_standardisation_process__run__empty_entities_arrays_return_empty_outputs(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "listed_building_data": _listed_building_empty_entities_df(spark),
-            "listed_building_outline_data": _listed_building_outline_empty_entities_df(spark),
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
-        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
-
-        assert listed_building_df.count() == 0
-        assert listed_building_outline_df.count() == 0
-
-    def test__listed_building_standardisation_process__run__empty_input_dataframes_return_empty_outputs(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "listed_building_data": _empty_listed_building_df(spark),
-            "listed_building_outline_data": _empty_listed_building_outline_df(spark),
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
-        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
-
-        assert listed_building_df.count() == 0
-        assert listed_building_outline_df.count() == 0
-        assert data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["write_mode"] == "overwrite"
-        assert data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["write_mode"] == "overwrite"
-
-    def test__listed_building_standardisation_process__run__one_source_empty_still_writes_the_other_output(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "listed_building_data": _listed_building_df(spark),
-            "listed_building_outline_data": _empty_listed_building_outline_df(spark),
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
-        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
-
-        assert listed_building_df.count() == 2
-        assert listed_building_outline_df.count() == 0
-
-    def test__listed_building_standardisation_process__run__preserves_duplicate_entities_like_legacy(
-        self,
-    ):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = {
-            "listed_building_data": _duplicate_listed_building_df(spark),
-            "listed_building_outline_data": _empty_listed_building_outline_df(spark),
-        }
-
-        with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
-        ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
-
-        assert listed_building_df.count() == 2
-        assert listed_building_df.where("entity = '1001'").count() == 2
+        existing_standardised_listed_bulding_outline = spark.createDataFrame(
+            (
+                dict(),  # A row that is all null
+            ),
+            schema=_listed_building_outline_entity_schema(),
+        )
+        self.write_existing_table(
+            spark,
+            existing_standardised_listed_bulding_outline,
+            listed_building_outline_table_name,
+            "odw_standardised_db",
+            "odw-standardised",
+            listed_building_outline_table_name,
+            "overwrite",
+        )
+        self.assert_run(test_case)

--- a/odw/test/unit_test/etl/curated/test_listed_building_curated_process.py
+++ b/odw/test/unit_test/etl/curated/test_listed_building_curated_process.py
@@ -131,9 +131,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
         rows = df.collect()
@@ -158,9 +157,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -182,9 +180,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -207,9 +204,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -238,9 +234,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -261,9 +256,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -293,9 +287,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -318,9 +311,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
         row = df.where(F.col("entity") == 1001).collect()[0]
@@ -343,9 +335,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -379,9 +370,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -435,9 +425,8 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil"):
-            inst = ListedBuildingCuratedProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingCuratedProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -518,20 +507,13 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
+        inst = ListedBuildingCuratedProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -585,20 +567,13 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": True,
         }
 
+        inst = ListedBuildingCuratedProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -649,20 +624,13 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": True,
         }
 
+        inst = ListedBuildingCuratedProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -724,20 +692,13 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
+        inst = ListedBuildingCuratedProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -755,20 +716,13 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
             "target_exists": False,
         }
 
+        inst = ListedBuildingCuratedProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingCuratedProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]

--- a/odw/test/unit_test/etl/curated/test_listed_building_curated_process.py
+++ b/odw/test/unit_test/etl/curated/test_listed_building_curated_process.py
@@ -445,3 +445,335 @@ class TestListedBuildingCuratedProcess(SparkTestCase):
         assert df.where(F.col("entity") == 1001).collect()[0]["name"] == "Building One Updated"
         assert result.metadata.insert_count == 0
         assert result.metadata.update_count == 1
+
+    def test__listed_building_curated_process__run__initial_load_matches_legacy(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "II",
+                        "Building One",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "2025-01-01",
+                        "row-1",
+                        None,
+                        "Y",
+                    ),
+                    (
+                        "listed-building",
+                        None,
+                        "1002",
+                        "2024-02-01",
+                        None,
+                        "I",
+                        "Building Two",
+                        "org-2",
+                        None,
+                        "listed-building",
+                        "LB-002",
+                        "2021-01-01",
+                        "grade-i",
+                        None,
+                        "2025-01-01",
+                        "row-2",
+                        None,
+                        "Y",
+                    ),
+                    (
+                        "listed-building",
+                        None,
+                        "1003",
+                        "2024-03-01",
+                        None,
+                        "II*",
+                        "Inactive Building",
+                        "org-3",
+                        None,
+                        "listed-building",
+                        "LB-003",
+                        "2022-01-01",
+                        "grade-ii-star",
+                        None,
+                        "2025-01-01",
+                        "row-3",
+                        None,
+                        "N",
+                    ),
+                ],
+                schema=_harmonised_schema(),
+            ),
+            "target_exists": False,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingCuratedProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
+        assert df.count() == 2
+        assert result.metadata.insert_count == 2
+        assert result.metadata.update_count == 0
+
+        assert df.columns == ["entity", "reference", "name", "listedBuildingGrade"]
+
+        entity_ids = {row["entity"] for row in df.select("entity").collect()}
+        assert entity_ids == {1001, 1002}
+        assert df.where(F.col("entity") == 1003).count() == 0
+
+    def test__listed_building_curated_process__run__updates_existing_entity_when_non_key_fields_change(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "II",
+                        "Building One Updated",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "2025-01-01",
+                        "row-9",
+                        None,
+                        "Y",
+                    ),
+                ],
+                schema=_harmonised_schema(),
+            ),
+            "target_data": spark.createDataFrame(
+                [
+                    (1001, "LB-001", "Building One", "II"),
+                ],
+                schema=_curated_schema(),
+            ),
+            "target_exists": True,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingCuratedProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        row = df.where(F.col("entity") == 1001).collect()[0]
+
+        assert row["name"] == "Building One Updated"
+        assert result.metadata.insert_count == 0
+        assert result.metadata.update_count == 1
+
+    def test__listed_building_curated_process__run__does_not_duplicate_identical_existing_entity(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        identical_source = spark.createDataFrame(
+            [
+                (
+                    "listed-building",
+                    None,
+                    "1001",
+                    "2024-01-01",
+                    "POLYGON((1 1,2 2,3 3,1 1))",
+                    "II",
+                    "Building One",
+                    "org-1",
+                    "POINT(1 1)",
+                    "listed-building",
+                    "LB-001",
+                    "2020-01-01",
+                    "grade-ii",
+                    "https://example.com/lb-001",
+                    "2025-01-01",
+                    "row-1",
+                    None,
+                    "Y",
+                ),
+            ],
+            schema=_harmonised_schema(),
+        )
+
+        source_data = {
+            "source_data": identical_source,
+            "target_data": spark.createDataFrame(
+                [
+                    (1001, "LB-001", "Building One", "II"),
+                ],
+                schema=_curated_schema(),
+            ),
+            "target_exists": True,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingCuratedProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert df.count() == 1
+        assert df.where(F.col("entity") == 1001).count() == 1
+        assert result.metadata.insert_count == 0
+        assert result.metadata.update_count == 0
+
+    def test__listed_building_curated_process__run__drops_duplicate_source_rows(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "II",
+                        "Building One",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "2025-01-01",
+                        "row-1",
+                        None,
+                        "Y",
+                    ),
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "II",
+                        "Building One",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "2025-01-01",
+                        "row-2",
+                        None,
+                        "Y",
+                    ),
+                ],
+                schema=_harmonised_schema(),
+            ),
+            "target_exists": False,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingCuratedProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert df.count() == 1
+        assert df.where(F.col("entity") == 1001).count() == 1
+        assert result.metadata.insert_count == 1
+        assert result.metadata.update_count == 0
+
+    def test__listed_building_curated_process__run__empty_source_returns_empty_output(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame([], schema=_harmonised_schema()),
+            "target_exists": False,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.curated.listed_building_curated_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingCuratedProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
+        assert df.count() == 0
+        assert result.metadata.insert_count == 0
+        assert result.metadata.update_count == 0

--- a/odw/test/unit_test/etl/harmonised/test_listed_building_harmonisation_process.py
+++ b/odw/test/unit_test/etl/harmonised/test_listed_building_harmonisation_process.py
@@ -171,9 +171,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
         row = df.collect()[0]
@@ -203,9 +202,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -245,9 +243,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
         row = df.select("rowID").collect()[0]
@@ -277,9 +274,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
         row = df.select("rowID").collect()[0]
@@ -304,9 +300,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -328,9 +323,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -357,9 +351,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -394,9 +387,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -441,9 +433,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -476,9 +467,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -509,9 +499,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, result = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, result = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
 
@@ -540,9 +529,8 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
-        with mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil"):
-            inst = ListedBuildingHarmonisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingHarmonisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
         rows = df.select("name", "rowID").orderBy("name").collect()
@@ -595,20 +583,13 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
+        inst = ListedBuildingHarmonisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -701,20 +682,13 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
+        inst = ListedBuildingHarmonisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -782,20 +756,13 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
+        inst = ListedBuildingHarmonisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -834,20 +801,13 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
+        inst = ListedBuildingHarmonisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -869,20 +829,13 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
+        inst = ListedBuildingHarmonisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -938,20 +891,13 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": False,
         }
 
+        inst = ListedBuildingHarmonisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]
@@ -992,20 +938,13 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
             "target_exists": True,
         }
 
+        inst = ListedBuildingHarmonisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingHarmonisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                result = inst.run()
+            result = inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         df = data_to_write[inst.OUTPUT_TABLE]["data"]

--- a/odw/test/unit_test/etl/harmonised/test_listed_building_harmonisation_process.py
+++ b/odw/test/unit_test/etl/harmonised/test_listed_building_harmonisation_process.py
@@ -123,6 +123,34 @@ def _expected_rowid_for_standardised_row(row):
     return hashlib.md5(joined.encode("utf-8")).hexdigest()
 
 
+def _existing_harmonised_df(spark):
+    return spark.createDataFrame(
+        [
+            (
+                "listed-building",
+                None,
+                "1001",
+                "2024-01-01",
+                "POLYGON((1 1,2 2,3 3,1 1))",
+                "II",
+                "Old Building One",
+                "org-1",
+                "POINT(1 1)",
+                "listed-building",
+                "LB-001",
+                "2020-01-01",
+                "grade-ii",
+                "https://example.com/lb-001",
+                "2025-01-01",
+                "old-row-id",
+                None,
+                "Y",
+            ),
+        ],
+        schema=_harmonised_schema(),
+    )
+
+
 class TestListedBuildingHarmonisationProcess(SparkTestCase):
     def test__listed_building_harmonisation_process__get_name__returns_expected_name(self):
         spark = PytestSparkSessionUtil().get_spark_session()
@@ -522,3 +550,469 @@ class TestListedBuildingHarmonisationProcess(SparkTestCase):
         assert rows[0]["rowID"]
         assert rows[1]["rowID"]
         assert rows[0]["rowID"] != rows[1]["rowID"]
+
+    def test__listed_building_harmonisation_process__run__initial_load_matches_legacy(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "Building One",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "II",
+                    ),
+                    (
+                        "listed-building",
+                        None,
+                        "1002",
+                        "2024-02-01",
+                        None,
+                        "Building Two",
+                        "org-2",
+                        None,
+                        "listed-building",
+                        "LB-002",
+                        "2021-01-01",
+                        "grade-i",
+                        None,
+                        "I",
+                    ),
+                ],
+                schema=_standardised_schema(),
+            ),
+            "target_exists": False,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingHarmonisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert df.count() == 2
+        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
+        assert result.metadata.insert_count == 2
+        assert result.metadata.update_count == 0
+
+        expected_columns = [
+            "dataset",
+            "endDate",
+            "entity",
+            "entryDate",
+            "geometry",
+            "listedBuildingGrade",
+            "name",
+            "organisationEntity",
+            "point",
+            "prefix",
+            "reference",
+            "startDate",
+            "typology",
+            "documentationUrl",
+            "dateReceived",
+            "rowID",
+            "validTo",
+            "isActive",
+        ]
+        assert df.columns == expected_columns
+
+        row = (
+            df.where(F.col("entity") == "1001")
+            .select(
+                "dataset",
+                "endDate",
+                "entryDate",
+                "listedBuildingGrade",
+                "organisationEntity",
+                "documentationUrl",
+                "dateReceived",
+                "isActive",
+                "validTo",
+                "rowID",
+            )
+            .collect()[0]
+        )
+
+        assert row["dataset"] == "listed-building"
+        assert row["endDate"] is None
+        assert row["entryDate"] == "2024-01-01"
+        assert row["listedBuildingGrade"] == "II"
+        assert row["organisationEntity"] == "org-1"
+        assert row["documentationUrl"] == "https://example.com/lb-001"
+        assert row["dateReceived"] is not None
+        assert row["isActive"] == "Y"
+        assert row["validTo"] is None
+        assert row["rowID"]
+
+        assert df.where(F.col("dateReceived").isNull()).count() == 0
+
+    def test__listed_building_harmonisation_process__run__deactivates_old_version_and_inserts_new_version_like_legacy(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "Building One Updated",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "II",
+                    ),
+                ],
+                schema=_standardised_schema(),
+            ),
+            "target_data": _existing_harmonised_df(spark),
+            "target_exists": True,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingHarmonisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        old_row = df.where((F.col("entity") == "1001") & (F.col("isActive") == "N")).select("name", "validTo", "rowID").collect()[0]
+        new_row = df.where((F.col("entity") == "1001") & (F.col("isActive") == "Y")).select("name", "validTo", "rowID").collect()[0]
+
+        assert old_row["name"] == "Old Building One"
+        assert old_row["validTo"] is not None
+        assert new_row["name"] == "Building One Updated"
+        assert new_row["validTo"] is None
+        assert old_row["rowID"] != new_row["rowID"]
+
+        assert df.where((F.col("entity") == "1001") & (F.col("isActive") == "N")).count() == 1
+        assert df.where((F.col("entity") == "1001") & (F.col("isActive") == "Y")).count() == 1
+        assert result.metadata.insert_count == 0
+        assert result.metadata.update_count == 1
+
+    def test__listed_building_harmonisation_process__run__inserts_new_reference_and_keeps_existing_active_row(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        new_only_source = spark.createDataFrame(
+            [
+                (
+                    "listed-building",
+                    None,
+                    "1001",
+                    "2024-01-01",
+                    "POLYGON((1 1,2 2,3 3,1 1))",
+                    "Building One",
+                    "org-1",
+                    "POINT(1 1)",
+                    "listed-building",
+                    "LB-001",
+                    "2020-01-01",
+                    "grade-ii",
+                    "https://example.com/lb-001",
+                    "II",
+                ),
+                (
+                    "listed-building",
+                    None,
+                    "1002",
+                    "2024-02-01",
+                    None,
+                    "Building Two",
+                    "org-2",
+                    None,
+                    "listed-building",
+                    "LB-002",
+                    "2021-01-01",
+                    "grade-i",
+                    None,
+                    "I",
+                ),
+            ],
+            schema=_standardised_schema(),
+        ).where(F.col("entity") == "1002")
+
+        source_data = {
+            "source_data": new_only_source,
+            "target_data": _existing_harmonised_df(spark),
+            "target_exists": True,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingHarmonisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert df.where((F.col("reference") == "LB-001") & (F.col("isActive") == "Y")).count() == 1
+        assert df.where((F.col("reference") == "LB-002") & (F.col("isActive") == "Y")).count() == 1
+        assert result.metadata.insert_count == 1
+        assert result.metadata.update_count == 0
+
+    def test__listed_building_harmonisation_process__run__does_not_duplicate_identical_active_row(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "Old Building One",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "II",
+                    ),
+                ],
+                schema=_standardised_schema(),
+            ),
+            "target_data": _existing_harmonised_df(spark),
+            "target_exists": True,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingHarmonisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        entity_rows = df.where(F.col("entity") == "1001")
+        assert entity_rows.count() == 1
+        assert entity_rows.where(F.col("isActive") == "Y").count() == 1
+        assert entity_rows.where(F.col("isActive") == "N").count() == 0
+        assert result.metadata.insert_count == 0
+        assert result.metadata.update_count == 0
+
+    def test__listed_building_harmonisation_process__run__empty_source_returns_empty_output_on_initial_load(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame([], schema=_standardised_schema()),
+            "target_exists": False,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingHarmonisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert df.count() == 0
+        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
+        assert result.metadata.insert_count == 0
+        assert result.metadata.update_count == 0
+
+    def test__listed_building_harmonisation_process__run__preserves_duplicate_source_rows_on_initial_load_like_legacy(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "Building One",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "II",
+                    ),
+                    (
+                        "listed-building",
+                        None,
+                        "1001",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "Building One",
+                        "org-1",
+                        "POINT(1 1)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-001",
+                        "II",
+                    ),
+                ],
+                schema=_standardised_schema(),
+            ),
+            "target_exists": False,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingHarmonisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        assert df.count() == 2
+        assert df.where(F.col("reference") == "LB-001").count() == 2
+        assert result.metadata.insert_count == 2
+        assert result.metadata.update_count == 0
+
+    def test__listed_building_harmonisation_process__run__same_reference_different_entity_follows_legacy_join_and_count_behaviour(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "source_data": spark.createDataFrame(
+                [
+                    (
+                        "listed-building",
+                        None,
+                        "9999",
+                        "2024-01-01",
+                        "POLYGON((1 1,2 2,3 3,1 1))",
+                        "Different Entity Same Reference",
+                        "org-9",
+                        "POINT(9 9)",
+                        "listed-building",
+                        "LB-001",
+                        "2020-01-01",
+                        "grade-ii",
+                        "https://example.com/lb-999",
+                        "II",
+                    ),
+                ],
+                schema=_standardised_schema(),
+            ),
+            "target_data": _existing_harmonised_df(spark),
+            "target_exists": True,
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.harmonised.listed_building_harmonisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingHarmonisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        # Legacy Notebook behaviour: the harmonisation merge/deactivation logic is keyed on entity, not reference
+        # So when entity 9999 reuses reference LB-001 existing entity 1001 remains untouched
+        assert df.where((F.col("entity") == "1001") & (F.col("isActive") == "Y")).count() == 1
+        assert df.where((F.col("entity") == "9999") & (F.col("isActive") == "Y")).count() == 1
+        assert result.metadata.insert_count == 0
+        assert result.metadata.update_count == 1

--- a/odw/test/unit_test/etl/standardised/test_listed_building_standardisation_process.py
+++ b/odw/test/unit_test/etl/standardised/test_listed_building_standardisation_process.py
@@ -739,3 +739,332 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
 
         assert listed_building_df.count() == 2
         assert listed_building_df.where("entity = '1001'").count() == 2
+
+    def test__listed_building_standardisation_process__run__writes_both_outputs_end_to_end_like_legacy(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "listed_building_data": _listed_building_raw_df(spark),
+            "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingStandardisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+
+        assert LISTED_BUILDING_OUTPUT_TABLE in data_to_write
+        assert LISTED_BUILDING_OUTLINE_OUTPUT_TABLE in data_to_write
+
+        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
+        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
+
+        assert listed_building_df.count() == 2
+        assert listed_building_outline_df.count() == 2
+
+        assert data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["write_mode"] == "overwrite"
+        assert data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["write_mode"] == "overwrite"
+
+        assert listed_building_df.columns == [
+            "dataset",
+            "end-date",
+            "entity",
+            "entry-date",
+            "geometry",
+            "name",
+            "organisation-entity",
+            "point",
+            "prefix",
+            "reference",
+            "start-date",
+            "typology",
+            "documentation-url",
+            "listed-building-grade",
+        ]
+
+        assert listed_building_outline_df.columns == [
+            "address",
+            "address-text",
+            "dataset",
+            "document-url",
+            "documentation-url",
+            "end-date",
+            "entity",
+            "entry-date",
+            "geometry",
+            "listed-building",
+            "name",
+            "notes",
+            "organisation-entity",
+            "point",
+            "prefix",
+            "reference",
+            "start-date",
+            "typology",
+        ]
+
+    def test__listed_building_standardisation_process__run__preserves_flattened_values_and_nulls_like_legacy(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "listed_building_data": _listed_building_raw_df(spark),
+            "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingStandardisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+
+        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
+        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
+
+        lb_row = (
+            listed_building_df.where("entity = '1001'")
+            .select(
+                "name",
+                "reference",
+                "listed-building-grade",
+                "geometry",
+                "documentation-url",
+            )
+            .collect()[0]
+        )
+        lb_null_row = listed_building_df.where("entity = '1002'").select("geometry", "point", "documentation-url").collect()[0]
+        lbo_row = (
+            listed_building_outline_df.where("entity = '2001'")
+            .select("address", "listed-building", "reference", "document-url", "notes")
+            .collect()[0]
+        )
+        lbo_null_row = (
+            listed_building_outline_df.where("entity = '2002'")
+            .select(
+                "address",
+                "address-text",
+                "document-url",
+                "documentation-url",
+                "geometry",
+                "notes",
+                "point",
+            )
+            .collect()[0]
+        )
+
+        assert lb_row["name"] == "Building One"
+        assert lb_row["reference"] == "LB-001"
+        assert lb_row["listed-building-grade"] == "II"
+        assert lb_row["geometry"] == "POLYGON((1 1,2 2,3 3,1 1))"
+        assert lb_row["documentation-url"] == "https://example.com/lb-001"
+
+        assert lb_null_row["geometry"] is None
+        assert lb_null_row["point"] is None
+        assert lb_null_row["documentation-url"] is None
+
+        assert lbo_row["address"] == "1 High Street"
+        assert lbo_row["listed-building"] == "1001"
+        assert lbo_row["reference"] == "LBO-001"
+        assert lbo_row["document-url"] == "https://example.com/doc-1"
+        assert lbo_row["notes"] == "Some notes"
+
+        assert lbo_null_row["address"] is None
+        assert lbo_null_row["address-text"] is None
+        assert lbo_null_row["document-url"] is None
+        assert lbo_null_row["documentation-url"] is None
+        assert lbo_null_row["geometry"] is None
+        assert lbo_null_row["notes"] is None
+        assert lbo_null_row["point"] is None
+
+    def test__listed_building_standardisation_process__run__explodes_entities_from_multiple_raw_rows(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "listed_building_data": _listed_building_multirow_raw_df(spark),
+            "listed_building_outline_data": _listed_building_outline_multirow_raw_df(spark),
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingStandardisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
+        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
+
+        assert listed_building_df.count() == 3
+        assert listed_building_outline_df.count() == 3
+
+        listed_building_entities = {row["entity"] for row in listed_building_df.select("entity").collect()}
+        listed_building_outline_entities = {row["entity"] for row in listed_building_outline_df.select("entity").collect()}
+
+        assert listed_building_entities == {"1001", "1002", "1003"}
+        assert listed_building_outline_entities == {"2001", "2002", "2003"}
+
+    def test__listed_building_standardisation_process__run__empty_entities_arrays_return_empty_outputs(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "listed_building_data": _listed_building_empty_entities_raw_df(spark),
+            "listed_building_outline_data": _listed_building_outline_empty_entities_raw_df(spark),
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingStandardisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
+        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
+
+        assert listed_building_df.count() == 0
+        assert listed_building_outline_df.count() == 0
+
+    def test__listed_building_standardisation_process__run__empty_input_dataframes_return_empty_outputs(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "listed_building_data": _empty_listed_building_raw_df(spark),
+            "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingStandardisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
+        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
+
+        assert listed_building_df.count() == 0
+        assert listed_building_outline_df.count() == 0
+        assert data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["write_mode"] == "overwrite"
+        assert data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["write_mode"] == "overwrite"
+
+    def test__listed_building_standardisation_process__run__one_source_empty_still_writes_the_other_output(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "listed_building_data": _empty_listed_building_raw_df(spark),
+            "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingStandardisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
+        listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
+
+        assert listed_building_df.count() == 2
+        assert listed_building_outline_df.count() == 0
+
+    def test__listed_building_standardisation_process__run__preserves_duplicate_entities_like_legacy(
+        self,
+    ):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        source_data = {
+            "listed_building_data": _duplicate_listed_building_raw_df(spark),
+            "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
+        }
+
+        with (
+            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
+            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+        ):
+            mock_etl_logging.return_value = mock.Mock()
+            mock_process_logging.return_value = mock.Mock()
+
+            inst = ListedBuildingStandardisationProcess(spark)
+
+            with (
+                mock.patch.object(inst, "load_data", return_value=source_data),
+                mock.patch.object(inst, "write_data") as mock_write,
+            ):
+                inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
+
+        assert listed_building_df.count() == 2
+        assert listed_building_df.where("entity = '1001'").count() == 2

--- a/odw/test/unit_test/etl/standardised/test_listed_building_standardisation_process.py
+++ b/odw/test/unit_test/etl/standardised/test_listed_building_standardisation_process.py
@@ -405,9 +405,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         assert LISTED_BUILDING_OUTPUT_TABLE in data_to_write
         assert LISTED_BUILDING_OUTLINE_OUTPUT_TABLE in data_to_write
@@ -422,9 +421,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
 
@@ -474,9 +472,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
 
@@ -534,9 +531,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
         listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
@@ -579,9 +575,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         assert data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["write_mode"] == "overwrite"
         assert data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["write_mode"] == "overwrite"
@@ -596,9 +591,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
         listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
@@ -651,9 +645,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_multirow_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
         listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
@@ -671,9 +664,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_empty_entities_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
         listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
@@ -691,9 +683,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
         listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
@@ -711,9 +702,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
         listed_building_outline_df = data_to_write[LISTED_BUILDING_OUTLINE_OUTPUT_TABLE]["data"]
@@ -731,9 +721,8 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
-        with mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil"):
-            inst = ListedBuildingStandardisationProcess(spark)
-            data_to_write, _ = inst.process(source_data=source_data)
+        inst = ListedBuildingStandardisationProcess(spark)
+        data_to_write, _ = inst.process(source_data=source_data)
 
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
 
@@ -750,20 +739,13 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
+        inst = ListedBuildingStandardisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
+            inst.run()
 
         data_to_write = mock_write.call_args[0][0]
 
@@ -827,20 +809,13 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
+        inst = ListedBuildingStandardisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
+            inst.run()
 
         data_to_write = mock_write.call_args[0][0]
 
@@ -912,20 +887,13 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_multirow_raw_df(spark),
         }
 
+        inst = ListedBuildingStandardisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
+            inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
@@ -950,20 +918,13 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _listed_building_outline_empty_entities_raw_df(spark),
         }
 
+        inst = ListedBuildingStandardisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
+            inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
@@ -982,20 +943,13 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
+        inst = ListedBuildingStandardisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
+            inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
@@ -1016,20 +970,13 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
+        inst = ListedBuildingStandardisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
+            inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]
@@ -1048,20 +995,13 @@ class TestListedBuildingStandardisationProcess(SparkTestCase):
             "listed_building_outline_data": _empty_listed_building_outline_raw_df(spark),
         }
 
+        inst = ListedBuildingStandardisationProcess(spark)
+
         with (
-            mock.patch("odw.core.etl.etl_process.LoggingUtil") as mock_etl_logging,
-            mock.patch("odw.core.etl.transformation.standardised.listed_building_standardisation_process.LoggingUtil") as mock_process_logging,
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
         ):
-            mock_etl_logging.return_value = mock.Mock()
-            mock_process_logging.return_value = mock.Mock()
-
-            inst = ListedBuildingStandardisationProcess(spark)
-
-            with (
-                mock.patch.object(inst, "load_data", return_value=source_data),
-                mock.patch.object(inst, "write_data") as mock_write,
-            ):
-                inst.run()
+            inst.run()
 
         data_to_write = mock_write.call_args[0][0]
         listed_building_df = data_to_write[LISTED_BUILDING_OUTPUT_TABLE]["data"]

--- a/odw/test/unit_test/util/test_table_util.py
+++ b/odw/test/unit_test/util/test_table_util.py
@@ -12,6 +12,10 @@ from typing import List, Dict
 
 
 class TestTableUtil(SparkTestCase):
+    @pytest.fixture(scope="module", autouse=True)
+    def setup(self, request):
+        yield
+
     DESCRIPTION_SCHEMA = StructType(
         [
             StructField("format", StringType(), True),

--- a/odw/test/util/test_case.py
+++ b/odw/test/util/test_case.py
@@ -1,10 +1,12 @@
 from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.core.util.logging_util import LoggingUtil
 import gc
 from pyspark.sql import SparkSession, DataFrame
 from odw.test.util.util import format_to_adls_path
 from typing import Dict, Any
 import logging
 import pytest
+import mock
 
 
 class TestCase:
@@ -53,6 +55,15 @@ class SparkTestCase(TestCase):
         spark = PytestSparkSessionUtil().get_spark_session()
         spark.catalog.clearCache()
         gc.collect()
+
+    @pytest.fixture(scope="module", autouse=True)
+    def setup(self, request):
+        with (
+            mock.patch.object(LoggingUtil, "__new__"),
+            mock.patch.object(LoggingUtil, "log_info", return_value=None),
+            mock.patch.object(LoggingUtil, "log_error", return_value=None),
+        ):
+            yield
 
     def write_existing_table(
         self,


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-3103

- Update listed building integration tests to test that input data correctly flows through the ETL process
- Migrate old integration tests to the unit test folder (since there were more like unit tests than integration tests, and it is good to keep these)