### PR TITLE
Feat/theodw 3103 refine integration tests2

### DIFF
--- a/odw/core/etl/transformation/curated/appeal_has_curated_mipins_process.py
+++ b/odw/core/etl/transformation/curated/appeal_has_curated_mipins_process.py
@@ -3,6 +3,7 @@ from odw.core.etl.transformation.curated.curation_process import CurationProcess
 
 
 class AppealHasCuratedMipinsProcess(CurationProcess):
+    HARMONISED_TABLE = "appeals_has"
     OUTPUT_TABLE = "appeals_has_curated_mipins"
 
     def __init__(self, spark):

--- a/odw/core/etl/transformation/harmonised/appeal_has_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/appeal_has_harmonisation_process.py
@@ -4,6 +4,10 @@ from odw.core.etl.transformation.harmonised.harmonsation_process import Harmonis
 
 class AppealHasHarmonisationProcess(HarmonisationProcess):
     OUTPUT_TABLE = "appeal_has"
+    SERVICE_BUS_TABLE = "sb_appeal_has"
+    HORIZON_TABLE = "horizon_appeal_has"
+    GROUP_RESOLVER_TABLE = "GroupResolver"
+    S78_TABLE = "appeal_s78"
 
     def __init__(self, spark):
         super().__init__(spark)

--- a/odw/core/etl/transformation/standardised/appeal_has_standardisation_process.py
+++ b/odw/core/etl/transformation/standardised/appeal_has_standardisation_process.py
@@ -4,6 +4,25 @@ from odw.core.etl.transformation.standardised.standardisation_process import Sta
 
 class AppealHasStandardisationProcess(StandardisationProcess):
     OUTPUT_TABLE = "horizon_appeal_has"
+    STANDARDISED_DB = "odw_standardised_db"
+    STANDARDISED_CASES_SPECIALISMS = "cases_specialisms"
+    STANDARDISED_HORIZON_CASES_S78 = "horizoncases_has"
+    STANDARDISED_VW_CASE_DATES = "vw_case_dates"
+    STANDARDISED_CASE_DOCUMENT_DATES_DATES = "casedocumentdatesdates"
+    STANDARDISED_CASE_SITE_STRINGS = "casesitestrings"
+    STANDARDISED_ADDITIONAL_FIELDS = "vw_additionalfields"
+    STANDARDISED_HORIZON_ADVERT_ATTRIBUTES = "horizon_advert_attributes"
+    STANDARDISED_HORIZON_SPECIALIST_CASE_DATES = "horizon_specialist_case_dates"
+    STANDARDISED_PLANNING_APP_STRINGS = "PlanningAppStrings"
+    STANDARDISED_PLANNING_APP_DATES = "PlanningAppDates"
+    STANDARDISED_LEAD_CASE = "BIS_LeadCase"
+    STANDARDISED_CASE_STRINGS = "CaseStrings"
+    STANDARDISED_HORIZON_CASE_INFO = "horizon_case_info"
+    STANDARDISED_HORIZON_CASE_DATES = "horizon_case_dates"
+    STANDARDISED_HORIZON_APPEALS_ADDITIONAL_DATA = "horizon_appeals_additional_data"
+    STANDARDISED_ADD_ADDITIONAL_DATA = "vw_addadditionaldata"
+    STANDARDISED_TYPE_OF_PROCEDURE = "typeofprocedure"
+    STANDARDISED_TYPE_OF_LEVEL = "TypeOfLevel"
 
     def __init__(self, spark):
         super().__init__(spark)

--- a/odw/core/etl/transformation/standardised/appeal_has_standardisation_process.py
+++ b/odw/core/etl/transformation/standardised/appeal_has_standardisation_process.py
@@ -6,7 +6,7 @@ class AppealHasStandardisationProcess(StandardisationProcess):
     OUTPUT_TABLE = "horizon_appeal_has"
     STANDARDISED_DB = "odw_standardised_db"
     STANDARDISED_CASES_SPECIALISMS = "cases_specialisms"
-    STANDARDISED_HORIZON_CASES_S78 = "horizoncases_has"
+    STANDARDISED_HORIZON_CASES_HAS = "horizoncases_has"
     STANDARDISED_VW_CASE_DATES = "vw_case_dates"
     STANDARDISED_CASE_DOCUMENT_DATES_DATES = "casedocumentdatesdates"
     STANDARDISED_CASE_SITE_STRINGS = "casesitestrings"

--- a/odw/test/integration_test/etl/curated/test_appeal_has_curated_mipins_process.py
+++ b/odw/test/integration_test/etl/curated/test_appeal_has_curated_mipins_process.py
@@ -2,12 +2,11 @@ from datetime import datetime
 import mock
 import pytest
 import pyspark.sql.types as T
-from odw.test.util.assertion import assert_dataframes_equal
+from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.curated.appeal_has_curated_mipins_process import AppealHasCuratedMipinsProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
 from decimal import Decimal
 
 pytestmark = pytest.mark.xfail(reason="Curated MIPINS logic not implemented yet")

--- a/odw/test/integration_test/etl/curated/test_appeal_has_curated_mipins_process.py
+++ b/odw/test/integration_test/etl/curated/test_appeal_has_curated_mipins_process.py
@@ -2,102 +2,15 @@ from datetime import datetime
 import mock
 import pytest
 import pyspark.sql.types as T
-from pyspark.sql import Row
-from pyspark.sql import functions as F
 from odw.test.util.assertion import assert_dataframes_equal
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.curated.appeal_has_curated_mipins_process import AppealHasCuratedMipinsProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
+from decimal import Decimal
 
 pytestmark = pytest.mark.xfail(reason="Curated MIPINS logic not implemented yet")
-
-
-OUTPUT_COLUMNS = [
-    "caseId",
-    "caseReference",
-    "submissionId",
-    "caseStatus",
-    "caseType",
-    "caseProcedure",
-    "lpaCode",
-    "caseOfficerId",
-    "inspectorId",
-    "allocationLevel",
-    "allocationBand",
-    "caseSpecialisms",
-    "caseSubmittedDate",
-    "caseCreatedDate",
-    "caseUpdatedDate",
-    "caseValidDate",
-    "caseValidationDate",
-    "caseValidationOutcome",
-    "caseValidationInvalidDetails",
-    "caseValidationIncompleteDetails",
-    "caseExtensionDate",
-    "caseStartedDate",
-    "casePublishedDate",
-    "linkedCaseStatus",
-    "leadCaseReference",
-    "lpaQuestionnaireDueDate",
-    "lpaQuestionnaireSubmittedDate",
-    "lpaQuestionnaireCreatedDate",
-    "lpaQuestionnairePublishedDate",
-    "lpaQuestionnaireValidationOutcome",
-    "lpaQuestionnaireValidationOutcomeDate",
-    "lpaQuestionnaireValidationDetails",
-    "caseWithdrawnDate",
-    "caseTransferredDate",
-    "transferredCaseClosedDate",
-    "caseDecisionOutcomeDate",
-    "caseDecisionPublishedDate",
-    "caseDecisionOutcome",
-    "caseCompletedDate",
-    "enforcementNotice",
-    "applicationReference",
-    "applicationDate",
-    "applicationDecision",
-    "applicationDecisionDate",
-    "caseSubmissionDueDate",
-    "siteAddressLine1",
-    "siteAddressLine2",
-    "siteAddressTown",
-    "siteAddressCounty",
-    "siteAddressPostcode",
-    "siteAccessDetails",
-    "siteSafetyDetails",
-    "siteAreaSquareMetres",
-    "floorSpaceSquareMetres",
-    "isCorrectAppealType",
-    "isGreenBelt",
-    "inConservationArea",
-    "ownsAllLand",
-    "ownsSomeLand",
-    "knowsOtherOwners",
-    "knowsAllOwners",
-    "advertisedAppeal",
-    "notificationMethod",
-    "ownersInformed",
-    "originalDevelopmentDescription",
-    "changedDevelopmentDescription",
-    "newConditionDetails",
-    "nearbyCaseReferences",
-    "neighbouringSiteAddresses",
-    "affectedListedBuildingNumbers",
-    "appellantCostsAppliedFor",
-    "lpaCostsAppliedFor",
-    "typeOfPlanningApplication",
-    "hasLandownersPermission",
-    "wasApplicationRefusedDueToHighwayOrTraffic",
-    "didAppellantSubmitCompletePhotosAndPlans",
-    "isSiteInAreaOfSpecialControlAdverts",
-    "advertDetails",
-    "padsSapId",
-    "applicationDecisionDueDate",
-    "IngestionDate",
-    "ValidTo",
-    "IsActive",
-]
 
 
 def _harmonised_schema():
@@ -279,46 +192,186 @@ def _base_row(**overrides):
         }
     )
     row.update(overrides)
-    return Row(**row)
+    return row
 
 
-def _df(spark, rows):
-    return spark.createDataFrame(rows, _harmonised_schema())
+def _curated_schema():
+    return T.StructType(
+        [
+            T.StructField("caseId", T.IntegerType(), True),
+            T.StructField("caseReference", T.StringType(), True),
+            T.StructField("submissionId", T.StringType(), True),
+            T.StructField("caseStatus", T.StringType(), True),
+            T.StructField("caseType", T.StringType(), True),
+            T.StructField("caseProcedure", T.StringType(), True),
+            T.StructField("lpaCode", T.StringType(), True),
+            T.StructField("caseOfficerId", T.StringType(), True),
+            T.StructField("inspectorId", T.StringType(), True),
+            T.StructField("allocationLevel", T.StringType(), True),
+            T.StructField("allocationBand", T.DecimalType(10, 0), True),
+            T.StructField("caseSpecialisms", T.ArrayType(T.StringType(), True), True),
+            T.StructField("caseSubmittedDate", T.TimestampType(), True),
+            T.StructField("caseCreatedDate", T.TimestampType(), True),
+            T.StructField("caseUpdatedDate", T.TimestampType(), True),
+            T.StructField("caseValidDate", T.TimestampType(), True),
+            T.StructField("caseValidationDate", T.TimestampType(), True),
+            T.StructField("caseValidationOutcome", T.StringType(), True),
+            T.StructField("caseValidationInvalidDetails", T.StringType(), True),
+            T.StructField("caseValidationIncompleteDetails", T.StringType(), True),
+            T.StructField("caseExtensionDate", T.TimestampType(), True),
+            T.StructField("caseStartedDate", T.TimestampType(), True),
+            T.StructField("casePublishedDate", T.TimestampType(), True),
+            T.StructField("linkedCaseStatus", T.StringType(), True),
+            T.StructField("leadCaseReference", T.StringType(), True),
+            T.StructField("lpaQuestionnaireDueDate", T.TimestampType(), True),
+            T.StructField("lpaQuestionnaireSubmittedDate", T.TimestampType(), True),
+            T.StructField("lpaQuestionnaireCreatedDate", T.TimestampType(), True),
+            T.StructField("lpaQuestionnairePublishedDate", T.TimestampType(), True),
+            T.StructField("lpaQuestionnaireValidationOutcome", T.StringType(), True),
+            T.StructField("lpaQuestionnaireValidationOutcomeDate", T.TimestampType(), True),
+            T.StructField("lpaQuestionnaireValidationDetails", T.StringType(), True),
+            T.StructField("caseWithdrawnDate", T.TimestampType(), True),
+            T.StructField("caseTransferredDate", T.TimestampType(), True),
+            T.StructField("transferredCaseClosedDate", T.TimestampType(), True),
+            T.StructField("caseDecisionOutcomeDate", T.TimestampType(), True),
+            T.StructField("caseDecisionPublishedDate", T.TimestampType(), True),
+            T.StructField("caseDecisionOutcome", T.StringType(), True),
+            T.StructField("caseCompletedDate", T.TimestampType(), True),
+            T.StructField("enforcementNotice", T.BooleanType(), True),
+            T.StructField("applicationReference", T.StringType(), True),
+            T.StructField("applicationDate", T.TimestampType(), True),
+            T.StructField("applicationDecision", T.StringType(), True),
+            T.StructField("applicationDecisionDate", T.TimestampType(), True),
+            T.StructField("caseSubmissionDueDate", T.TimestampType(), True),
+            T.StructField("siteAddressLine1", T.StringType(), True),
+            T.StructField("siteAddressLine2", T.StringType(), True),
+            T.StructField("siteAddressTown", T.StringType(), True),
+            T.StructField("siteAddressCounty", T.StringType(), True),
+            T.StructField("siteAddressPostcode", T.StringType(), True),
+            T.StructField("siteAccessDetails", T.StringType(), True),
+            T.StructField("siteSafetyDetails", T.StringType(), True),
+            T.StructField("siteAreaSquareMetres", T.BooleanType(), True),
+            T.StructField("floorSpaceSquareMetres", T.DecimalType(10, 0), True),
+            T.StructField("isCorrectAppealType", T.BooleanType(), True),
+            T.StructField("isGreenBelt", T.BooleanType(), True),
+            T.StructField("inConservationArea", T.BooleanType(), True),
+            T.StructField("ownsAllLand", T.BooleanType(), True),
+            T.StructField("ownsSomeLand", T.BooleanType(), True),
+            T.StructField("knowsOtherOwners", T.StringType(), True),
+            T.StructField("knowsAllOwners", T.StringType(), True),
+            T.StructField("advertisedAppeal", T.BooleanType(), True),
+            T.StructField("notificationMethod", T.StringType(), True),
+            T.StructField("ownersInformed", T.BooleanType(), True),
+            T.StructField("originalDevelopmentDescription", T.StringType(), True),
+            T.StructField("changedDevelopmentDescription", T.BooleanType(), True),
+            T.StructField("newConditionDetails", T.StringType(), True),
+            T.StructField("nearbyCaseReferences", T.StringType(), True),
+            T.StructField("neighbouringSiteAddresses", T.StringType(), True),
+            T.StructField("affectedListedBuildingNumbers", T.StringType(), True),
+            T.StructField("appellantCostsAppliedFor", T.BooleanType(), True),
+            T.StructField("lpaCostsAppliedFor", T.BooleanType(), True),
+            T.StructField("typeOfPlanningApplication", T.StringType(), True),
+            T.StructField("hasLandownersPermission", T.StringType(), True),
+            T.StructField("wasApplicationRefusedDueToHighwayOrTraffic", T.StringType(), True),
+            T.StructField("didAppellantSubmitCompletePhotosAndPlans", T.StringType(), True),
+            T.StructField("isSiteInAreaOfSpecialControlAdverts", T.StringType(), True),
+            T.StructField("advertDetails", T.StringType(), True),
+            T.StructField("padsSapId", T.StringType(), True),
+            T.StructField("applicationDecisionDueDate", T.TimestampType(), True),
+            T.StructField("IngestionDate", T.TimestampType(), True),
+            T.StructField("ValidTo", T.TimestampType(), True),
+            T.StructField("IsActive", T.StringType(), True),
+        ]
+    )
 
 
-def _df_with_old_dates(spark, rows, date_cols):
-    schema = _harmonised_schema()
-
-    schema_fields = []
-    for field in schema.fields:
-        if field.name in date_cols:
-            schema_fields.append(T.StructField(field.name, T.StringType(), True))
-        else:
-            schema_fields.append(field)
-
-    updated_schema = T.StructType(schema_fields)
-
-    cleaned_rows = []
-
-    for row in rows:
-        row_dict = row.asDict()
-        updated_row = {}
-
-        for key, value in row_dict.items():
-            if key in date_cols and isinstance(value, datetime):
-                updated_row[key] = value.isoformat()
-            else:
-                updated_row[key] = value
-
-        cleaned_rows.append(updated_row)
-
-    df = spark.createDataFrame(cleaned_rows, schema=updated_schema)
-
-    return df.withColumns({col_name: F.col(col_name).cast("timestamp") for col_name in date_cols})
-
-
-def _source_data(harmonised_data):
-    return {"harmonised_data": harmonised_data}
+def _curated_row(**overrides):
+    base = {
+        "caseId": 7000001,
+        "caseReference": "7000001",
+        "submissionId": "SUB-001",
+        "caseStatus": "valid",
+        "caseType": "HAS",
+        "caseProcedure": "WR",
+        "lpaCode": "Q1234",
+        "caseOfficerId": "OFFICER-001",
+        "inspectorId": "INSPECTOR-001",
+        "allocationLevel": "Level 1",
+        "allocationBand": Decimal("7"),
+        "caseSpecialisms": ["Advertisements"],
+        "caseSubmittedDate": datetime(2025, 6, 1, 13, 0),
+        "caseCreatedDate": datetime(2025, 6, 1, 13, 0),
+        "caseUpdatedDate": datetime(2025, 6, 1, 13, 0),
+        "caseValidDate": datetime(2025, 6, 1, 13, 0),
+        "caseValidationDate": datetime(2025, 6, 1, 13, 0),
+        "caseValidationOutcome": "Valid",
+        "caseValidationInvalidDetails": "Invalid details",
+        "caseValidationIncompleteDetails": "[Missing plan]",
+        "caseExtensionDate": datetime(2025, 6, 1, 13, 0),
+        "caseStartedDate": datetime(2025, 6, 1, 13, 0),
+        "casePublishedDate": datetime(2025, 6, 1, 13, 0),
+        "linkedCaseStatus": "Linked",
+        "leadCaseReference": "LEAD-001",
+        "lpaQuestionnaireDueDate": datetime(2025, 6, 1, 13, 0),
+        "lpaQuestionnaireSubmittedDate": datetime(2025, 6, 1, 13, 0),
+        "lpaQuestionnaireCreatedDate": datetime(2025, 6, 1, 13, 0),
+        "lpaQuestionnairePublishedDate": datetime(2025, 6, 1, 13, 0),
+        "lpaQuestionnaireValidationOutcome": "Valid",
+        "lpaQuestionnaireValidationOutcomeDate": datetime(2025, 6, 1, 13, 0),
+        "lpaQuestionnaireValidationDetails": "[Accepted]",
+        "caseWithdrawnDate": None,
+        "caseTransferredDate": None,
+        "transferredCaseClosedDate": None,
+        "caseDecisionOutcomeDate": datetime(2025, 6, 1, 13, 0),
+        "caseDecisionPublishedDate": datetime(2025, 6, 1, 13, 0),
+        "caseDecisionOutcome": "Allowed",
+        "caseCompletedDate": datetime(2025, 6, 1, 13, 0),
+        "enforcementNotice": True,
+        "applicationReference": "APP-001",
+        "applicationDate": datetime(2025, 6, 1, 12, 0),
+        "applicationDecision": "Granted",
+        "applicationDecisionDate": datetime(2025, 6, 1, 13, 0),
+        "caseSubmissionDueDate": datetime(2025, 6, 1, 13, 0),
+        "siteAddressLine1": "Line 1",
+        "siteAddressLine2": "Line 2",
+        "siteAddressTown": "Town",
+        "siteAddressCounty": "County",
+        "siteAddressPostcode": "AA1 1AA",
+        "siteAccessDetails": "[Gate code]",
+        "siteSafetyDetails": "Safety details",
+        "siteAreaSquareMetres": True,
+        "floorSpaceSquareMetres": Decimal("123"),
+        "isCorrectAppealType": True,
+        "isGreenBelt": False,
+        "inConservationArea": True,
+        "ownsAllLand": False,
+        "ownsSomeLand": True,
+        "knowsOtherOwners": "Yes",
+        "knowsAllOwners": "No",
+        "advertisedAppeal": True,
+        "notificationMethod": "email",
+        "ownersInformed": False,
+        "originalDevelopmentDescription": "Original development",
+        "changedDevelopmentDescription": True,
+        "newConditionDetails": "Conditions",
+        "nearbyCaseReferences": "7000002",
+        "neighbouringSiteAddresses": "[Neighbour address]",
+        "affectedListedBuildingNumbers": "LB-001",
+        "appellantCostsAppliedFor": True,
+        "lpaCostsAppliedFor": False,
+        "typeOfPlanningApplication": "Full Planning",
+        "hasLandownersPermission": "Y",
+        "wasApplicationRefusedDueToHighwayOrTraffic": "N",
+        "didAppellantSubmitCompletePhotosAndPlans": "Y",
+        "isSiteInAreaOfSpecialControlAdverts": "N",
+        "advertDetails": "Advert details",
+        "padsSapId": "SAP-001",
+        "applicationDecisionDueDate": datetime(2025, 6, 1, 13, 0),
+        "IngestionDate": datetime(2025, 6, 1, 13, 0),
+        "ValidTo": datetime(2025, 6, 1, 13, 0),
+        "IsActive": "Y",
+    }
+    return base | overrides
 
 
 class TestAppealHasCuratedMipinsProcess(ETLTestCase):
@@ -329,144 +382,39 @@ class TestAppealHasCuratedMipinsProcess(ETLTestCase):
     casts, output columns and write configuration
     """
 
-    def test__appeal_has_curated_mipins_process__run__writes_legacy_mipins_output_end_to_end(self):
+    def assert_curated_etl(self, test_case: str):
         spark = PytestSparkSessionUtil().get_spark_session()
+        appeal_has = spark.createDataFrame((_base_row(), _base_row()), schema=_harmonised_schema())
+        appeal_has_table = f"{test_case}_appeal_has"
+        self.write_existing_table(spark, appeal_has, appeal_has_table, "odw_harmonised_db", "odw-harmonised", appeal_has_table, "overwrite")
+        expected_curated_data_after_writing = spark.createDataFrame((_curated_row(),), schema=_curated_schema())
+        output_table = f"{test_case}_appeals_has_curated_mipins"
+        with mock.patch.object(AppealHasCuratedMipinsProcess, "HARMONISED_TABLE", appeal_has_table):
+            with mock.patch.object(AppealHasCuratedMipinsProcess, "OUTPUT_TABLE", output_table):
+                inst = AppealHasCuratedMipinsProcess(spark)
+                result = inst.run()
+                assert_etl_result_successful(result)
+                actual_table_data = spark.table(output_table)
+                assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
 
-        source_df = _df(
-            spark,
-            [
-                _base_row(caseReference="7000001"),  # kept: ODT source, valid LPA and MIPINS case ref range
-                _base_row(caseReference="7000002", lpaCode="Q9999"),  # dropped: LPA code is excluded
-                _base_row(caseReference="5000000"),  # dropped: case ref is outside MIPINS range
-                _base_row(caseReference="7000003", ODTSourceSystem="HORIZON"),  # dropped: non ODT source
-            ],
-        )
-        source_data = _source_data(source_df)
+    def test__appeal_has_curated_mipins_process__run__with_no_existing_data(self):
+        """
+        - Given I have harmonised appeal_has data
+        - When I call AppealHasCuratedMipinsProcess.run
+        - Then the data should be transformed and the appeals_has_curated_mipins table should be created
+        """
+        self.assert_curated_etl("t_ahcmp_r_wned")
 
-        inst = AppealHasCuratedMipinsProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        write_config = data_to_write[inst.OUTPUT_TABLE]
-        df = write_config["data"]
-        actual_df = df.select(
-            "caseId",
-            "caseReference",
-            "lpaCode",
-            "allocationBand",
-            "enforcementNotice",
-            "siteAreaSquareMetres",
-            "floorSpaceSquareMetres",
-            "caseSubmittedDate",
-            "IngestionDate",
-            "ValidTo",
-        )
-
-        expected_df = spark.createDataFrame(
-            [
-                (
-                    7000001,
-                    "7000001",
-                    "Q1234",
-                    7.0,
-                    True,
-                    True,
-                    123.0,
-                    datetime(2025, 6, 1, 13, 0),
-                    datetime(2025, 6, 1, 13, 0),
-                    datetime(2025, 6, 1, 13, 0),
-                )
-            ],
-            actual_df.schema,
-        )
-
-        assert_dataframes_equal(actual_df, expected_df)
-
-        assert write_config["write_mode"] == "overwrite"
-        assert write_config["file_format"] == "parquet"
-        assert "partition_by" not in write_config
-
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 1,
-            "update_count": 0,
-            "delete_count": 0,
-        }
-
-    def test__appeal_has_curated_mipins_process__run__empty_source_writes_empty_output_like_legacy(self):
+    def test__appeal_has_curated_mipins_process__run__with_existing_data(self):
+        """
+        - Given I have harmonised appeal_has data and an existing appeals_has_curated_mipins table
+        - When I call AppealHasCuratedMipinsProcess.run
+        - Then the data should be transformed and the appeals_has_curated_mipins table should be overwritten
+        """
+        test_case = "t_ahcmp_r_wed"
+        output_table = f"{test_case}_appeals_has_curated_mipins"
         spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = _source_data(spark.createDataFrame([], _harmonised_schema()))
-
-        inst = AppealHasCuratedMipinsProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        write_config = data_to_write[inst.OUTPUT_TABLE]
-        df = write_config["data"]
-
-        assert df.count() == 0
-        assert df.columns == OUTPUT_COLUMNS
-        assert write_config["write_mode"] == "overwrite"
-        assert write_config["file_format"] == "parquet"
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 0,
-            "update_count": 0,
-            "delete_count": 0,
-        }
-
-    def test__appeal_has_curated_mipins_process__run__filters_pre_1900_dates_like_legacy(self):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_df = _df_with_old_dates(
-            spark,
-            [
-                _base_row(caseReference="7000001"),
-                _base_row(
-                    caseReference="7000002",
-                    caseSubmittedDate=datetime(1899, 12, 31),
-                ),
-            ],
-            date_cols=["caseSubmittedDate"],
-        )
-        source_data = _source_data(source_df)
-
-        inst = AppealHasCuratedMipinsProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        df = mock_write.call_args[0][0][inst.OUTPUT_TABLE]["data"]
-        rows = df.collect()
-
-        assert df.count() == 1
-        assert rows[0]["caseReference"] == "7000001"
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 1,
-            "update_count": 0,
-            "delete_count": 0,
-        }
+        existing_data = spark.createDataFrame((_curated_row(caseId=1),), schema=_curated_schema())
+        self.assert_curated_etl(test_case)
+        self.write_existing_table(spark, existing_data, output_table, "odw_curated_db", "odw-curated", output_table, "overwrite")
+        self.assert_curated_etl(test_case)

--- a/odw/test/integration_test/etl/curated/test_appeal_has_curated_process.py
+++ b/odw/test/integration_test/etl/curated/test_appeal_has_curated_process.py
@@ -1,120 +1,14 @@
 import mock
 import pytest
 import pyspark.sql.types as T
-from odw.test.util.assertion import assert_dataframes_equal
+from pyspark.sql import SparkSession
+from odw.test.util.assertion import assert_dataframes_equal, assert_etl_result_successful
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.curated.appeal_has_curated_process import AppealHasCuratedProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
 
 pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
-
-
-CURATED_COLUMNS = [
-    "caseId",
-    "caseReference",
-    "submissionId",
-    "caseStatus",
-    "caseType",
-    "caseProcedure",
-    "lpaCode",
-    "caseOfficerId",
-    "inspectorId",
-    "allocationLevel",
-    "allocationBand",
-    "caseSpecialisms",
-    "caseSubmittedDate",
-    "caseCreatedDate",
-    "caseUpdatedDate",
-    "caseValidDate",
-    "caseValidationDate",
-    "caseValidationOutcome",
-    "caseValidationInvalidDetails",
-    "caseValidationIncompleteDetails",
-    "caseExtensionDate",
-    "caseStartedDate",
-    "casePublishedDate",
-    "linkedCaseStatus",
-    "leadCaseReference",
-    "lpaQuestionnaireDueDate",
-    "lpaQuestionnaireSubmittedDate",
-    "lpaQuestionnaireCreatedDate",
-    "lpaQuestionnairePublishedDate",
-    "lpaQuestionnaireValidationOutcome",
-    "lpaQuestionnaireValidationOutcomeDate",
-    "lpaQuestionnaireValidationDetails",
-    "lpaStatement",
-    "caseWithdrawnDate",
-    "caseTransferredDate",
-    "transferredCaseClosedDate",
-    "caseDecisionOutcomeDate",
-    "caseDecisionPublishedDate",
-    "caseDecisionOutcome",
-    "caseCompletedDate",
-    "enforcementNotice",
-    "applicationReference",
-    "applicationDate",
-    "applicationDecision",
-    "applicationDecisionDate",
-    "caseSubmissionDueDate",
-    "siteAddressLine1",
-    "siteAddressLine2",
-    "siteAddressTown",
-    "siteAddressCounty",
-    "siteAddressPostcode",
-    "siteAccessDetails",
-    "siteSafetyDetails",
-    "siteAreaSquareMetres",
-    "floorSpaceSquareMetres",
-    "isCorrectAppealType",
-    "isGreenBelt",
-    "inConservationArea",
-    "ownsAllLand",
-    "ownsSomeLand",
-    "knowsOtherOwners",
-    "knowsAllOwners",
-    "advertisedAppeal",
-    "notificationMethod",
-    "ownersInformed",
-    "originalDevelopmentDescription",
-    "changedDevelopmentDescription",
-    "newConditionDetails",
-    "nearbyCaseReferences",
-    "neighbouringSiteAddresses",
-    "reasonForNeighbourVisits",
-    "affectedListedBuildingNumbers",
-    "appellantCostsAppliedFor",
-    "lpaCostsAppliedFor",
-    "typeOfPlanningApplication",
-    "affectsScheduledMonument",
-    "hasProtectedSpecies",
-    "isAonbNationalLandscape",
-    "hasInfrastructureLevy",
-    "isInfrastructureLevyFormallyAdopted",
-    "infrastructureLevyAdoptedDate",
-    "infrastructureLevyExpectedDate",
-    "caseworkReason",
-    "importantInformation",
-    "jurisdiction",
-    "redeterminedIndicator",
-    "dateCostsReportDespatched",
-    "dateNotRecoveredOrDerecovered",
-    "dateRecovered",
-    "originalCaseDecisionDate",
-    "targetDate",
-    "siteGridReferenceEasting",
-    "siteGridReferenceNorthing",
-    "hasLandownersPermission",
-    "isSiteInAreaOfSpecialControlAdverts",
-    "wasApplicationRefusedDueToHighwayOrTraffic",
-    "didAppellantSubmitCompletePhotosAndPlans",
-    "advertDetails",
-    "lpaProcedurePreferenceDetails",
-    "designatedSitesNames",
-    "lpaProcedurePreference",
-    "lpaProcedurePreferenceDuration",
-    "padsSapId",
-]
 
 
 def _harmonised_schema():
@@ -176,11 +70,7 @@ def _harmonised_schema():
     )
 
 
-def _empty_harmonised_df(spark):
-    return spark.createDataFrame([], _harmonised_schema())
-
-
-def _harmonised_df(spark):
+def _harmonised_df(spark: SparkSession):
     return spark.createDataFrame(
         [
             (
@@ -296,225 +186,155 @@ def _harmonised_df(spark):
     )
 
 
-def _source_data(harmonised_data):
-    return {"harmonised_data": harmonised_data}
+def _curated_schema():
+    return T.StructType(
+        [
+            T.StructField("caseId", T.StringType(), True),
+            T.StructField("caseReference", T.StringType(), True),
+            T.StructField("submissionId", T.StringType(), True),
+            T.StructField("caseStatus", T.StringType(), True),
+            T.StructField("caseType", T.StringType(), True),
+            T.StructField("caseProcedure", T.StringType(), True),
+            T.StructField("lpaCode", T.StringType(), True),
+            T.StructField("caseOfficerId", T.StringType(), True),
+            T.StructField("inspectorId", T.StringType(), True),
+            T.StructField("allocationLevel", T.StringType(), True),
+            T.StructField("allocationBand", T.StringType(), True),
+            T.StructField("caseSpecialisms", T.ArrayType(T.StringType(), True), True),
+            T.StructField("caseCreatedDate", T.StringType(), True),
+            T.StructField("caseUpdatedDate", T.StringType(), True),
+            T.StructField("caseValidationDate", T.StringType(), True),
+            T.StructField("caseValidationOutcome", T.StringType(), True),
+            T.StructField("caseStartedDate", T.StringType(), True),
+            T.StructField("linkedCaseStatus", T.StringType(), True),
+            T.StructField("leadCaseReference", T.StringType(), True),
+            T.StructField("lpaQuestionnaireDueDate", T.StringType(), True),
+            T.StructField("lpaQuestionnaireSubmittedDate", T.StringType(), True),
+            T.StructField("caseWithdrawnDate", T.StringType(), True),
+            T.StructField("caseDecisionOutcomeDate", T.StringType(), True),
+            T.StructField("caseDecisionOutcome", T.StringType(), True),
+            T.StructField("caseCompletedDate", T.StringType(), True),
+            T.StructField("applicationReference", T.StringType(), True),
+            T.StructField("applicationDate", T.StringType(), True),
+            T.StructField("applicationDecisionDate", T.StringType(), True),
+            T.StructField("siteAddressLine1", T.StringType(), True),
+            T.StructField("siteAddressLine2", T.StringType(), True),
+            T.StructField("siteAddressTown", T.StringType(), True),
+            T.StructField("siteAddressCounty", T.StringType(), True),
+            T.StructField("siteAddressPostcode", T.StringType(), True),
+            T.StructField("siteAreaSquareMetres", T.DoubleType(), True),
+            T.StructField("floorSpaceSquareMetres", T.DoubleType(), True),
+            T.StructField("isGreenBelt", T.StringType(), True),
+            T.StructField("inConservationArea", T.StringType(), True),
+            T.StructField("originalDevelopmentDescription", T.StringType(), True),
+            T.StructField("typeOfPlanningApplication", T.StringType(), True),
+            T.StructField("dateCostsReportDespatched", T.StringType(), True),
+            T.StructField("dateNotRecoveredOrDerecovered", T.StringType(), True),
+            T.StructField("dateRecovered", T.StringType(), True),
+            T.StructField("importantInformation", T.StringType(), True),
+            T.StructField("isAonbNationalLandscape", T.StringType(), True),
+            T.StructField("jurisdiction", T.StringType(), True),
+            T.StructField("lpaProcedurePreference", T.StringType(), True),
+            T.StructField("originalCaseDecisionDate", T.StringType(), True),
+            T.StructField("redeterminedIndicator", T.StringType(), True),
+            T.StructField("siteGridReferenceEasting", T.StringType(), True),
+            T.StructField("siteGridReferenceNorthing", T.StringType(), True),
+            T.StructField("padsSapId", T.StringType(), True),
+            T.StructField("IsActive", T.StringType(), True),
+        ]
+    )
+
+
+def _curated_row(**overrides):
+    base = {
+        "caseId": "1001",
+        "caseReference": "HAS-001",
+        "submissionId": "SUB-001",
+        "caseStatus": "valid",
+        "caseType": "HAS",
+        "caseProcedure": "WR",
+        "lpaCode": "LPA01",
+        "caseOfficerId": "OFFICER-001",
+        "inspectorId": "INSPECTOR-001",
+        "allocationLevel": "Level 1",
+        "allocationBand": "Band A",
+        "caseSpecialisms": ["Advertisements", "Listed Building"],
+        "caseCreatedDate": "2025-01-01",
+        "caseUpdatedDate": "2025-01-02",
+        "caseValidationDate": "2025-01-03",
+        "caseValidationOutcome": "Valid appeal",
+        "caseStartedDate": "2025-01-04",
+        "linkedCaseStatus": "Linked",
+        "leadCaseReference": "LEAD-001",
+        "lpaQuestionnaireDueDate": "2025-01-05",
+        "lpaQuestionnaireSubmittedDate": "2025-01-06",
+        "caseWithdrawnDate": None,
+        "caseDecisionOutcomeDate": "2025-01-07",
+        "caseDecisionOutcome": "Allowed",
+        "caseCompletedDate": "2025-01-08",
+        "applicationReference": "APP-REF-001",
+        "applicationDate": "2025-01-09",
+        "applicationDecisionDate": "2025-01-10",
+        "siteAddressLine1": "Line 1",
+        "siteAddressLine2": "Line 2",
+        "siteAddressTown": "Town 1",
+        "siteAddressCounty": "County 1",
+        "siteAddressPostcode": "AA1 1AA",
+        "siteAreaSquareMetres": 1000.0,
+        "floorSpaceSquareMetres": 50.0,
+        "isGreenBelt": "Y",
+        "inConservationArea": "N",
+        "originalDevelopmentDescription": "Development 1",
+        "typeOfPlanningApplication": "Full Planning",
+        "dateCostsReportDespatched": "2025-01-11",
+        "dateNotRecoveredOrDerecovered": "2025-01-12",
+        "dateRecovered": "2025-01-13",
+        "importantInformation": "Important info 1",
+        "isAonbNationalLandscape": "Y",
+        "jurisdiction": "HAS",
+        "lpaProcedurePreference": "Written Reps",
+        "originalCaseDecisionDate": "2025-01-14",
+        "redeterminedIndicator": "N",
+        "siteGridReferenceEasting": "123",
+        "siteGridReferenceNorthing": "456",
+        "padsSapId": "SAP-001",
+        "IsActive": "Y",
+    }
+    return base | overrides
 
 
 class TestAppealHasCuratedProcess(ETLTestCase):
-    def test__appeal_has_curated_process__run__curates_active_harmonised_rows_end_to_end_like_legacy(self):
+    def assert_curated_etl(self, test_case: str):
         spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = _source_data(_harmonised_df(spark))
-
-        inst = AppealHasCuratedProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
+        appeal_has = _harmonised_df(spark)
+        appeal_has_table = f"{test_case}_appeal_has"
+        self.write_existing_table(spark, appeal_has, appeal_has_table, "odw_harmonised_db", "odw-harmonsed", appeal_has_table, "overwrite")
+        expected_curated_data_after_writing = spark.createDataFrame((_curated_row(),), schema=_curated_schema())
+        with mock.patch.object(AppealHasCuratedProcess, "OUTPUT_TABLE", appeal_has_table):
+            inst = AppealHasCuratedProcess(spark)
             result = inst.run()
+            assert_etl_result_successful(result)
+            actual_table_data = spark.table(appeal_has_table)
+            assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
 
-        data_to_write = mock_write.call_args[0][0]
-        write_config = data_to_write[inst.OUTPUT_TABLE]
-        df = write_config["data"]
+    def test__appeal_has_curated_process__run__with_no_existing_data(self):
+        """
+        - Given I have harmonised appeal_has data
+        - When I call AppealHasCuratedMipinsProcess.run
+        - Then the data should be transformed and the appeals_has_curated_mipins table should be created
+        """
+        self.assert_curated_etl("t_ahcp_r_wned")
 
-        assert "IsActive" not in df.columns
-        assert write_config["write_mode"] == "overwrite"
-        assert write_config["file_format"] == "parquet"
-        assert "partition_by" not in write_config
-
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 1,
-            "update_count": 0,
-            "delete_count": 0,
-        }
-
-        actual_df = df.select(
-            "caseId",
-            "caseReference",
-            "submissionId",
-            "caseStatus",
-            "caseType",
-            "caseProcedure",
-            "lpaCode",
-            "caseOfficerId",
-            "inspectorId",
-            "allocationLevel",
-            "allocationBand",
-            "caseSpecialisms",
-            "caseCreatedDate",
-            "caseUpdatedDate",
-            "caseValidationDate",
-            "caseValidationOutcome",
-            "linkedCaseStatus",
-            "leadCaseReference",
-            "lpaQuestionnaireDueDate",
-            "lpaQuestionnaireSubmittedDate",
-            "caseDecisionOutcomeDate",
-            "caseDecisionOutcome",
-            "caseCompletedDate",
-            "applicationReference",
-            "applicationDate",
-            "applicationDecisionDate",
-            "siteAddressLine1",
-            "siteAddressLine2",
-            "siteAddressTown",
-            "siteAddressCounty",
-            "siteAddressPostcode",
-            "siteAreaSquareMetres",
-            "floorSpaceSquareMetres",
-            "isGreenBelt",
-            "inConservationArea",
-            "originalDevelopmentDescription",
-            "typeOfPlanningApplication",
-            "dateCostsReportDespatched",
-            "dateNotRecoveredOrDerecovered",
-            "dateRecovered",
-            "importantInformation",
-            "isAonbNationalLandscape",
-            "jurisdiction",
-            "lpaProcedurePreference",
-            "originalCaseDecisionDate",
-            "redeterminedIndicator",
-            "siteGridReferenceEasting",
-            "siteGridReferenceNorthing",
-            "padsSapId",
-        )
-
-        expected_df = spark.createDataFrame(
-            [
-                (
-                    "1001",
-                    "HAS-001",
-                    "SUB-001",
-                    "valid",
-                    "HAS",
-                    "WR",
-                    "LPA01",
-                    "OFFICER-001",
-                    "INSPECTOR-001",
-                    "Level 1",
-                    "Band A",
-                    ["Advertisements", "Listed Building"],
-                    "2025-01-02",
-                    "2025-01-03",
-                    "2025-01-03",
-                    "Valid appeal",
-                    "Linked",
-                    "LEAD-001",
-                    "2025-01-05",
-                    "2025-01-06",
-                    "2025-01-07",
-                    "Allowed",
-                    "2025-01-08",
-                    "APP-REF-001",
-                    "2025-01-09",
-                    "2025-01-10",
-                    "Line 1",
-                    "Line 2",
-                    "Town 1",
-                    "County 1",
-                    "AA1 1AA",
-                    1000.0,
-                    50.0,
-                    "Y",
-                    "N",
-                    "Development 1",
-                    "Full Planning",
-                    "2025-01-11",
-                    "2025-01-12",
-                    "2025-01-13",
-                    "Important info 1",
-                    "Y",
-                    "HAS",
-                    "Written Reps",
-                    "2025-01-14",
-                    "N",
-                    "123",
-                    "456",
-                    "SAP-001",
-                )
-            ],
-            actual_df.schema,
-        )
-
-        assert_dataframes_equal(actual_df, expected_df)
-
-    def test__appeal_has_curated_process__run__empty_harmonised_source_writes_empty_output_like_legacy(self):
+    def test__appeal_has_curated_process__run__with_existing_data(self):
+        """
+        - Given I have harmonised appeal_has data and an existing curated appeal_has table
+        - When I call AppealHasCuratedMipinsProcess.run
+        - Then the data should be transformed and the appeals_has_curated_mipins table should be created
+        """
+        test_case = "t_ahcp_r_wed"
+        output_table = f"{test_case}_appeals_has"
         spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = _source_data(_empty_harmonised_df(spark))
-
-        inst = AppealHasCuratedProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        write_config = data_to_write[inst.OUTPUT_TABLE]
-        df = write_config["data"]
-
-        assert df.count() == 0
-        assert df.columns == CURATED_COLUMNS
-        assert write_config["write_mode"] == "overwrite"
-        assert write_config["file_format"] == "parquet"
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 0,
-            "update_count": 0,
-            "delete_count": 0,
-        }
-
-    def test__appeal_has_curated_process__run__adds_missing_columns_as_null_like_legacy(self):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        minimal_df = spark.createDataFrame(
-            [("1001", "HAS-001", "valid", "HAS", "Y")],
-            T.StructType(
-                [
-                    T.StructField("caseId", T.StringType(), True),
-                    T.StructField("caseReference", T.StringType(), True),
-                    T.StructField("caseStatus", T.StringType(), True),
-                    T.StructField("caseType", T.StringType(), True),
-                    T.StructField("IsActive", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data = _source_data(minimal_df)
-
-        inst = AppealHasCuratedProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        df = mock_write.call_args[0][0][inst.OUTPUT_TABLE]["data"]
-        row = df.collect()[0]
-
-        assert df.columns == CURATED_COLUMNS
-
-        for col_name in CURATED_COLUMNS:
-            if col_name not in {"caseId", "caseReference", "caseStatus", "caseType"}:
-                assert row[col_name] is None
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 1,
-            "update_count": 0,
-            "delete_count": 0,
-        }
+        existing_data = spark.createDataFrame((_curated_row(caseId="1"),), schema=_curated_schema())
+        self.assert_curated_etl(test_case)
+        self.write_existing_table(spark, existing_data, output_table, "odw_curated_db", "odw-curated", output_table, "overwrite")
+        self.assert_curated_etl(test_case)

--- a/odw/test/integration_test/etl/harmonised/test_appeal_has_harmonisation_process.py
+++ b/odw/test/integration_test/etl/harmonised/test_appeal_has_harmonisation_process.py
@@ -3,13 +3,11 @@ import mock
 import pytest
 import pyspark.sql.types as T
 from pyspark.sql import Row
-from pyspark.sql import functions as F
-from odw.test.util.assertion import assert_dataframes_equal
+from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.harmonised.appeal_has_harmonisation_process import AppealHasHarmonisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
-from odw.test.util.assertion import assert_dataframes_equal, assert_etl_result_successful
 
 # pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
 

--- a/odw/test/integration_test/etl/harmonised/test_appeal_has_harmonisation_process.py
+++ b/odw/test/integration_test/etl/harmonised/test_appeal_has_harmonisation_process.py
@@ -9,7 +9,7 @@ from odw.core.etl.transformation.harmonised.appeal_has_harmonisation_process imp
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
 
-# pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
+pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
 
 
 def _appeal_has_schema():

--- a/odw/test/integration_test/etl/harmonised/test_appeal_has_harmonisation_process.py
+++ b/odw/test/integration_test/etl/harmonised/test_appeal_has_harmonisation_process.py
@@ -9,8 +9,9 @@ import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.harmonised.appeal_has_harmonisation_process import AppealHasHarmonisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.test.util.assertion import assert_dataframes_equal, assert_etl_result_successful
 
-pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
+# pytestmark = pytest.mark.xfail(reason="Harmonisation logic not implemented yet")
 
 
 def _appeal_has_schema():
@@ -255,17 +256,262 @@ def _s78_df(spark, rows=None):
     return spark.createDataFrame(rows, _s78_schema())
 
 
-def _source_data(spark, service_bus_data=None, horizon_data=None, appeal_s78_data=None):
-    return {
-        "service_bus_data": service_bus_data or _empty_df(spark, _appeal_has_schema()),
-        "horizon_data": horizon_data or _empty_df(spark, _horizon_schema()),
-        "appeal_s78_data": appeal_s78_data or _s78_df(spark),
+def _harmonised_appeal_has_schema():
+    return T.StructType(
+        [
+            T.StructField("caseReference", T.StringType(), True),
+            T.StructField("AppealsHasID", T.LongType(), False),
+            T.StructField("caseId", T.StringType(), True),
+            T.StructField("submissionId", T.StringType(), True),
+            T.StructField("caseStatus", T.StringType(), True),
+            T.StructField("caseType", T.StringType(), True),
+            T.StructField("caseProcedure", T.StringType(), True),
+            T.StructField("lpaCode", T.StringType(), True),
+            T.StructField("caseOfficerId", T.StringType(), True),
+            T.StructField("inspectorId", T.StringType(), True),
+            T.StructField("allocationLevel", T.StringType(), True),
+            T.StructField("allocationBand", T.StringType(), True),
+            T.StructField("caseSpecialisms", T.ArrayType(T.StringType(), True), True),
+            T.StructField("caseSubmittedDate", T.StringType(), True),
+            T.StructField("caseCreatedDate", T.StringType(), True),
+            T.StructField("caseUpdatedDate", T.StringType(), True),
+            T.StructField("caseValidDate", T.StringType(), True),
+            T.StructField("caseValidationDate", T.StringType(), True),
+            T.StructField("caseValidationOutcome", T.StringType(), True),
+            T.StructField("caseValidationInvalidDetails", T.StringType(), True),
+            T.StructField("caseValidationIncompleteDetails", T.StringType(), True),
+            T.StructField("caseExtensionDate", T.StringType(), True),
+            T.StructField("caseStartedDate", T.StringType(), True),
+            T.StructField("casePublishedDate", T.StringType(), True),
+            T.StructField("linkedCaseStatus", T.StringType(), True),
+            T.StructField("leadCaseReference", T.StringType(), True),
+            T.StructField("lpaQuestionnaireDueDate", T.StringType(), True),
+            T.StructField("lpaQuestionnaireSubmittedDate", T.StringType(), True),
+            T.StructField("lpaQuestionnaireCreatedDate", T.StringType(), True),
+            T.StructField("lpaQuestionnairePublishedDate", T.StringType(), True),
+            T.StructField("lpaQuestionnaireValidationOutcome", T.StringType(), True),
+            T.StructField("lpaQuestionnaireValidationOutcomeDate", T.StringType(), True),
+            T.StructField("lpaQuestionnaireValidationDetails", T.StringType(), True),
+            T.StructField("lpaStatement", T.StringType(), True),
+            T.StructField("caseWithdrawnDate", T.StringType(), True),
+            T.StructField("caseTransferredDate", T.StringType(), True),
+            T.StructField("transferredCaseClosedDate", T.StringType(), True),
+            T.StructField("caseDecisionOutcomeDate", T.StringType(), True),
+            T.StructField("caseDecisionPublishedDate", T.StringType(), True),
+            T.StructField("caseDecisionOutcome", T.StringType(), True),
+            T.StructField("caseCompletedDate", T.StringType(), True),
+            T.StructField("enforcementNotice", T.StringType(), True),
+            T.StructField("applicationReference", T.StringType(), True),
+            T.StructField("applicationDate", T.StringType(), True),
+            T.StructField("applicationDecision", T.StringType(), True),
+            T.StructField("applicationDecisionDate", T.StringType(), True),
+            T.StructField("caseSubmissionDueDate", T.StringType(), True),
+            T.StructField("siteAddressLine1", T.StringType(), True),
+            T.StructField("siteAddressLine2", T.StringType(), True),
+            T.StructField("siteAddressTown", T.StringType(), True),
+            T.StructField("siteAddressCounty", T.StringType(), True),
+            T.StructField("siteAddressPostcode", T.StringType(), True),
+            T.StructField("siteAccessDetails", T.StringType(), True),
+            T.StructField("siteSafetyDetails", T.StringType(), True),
+            T.StructField("siteAreaSquareMetres", T.DoubleType(), True),
+            T.StructField("floorSpaceSquareMetres", T.DoubleType(), True),
+            T.StructField("isCorrectAppealType", T.StringType(), True),
+            T.StructField("isGreenBelt", T.StringType(), True),
+            T.StructField("inConservationArea", T.StringType(), True),
+            T.StructField("ownsAllLand", T.StringType(), True),
+            T.StructField("ownsSomeLand", T.StringType(), True),
+            T.StructField("knowsOtherOwners", T.StringType(), True),
+            T.StructField("knowsAllOwners", T.StringType(), True),
+            T.StructField("advertisedAppeal", T.StringType(), True),
+            T.StructField("notificationMethod", T.StringType(), True),
+            T.StructField("ownersInformed", T.StringType(), True),
+            T.StructField("originalDevelopmentDescription", T.StringType(), True),
+            T.StructField("changedDevelopmentDescription", T.StringType(), True),
+            T.StructField("newConditionDetails", T.StringType(), True),
+            T.StructField("nearbyCaseReferences", T.StringType(), True),
+            T.StructField("neighbouringSiteAddresses", T.StringType(), True),
+            T.StructField("affectedListedBuildingNumbers", T.StringType(), True),
+            T.StructField("appellantCostsAppliedFor", T.StringType(), True),
+            T.StructField("lpaCostsAppliedFor", T.StringType(), True),
+            T.StructField("typeOfPlanningApplication", T.StringType(), True),
+            T.StructField("reasonForNeighbourVisits", T.StringType(), True),
+            T.StructField("affectsScheduledMonument", T.StringType(), True),
+            T.StructField("caseworkReason", T.StringType(), True),
+            T.StructField("dateCostsReportDespatched", T.StringType(), True),
+            T.StructField("dateNotRecoveredOrDerecovered", T.StringType(), True),
+            T.StructField("dateRecovered", T.StringType(), True),
+            T.StructField("designatedSitesNames", T.StringType(), True),
+            T.StructField("didAppellantSubmitCompletePhotosAndPlans", T.StringType(), True),
+            T.StructField("hasInfrastructureLevy", T.StringType(), True),
+            T.StructField("hasLandownersPermission", T.StringType(), True),
+            T.StructField("hasProtectedSpecies", T.StringType(), True),
+            T.StructField("importantInformation", T.StringType(), True),
+            T.StructField("infrastructureLevyAdoptedDate", T.StringType(), True),
+            T.StructField("infrastructureLevyExpectedDate", T.StringType(), True),
+            T.StructField("isAonbNationalLandscape", T.StringType(), True),
+            T.StructField("isInfrastructureLevyFormallyAdopted", T.StringType(), True),
+            T.StructField("isSiteInAreaOfSpecialControlAdverts", T.StringType(), True),
+            T.StructField("advertDetails", T.StringType(), True),
+            T.StructField("jurisdiction", T.StringType(), True),
+            T.StructField("lpaProcedurePreference", T.StringType(), True),
+            T.StructField("lpaProcedurePreferenceDetails", T.StringType(), True),
+            T.StructField("lpaProcedurePreferenceDuration", T.StringType(), True),
+            T.StructField("originalCaseDecisionDate", T.StringType(), True),
+            T.StructField("redeterminedIndicator", T.StringType(), True),
+            T.StructField("siteGridReferenceEasting", T.StringType(), True),
+            T.StructField("siteGridReferenceNorthing", T.StringType(), True),
+            T.StructField("targetDate", T.StringType(), True),
+            T.StructField("wasApplicationRefusedDueToHighwayOrTraffic", T.StringType(), True),
+            T.StructField("padsSapId", T.StringType(), True),
+            T.StructField("migrated", T.StringType(), True),
+            T.StructField("ODTSourceSystem", T.StringType(), True),
+            T.StructField("IngestionDate", T.TimestampType(), True),
+            T.StructField("message_id", T.StringType(), True),
+            T.StructField("SourceSystemID", T.StringType(), True),
+            T.StructField("ValidTo", T.TimestampType(), True),
+            T.StructField("RowID", T.StringType(), False),
+            T.StructField("IsActive", T.StringType(), False),
+        ]
+    )
+
+
+def _harmonised_appeal_has_row(**overrides):
+    base = {
+        "caseReference": "HAS-001",
+        "AppealsHasID": 1,
+        "caseId": "1001",
+        "submissionId": None,
+        "caseStatus": "submitted",
+        "caseType": "HAS",
+        "caseProcedure": "WR",
+        "lpaCode": "LPA01",
+        "caseOfficerId": None,
+        "inspectorId": "INS-001",
+        "allocationLevel": "Level 1",
+        "allocationBand": "Band A",
+        "caseSpecialisms": ["Advertisements"],
+        "caseSubmittedDate": None,
+        "caseCreatedDate": "2025-01-01",
+        "caseUpdatedDate": "2025-01-02",
+        "caseValidDate": None,
+        "caseValidationDate": "2025-01-03",
+        "caseValidationOutcome": "Valid appeal",
+        "caseValidationInvalidDetails": None,
+        "caseValidationIncompleteDetails": None,
+        "caseExtensionDate": None,
+        "caseStartedDate": None,
+        "casePublishedDate": None,
+        "linkedCaseStatus": None,
+        "leadCaseReference": None,
+        "lpaQuestionnaireDueDate": None,
+        "lpaQuestionnaireSubmittedDate": None,
+        "lpaQuestionnaireCreatedDate": None,
+        "lpaQuestionnairePublishedDate": None,
+        "lpaQuestionnaireValidationOutcome": None,
+        "lpaQuestionnaireValidationOutcomeDate": None,
+        "lpaQuestionnaireValidationDetails": None,
+        "lpaStatement": None,
+        "caseWithdrawnDate": None,
+        "caseTransferredDate": None,
+        "transferredCaseClosedDate": None,
+        "caseDecisionOutcomeDate": None,
+        "caseDecisionPublishedDate": None,
+        "caseDecisionOutcome": None,
+        "caseCompletedDate": None,
+        "enforcementNotice": None,
+        "applicationReference": None,
+        "applicationDate": None,
+        "applicationDecision": None,
+        "applicationDecisionDate": None,
+        "caseSubmissionDueDate": None,
+        "siteAddressLine1": "1 Test Street",
+        "siteAddressLine2": None,
+        "siteAddressTown": "Test Town",
+        "siteAddressCounty": None,
+        "siteAddressPostcode": "AA1 1AA",
+        "siteAccessDetails": None,
+        "siteSafetyDetails": None,
+        "siteAreaSquareMetres": 1000.0,
+        "floorSpaceSquareMetres": 50.0,
+        "isCorrectAppealType": None,
+        "isGreenBelt": None,
+        "inConservationArea": None,
+        "ownsAllLand": None,
+        "ownsSomeLand": None,
+        "knowsOtherOwners": None,
+        "knowsAllOwners": None,
+        "advertisedAppeal": None,
+        "notificationMethod": None,
+        "ownersInformed": None,
+        "originalDevelopmentDescription": None,
+        "changedDevelopmentDescription": None,
+        "newConditionDetails": None,
+        "nearbyCaseReferences": None,
+        "neighbouringSiteAddresses": None,
+        "affectedListedBuildingNumbers": None,
+        "appellantCostsAppliedFor": None,
+        "lpaCostsAppliedFor": None,
+        "typeOfPlanningApplication": None,
+        "reasonForNeighbourVisits": None,
+        "affectsScheduledMonument": None,
+        "caseworkReason": None,
+        "dateCostsReportDespatched": None,
+        "dateNotRecoveredOrDerecovered": None,
+        "dateRecovered": None,
+        "designatedSitesNames": None,
+        "didAppellantSubmitCompletePhotosAndPlans": None,
+        "hasInfrastructureLevy": None,
+        "hasLandownersPermission": None,
+        "hasProtectedSpecies": None,
+        "importantInformation": None,
+        "infrastructureLevyAdoptedDate": None,
+        "infrastructureLevyExpectedDate": None,
+        "isAonbNationalLandscape": None,
+        "isInfrastructureLevyFormallyAdopted": None,
+        "isSiteInAreaOfSpecialControlAdverts": None,
+        "advertDetails": None,
+        "jurisdiction": None,
+        "lpaProcedurePreference": None,
+        "lpaProcedurePreferenceDetails": None,
+        "lpaProcedurePreferenceDuration": None,
+        "originalCaseDecisionDate": None,
+        "redeterminedIndicator": None,
+        "siteGridReferenceEasting": None,
+        "siteGridReferenceNorthing": None,
+        "targetDate": None,
+        "wasApplicationRefusedDueToHighwayOrTraffic": None,
+        "padsSapId": None,
+        "migrated": "0",
+        "ODTSourceSystem": "ODT",
+        "IngestionDate": datetime(2025, 1, 1, 0, 0),
+        "message_id": "msg-001",
+        "SourceSystemID": "source-001",
+        "ValidTo": datetime(2025, 2, 1, 0, 0),
+        "RowID": "",
+        "IsActive": "N",
     }
+    return base | overrides
+
+
+def _resolver_schema():
+    return T.StructType(
+        [
+            T.StructField("caseReference", T.StringType(), True),
+            T.StructField("currentGroup", T.StringType(), False),
+            T.StructField("asOfTimestamp", T.TimestampType(), True),
+        ]
+    )
+
+
+def _resolver_row(**overrides):
+    base = {"caseReference": "HAS-001", "currentGroup": "A", "asOfTimestamp": datetime(2025, 2, 1, 0, 0)}
+    return base | overrides
 
 
 class TestRefAppealHasHarmonisationProcess(ETLTestCase):
-    def test__appeal_has_harmonisation_process__run__harmonises_service_bus_and_horizon_end_to_end_like_legacy(self):
+    def assert_successful_harmonisation(self, test_case: str):
         spark = PytestSparkSessionUtil().get_spark_session()
+        appeal_has_table = f"{test_case}_appeal_has"
 
         service_bus_data = _sb_df(
             spark,
@@ -289,6 +535,8 @@ class TestRefAppealHasHarmonisationProcess(ETLTestCase):
                 ),
             ],
         )
+        service_bus_table = f"{test_case}_sb_appeal_has"
+        self.write_existing_table(spark, service_bus_data, service_bus_table, "odw_harmonised_db", "odw-harmonised", service_bus_table, "overwrite")
 
         horizon_data = _horizon_df(
             spark,
@@ -347,6 +595,8 @@ class TestRefAppealHasHarmonisationProcess(ETLTestCase):
                 )
             ],
         )
+        horizon_table = f"{test_case}_horizon_appeal_has"
+        self.write_existing_table(spark, horizon_data, horizon_table, "odw_standardised_db", "odw-standardised", horizon_table, "overwrite")
 
         appeal_s78_data = _s78_df(
             spark,
@@ -354,288 +604,115 @@ class TestRefAppealHasHarmonisationProcess(ETLTestCase):
                 ("HAS-002", datetime(2025, 4, 1), None, "Y"),
             ],
         )
-
-        source_data = _source_data(spark, service_bus_data, horizon_data, appeal_s78_data)
-
-        inst = AppealHasHarmonisationProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        write_config = data_to_write[inst.OUTPUT_TABLE]
-        df = write_config["data"]
-
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 3,
-            "update_count": 0,
-            "delete_count": 0,
-        }
-        assert write_config["write_mode"] == "overwrite"
-        assert write_config["partition_by"] == ["IsActive"]
-        assert write_config["file_format"] == "delta"
-
-        actual_df = df.select(
-            "caseReference",
-            "IngestionDate",
-            "ValidTo",
-            "IsActive",
-            "ODTSourceSystem",
-            "caseSpecialisms",
-            "caseStatus",
-            "siteAddressPostcode",
+        appeal_s78_table = f"{test_case}_appeal_s78"
+        self.write_existing_table(spark, appeal_s78_data, appeal_s78_table, "odw_harmonised_db", "odw-harmonised", appeal_s78_table, "overwrite")
+        expected_appeal_has_data = spark.createDataFrame(
+            (
+                _harmonised_appeal_has_row(),
+                _harmonised_appeal_has_row(
+                    AppealsHasID=2, caseStatus="valid", IngestionDate=datetime(2025, 2, 1, 0, 0), message_id="msg-002", ValidTo=None, IsActive="Y"
+                ),
+                _harmonised_appeal_has_row(
+                    caseReference="HAS-002",
+                    caseId="1002",
+                    caseStatus="horizon submitted",
+                    caseProcedure="LI",
+                    lpaCode="LPA02",
+                    inspectorId="INS-002",
+                    allocationLevel="Level 2",
+                    allocationBand="Band B",
+                    caseSpecialisms=["Listed Building", "Advertisements"],
+                    caseCreatedDate="2025-03-01",
+                    caseUpdatedDate="2025-03-02",
+                    caseValidationDate="2025-03-03",
+                    caseStartedDate="2025-03-04",
+                    linkedCaseStatus="Linked",
+                    leadCaseReference="LEAD-002",
+                    lpaQuestionnaireDueDate="2025-03-05",
+                    lpaQuestionnaireSubmittedDate="2025-03-06",
+                    caseWithdrawnDate="2025-03-07",
+                    caseDecisionOutcomeDate="2025-03-08",
+                    caseDecisionOutcome="Allowed",
+                    caseCompletedDate="2025-03-09",
+                    applicationReference="APP-REF-002",
+                    applicationDate="2025-03-10",
+                    applicationDecisionDate="2025-03-11",
+                    siteAddressLine1="Line 1",
+                    siteAddressLine2="Line 2",
+                    siteAddressTown="Town",
+                    siteAddressCounty="County",
+                    siteAddressPostcode="BB1 1BB",
+                    siteAreaSquareMetres=2000.0,
+                    floorSpaceSquareMetres=75.0,
+                    isGreenBelt="Y",
+                    inConservationArea="N",
+                    originalDevelopmentDescription="Development 2",
+                    typeOfPlanningApplication="Full Planning",
+                    dateCostsReportDespatched="2025-03-12",
+                    dateNotRecoveredOrDerecovered="2025-03-13",
+                    dateRecovered="2025-03-14",
+                    importantInformation="Important horizon info",
+                    isAonbNationalLandscape="Y",
+                    jurisdiction="HAS",
+                    lpaProcedurePreference="Inquiry",
+                    originalCaseDecisionDate="2025-03-15",
+                    redeterminedIndicator="N",
+                    siteGridReferenceEasting="123",
+                    siteGridReferenceNorthing="456",
+                    migrated=None,
+                    ODTSourceSystem="HORIZON",
+                    IngestionDate=datetime(2025, 3, 1, 0, 0),
+                    message_id=None,
+                    SourceSystemID=None,
+                    ValidTo=datetime(2025, 4, 1, 0, 0),
+                ),
+            ),
+            schema=_harmonised_appeal_has_schema(),
         )
-
-        expected_df = spark.createDataFrame(
-            [
-                (
-                    "HAS-001",
-                    datetime(2025, 1, 1),
-                    datetime(2025, 2, 1),
-                    "N",
-                    "ODT",
-                    ["Advertisements"],
-                    "submitted",
-                    "AA1 1AA",
-                ),
-                (
-                    "HAS-001",
-                    datetime(2025, 2, 1),
-                    None,
-                    "Y",
-                    "ODT",
-                    ["Advertisements"],
-                    "valid",
-                    "AA1 1AA",
-                ),
-                (
-                    "HAS-002",
-                    datetime(2025, 3, 1),
-                    datetime(2025, 4, 1),
-                    "N",
-                    "HORIZON",
-                    ["Listed Building", "Advertisements"],
-                    "horizon submitted",
-                    "BB1 1BB",
-                ),
-            ],
-            actual_df.schema,
-        )
-
-        assert_dataframes_equal(actual_df, expected_df)
-
-    def test__appeal_has_harmonisation_process__run__empty_sources_write_empty_output_like_legacy(self):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        source_data = _source_data(spark)
-
-        inst = AppealHasHarmonisationProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 0,
-            "update_count": 0,
-            "delete_count": 0,
-        }
-        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
-        assert data_to_write[inst.OUTPUT_TABLE]["partition_by"] == ["IsActive"]
-        assert data_to_write[inst.OUTPUT_TABLE]["file_format"] == "delta"
-
-    def test__appeal_has_harmonisation_process__run__covers_scd2_duplicates_ties_s78_and_schema_end_to_end_like_legacy(self):
-        spark = PytestSparkSessionUtil().get_spark_session()
-
-        service_bus_data = _sb_df(
-            spark,
-            [
-                _base_sb_row(
-                    caseReference="HAS-001",
-                    caseStatus="submitted",
-                    RowID="a-row",
-                    ODTSourceSystem="ODT",
-                    IngestionDate=datetime(2025, 1, 1),
-                    message_id="msg-001",
-                ),
-                _base_sb_row(
-                    caseReference="HAS-001",
-                    caseStatus="valid",
-                    RowID="b-row",
-                    ODTSourceSystem="ODT",
-                    IngestionDate=datetime(2025, 2, 1),
-                    message_id="msg-002",
-                ),
-                _base_sb_row(
-                    caseReference="HAS-001",
-                    caseStatus="valid",
-                    RowID="b-row",
-                    ODTSourceSystem="ODT",
-                    IngestionDate=datetime(2025, 2, 1),
-                    message_id="msg-002",
-                ),
-                _base_sb_row(
-                    caseReference=None,
-                    caseStatus="null key should be removed",
-                    ODTSourceSystem="ODT",
-                    IngestionDate=datetime(2025, 1, 1),
-                    message_id="bad-msg",
-                ),
-            ],
-        )
-
-        horizon_data = _horizon_df(
-            spark,
-            [
-                (
-                    "HAS-002",
-                    "1002",
-                    "horizon submitted",
-                    "HAS",
-                    "LI",
-                    "LPA02",
-                    "INS-002",
-                    "Level 2",
-                    "Band B",
-                    "Listed Building,Advertisements",
-                    "2025-03-01",
-                    "2025-03-02",
-                    "2025-03-03",
-                    "Valid appeal",
-                    "2025-03-04",
-                    "Linked",
-                    "LEAD-002",
-                    "2025-03-05",
-                    "2025-03-06",
-                    "2025-03-07",
-                    "2025-03-08",
-                    "Allowed",
-                    "2025-03-09",
-                    "APP-REF-002",
-                    "2025-03-10",
-                    "2025-03-11",
-                    "Line 1",
-                    "Line 2",
-                    "Town",
-                    "County",
-                    "BB1 1BB",
-                    2000.0,
-                    75.0,
-                    "Y",
-                    "N",
-                    "Development 2",
-                    "Full Planning",
-                    "2025-03-12",
-                    "2025-03-13",
-                    "2025-03-14",
-                    "Important horizon info",
-                    "Y",
-                    "HAS",
-                    "Inquiry",
-                    "2025-03-15",
-                    "N",
-                    "123",
-                    "456",
-                    None,
-                    datetime(2025, 3, 1),
-                )
-            ],
-        )
-
-        appeal_s78_data = _s78_df(
+        expected_group_resolver_data = spark.createDataFrame((_resolver_row(),), schema=_resolver_schema())
+        group_resolver_table = f"{test_case}_GroupResolver"
+        expected_s78_data_after = _s78_df(
             spark,
             [
                 ("HAS-002", datetime(2025, 4, 1), None, "Y"),
             ],
         )
-
-        source_data = _source_data(spark, service_bus_data, horizon_data, appeal_s78_data)
-
-        inst = AppealHasHarmonisationProcess(spark)
-
         with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
+            mock.patch.object(AppealHasHarmonisationProcess, "OUTPUT_TABLE", appeal_has_table),
+            mock.patch.object(AppealHasHarmonisationProcess, "SERVICE_BUS_TABLE", service_bus_table),
+            mock.patch.object(AppealHasHarmonisationProcess, "HORIZON_TABLE", horizon_table),
+            mock.patch.object(AppealHasHarmonisationProcess, "GROUP_RESOLVER_TABLE", group_resolver_table),
+            mock.patch.object(AppealHasHarmonisationProcess, "S78_TABLE", appeal_s78_table),
         ):
+            inst = AppealHasHarmonisationProcess(spark)
             result = inst.run()
+            assert_etl_result_successful(result)
+            actual_has_data = spark.table(appeal_has_table)
+            assert_dataframes_equal(expected_appeal_has_data, actual_has_data)
+            actual_group_resolver_data = spark.table()
+            assert_dataframes_equal(expected_group_resolver_data, actual_group_resolver_data)
+            actual_s78_data = spark.table()
+            assert_dataframes_equal(expected_s78_data_after, actual_s78_data)
 
-        data_to_write = mock_write.call_args[0][0]
-        write_config = data_to_write[inst.OUTPUT_TABLE]
-        df = write_config["data"]
+    def test__appeal_has_harmonisation_process__run__with_no_existing_data(self):
+        """
+        - Given I have some existing standardised appeal has data, some s78 and service bus/horizon appeal has data
+        - When I call AppealHasHarmonisationProcess.run
+        - Then the appeal has data should be harmonised, and group resolver/s78 tables updated
+        """
+        self.assert_successful_harmonisation("t_ahhp_r_wned")
 
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 3,
-            "update_count": 0,
-            "delete_count": 0,
-        }
-        assert df.where(F.col("caseReference").isNull()).count() == 0
-        assert df.where(F.col("IsActive") == "Y").groupBy("caseReference").count().where("count > 1").count() == 0
-
-        assert write_config["write_mode"] == "overwrite"
-        assert write_config["partition_by"] == ["IsActive"]
-        assert write_config["file_format"] == "delta"
-        assert df.columns == [field.name for field in _appeal_has_schema()]
-
-        actual_df = df.select(
-            "caseReference",
-            "IngestionDate",
-            "ValidTo",
-            "IsActive",
-            "AppealsHasID",
-            "ODTSourceSystem",
-            "caseSpecialisms",
+    def test__appeal_has_harmonisation_process__run__with_existing_data(self):
+        """
+        - Given I have some existing standardised appeal has data, some s78 and service bus/horizon appeal has data and an existing harmonised has table
+        - When I call AppealHasHarmonisationProcess.run
+        - Then the harmonised appeal has data should be overwritten, and group resolver/s78 tables updated
+        """
+        test_case = "t_ahhp_r_wed"
+        spark = PytestSparkSessionUtil().get_spark_session()
+        existing_appeal_has = spark.createDataFrame(
+            (_harmonised_appeal_has_row(caseReference="some old ref to be deleted"),), schema=_harmonised_appeal_has_schema()
         )
-
-        expected_df = spark.createDataFrame(
-            [
-                (
-                    "HAS-001",
-                    datetime(2025, 1, 1),
-                    datetime(2025, 2, 1),
-                    "N",
-                    1,
-                    "ODT",
-                    ["Advertisements"],
-                ),
-                (
-                    "HAS-001",
-                    datetime(2025, 2, 1),
-                    None,
-                    "Y",
-                    2,
-                    "ODT",
-                    ["Advertisements"],
-                ),
-                (
-                    "HAS-002",
-                    datetime(2025, 3, 1),
-                    datetime(2025, 4, 1),
-                    "N",
-                    3,
-                    "HORIZON",
-                    ["Listed Building", "Advertisements"],
-                ),
-            ],
-            actual_df.schema,
-        )
-
-        assert_dataframes_equal(actual_df, expected_df)
+        appeal_has_table = f"{test_case}_appeal_has"
+        self.write_existing_table(spark, existing_appeal_has, appeal_has_table, "odw_harmonised_db", "odw-harmonised", appeal_has_table, "overwrite")
+        self.assert_successful_harmonisation("t_ahhp_r_wned")

--- a/odw/test/integration_test/etl/standardised/test_appeal_has_standardisation_process.py
+++ b/odw/test/integration_test/etl/standardised/test_appeal_has_standardisation_process.py
@@ -1,688 +1,2058 @@
 import mock
 import pytest
 import pyspark.sql.types as T
-from odw.test.util.assertion import assert_dataframes_equal
+from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.standardised.appeal_has_standardisation_process import AppealHasStandardisationProcess
 from odw.test.integration_test.etl.etl_test_case import ETLTestCase
 from odw.test.util.session_util import PytestSparkSessionUtil
+from pyspark.sql.types import StructType, StructField, TimestampType, StringType, IntegerType, DoubleType
+from datetime import datetime
+from contextlib import ExitStack
 
 pytestmark = pytest.mark.xfail(reason="Standardisation logic not implemented yet")
 
 
-def _metadata_schema(extra_fields):
-    return T.StructType(
-        extra_fields
-        + [
-            T.StructField("expected_from", T.StringType(), True),
-            T.StructField("modified_datetime", T.StringType(), True),
-            T.StructField("ingested_datetime", T.StringType(), True),
-            T.StructField("file_id", T.IntegerType(), True),
+def horizon_cases_has_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "CaseNodeId": None,
+        "subType": None,
+        "modifyDate": datetime(2025, 1, 1),
+        "Abbreviation": None,
+        "caseReference": None,
+        "caseUniqueId": None,
+        "caseOfficerId": None,
+        "caseOfficerLogin": None,
+        "caseOfficerName": None,
+        "coEmailAddress": None,
+        "casSubType": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def horizon_cases_has_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("CaseNodeId", StringType(), True),
+            StructField("subType", StringType(), True),
+            StructField("modifyDate", TimestampType(), True),
+            StructField("Abbreviation", StringType(), True),
+            StructField("caseReference", StringType(), True),
+            StructField("caseUniqueId", StringType(), True),
+            StructField("caseOfficerId", StringType(), True),
+            StructField("caseOfficerLogin", StringType(), True),
+            StructField("caseOfficerName", StringType(), True),
+            StructField("coEmailAddress", StringType(), True),
+            StructField("casSubType", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
         ]
     )
 
 
-def _empty_df(spark, schema):
-    return spark.createDataFrame([], schema)
+def cases_specialisms_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "casereference": None,
+        "lastmodified": None,
+        "casespecialism": None,
+        "input_file": None,
+        "ingested_by_process_name": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": "cases_specialisms",
+        "file_id": None,
+    }
+    return base | overrides
 
 
-def _minimal_source_data(spark, hzn_cases_has_df):
+def cases_specialisms_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casereference", StringType(), True),
+            StructField("lastmodified", StringType(), True),
+            StructField("casespecialism", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def vw_cases_dates_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "casenodeid": None,
+        "receiptdate": None,
+        "startdate": None,
+        "appealdocscomplete": None,
+        "callindate": None,
+        "datereceivedfromcallinauthority": None,
+        "bespoketargetdate": None,
+        "daterecovered": None,
+        "datenotrecoveredorderecovered": None,
+        "decisionsubmitdate": None,
+        "noticewithdrawndate": None,
+        "appealwithdrawndate": None,
+        "casedecisiondate": None,
+        "appealturnedawaydate": None,
+        "appeallapseddate": None,
+        "casecloseddate": None,
+        "proceduredetermineddate": None,
+        "originalcasedecisiondate": None,
+        "planningguaranteedate": None,
+        "datedecisionreportreceivedinpins": None,
+        "datesenttoreader": None,
+        "datereturnedfromreader": None,
+        "datepublicationprocedurecompleted": None,
+        "datecostsreportdespatched": None,
+        "orderrejectedorreturned": None,
+        "input_file": None,
+        "ingested_by_process_name": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": "vw_case_dates",
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def vw_cases_dates_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casenodeid", StringType(), True),
+            StructField("receiptdate", StringType(), True),
+            StructField("startdate", StringType(), True),
+            StructField("appealdocscomplete", StringType(), True),
+            StructField("callindate", StringType(), True),
+            StructField("datereceivedfromcallinauthority", StringType(), True),
+            StructField("bespoketargetdate", StringType(), True),
+            StructField("daterecovered", StringType(), True),
+            StructField("datenotrecoveredorderecovered", StringType(), True),
+            StructField("decisionsubmitdate", StringType(), True),
+            StructField("noticewithdrawndate", StringType(), True),
+            StructField("appealwithdrawndate", StringType(), True),
+            StructField("casedecisiondate", StringType(), True),
+            StructField("appealturnedawaydate", StringType(), True),
+            StructField("appeallapseddate", StringType(), True),
+            StructField("casecloseddate", StringType(), True),
+            StructField("proceduredetermineddate", StringType(), True),
+            StructField("originalcasedecisiondate", StringType(), True),
+            StructField("planningguaranteedate", StringType(), True),
+            StructField("datedecisionreportreceivedinpins", StringType(), True),
+            StructField("datesenttoreader", StringType(), True),
+            StructField("datereturnedfromreader", StringType(), True),
+            StructField("datepublicationprocedurecompleted", StringType(), True),
+            StructField("datecostsreportdespatched", StringType(), True),
+            StructField("orderrejectedorreturned", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def case_document_dates_dates_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "casenodeid": None,
+        "appealrefnumber": None,
+        "questionnairedue": None,
+        "questionnairereceived": None,
+        "lpaconditionssubmitted": None,
+        "lpaconditionsforwarded": None,
+        "statementduedate": None,
+        "appellantstatementsubmitted": None,
+        "appellantstatementforwarded": None,
+        "lpastatementsubmitted": None,
+        "lpastatementforwarded": None,
+        "datenotificationlettersent": None,
+        "interestedpartyrepsduedate": None,
+        "interestedpartyrepsforwarded": None,
+        "finalcommentsdue": None,
+        "appellantcommentssubmitted": None,
+        "appellantcommentsforwarded": None,
+        "lpacommentssubmitted": None,
+        "lpacommentsforwarded": None,
+        "commongrounddue": None,
+        "commongroundreceived": None,
+        "sitenoticesent": None,
+        "proofsdue": None,
+        "appellantsproofssubmitted": None,
+        "appellantsproofsforwarded": None,
+        "lpaproofssubmitted": None,
+        "lpaproofsforwarded": None,
+        "input_file": None,
+        "ingested_by_process_name": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def case_document_dates_dates_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casenodeid", StringType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("questionnairedue", StringType(), True),
+            StructField("questionnairereceived", StringType(), True),
+            StructField("lpaconditionssubmitted", StringType(), True),
+            StructField("lpaconditionsforwarded", StringType(), True),
+            StructField("statementduedate", StringType(), True),
+            StructField("appellantstatementsubmitted", StringType(), True),
+            StructField("appellantstatementforwarded", StringType(), True),
+            StructField("lpastatementsubmitted", StringType(), True),
+            StructField("lpastatementforwarded", StringType(), True),
+            StructField("datenotificationlettersent", StringType(), True),
+            StructField("interestedpartyrepsduedate", StringType(), True),
+            StructField("interestedpartyrepsforwarded", StringType(), True),
+            StructField("finalcommentsdue", StringType(), True),
+            StructField("appellantcommentssubmitted", StringType(), True),
+            StructField("appellantcommentsforwarded", StringType(), True),
+            StructField("lpacommentssubmitted", StringType(), True),
+            StructField("lpacommentsforwarded", StringType(), True),
+            StructField("commongrounddue", StringType(), True),
+            StructField("commongroundreceived", StringType(), True),
+            StructField("sitenoticesent", StringType(), True),
+            StructField("proofsdue", StringType(), True),
+            StructField("appellantsproofssubmitted", StringType(), True),
+            StructField("appellantsproofsforwarded", StringType(), True),
+            StructField("lpaproofssubmitted", StringType(), True),
+            StructField("lpaproofsforwarded", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def case_site_strings_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "casenodeid": None,
+        "landuse": None,
+        "areaofsite": None,
+        "addressline1": None,
+        "addressline2": None,
+        "town": None,
+        "county": None,
+        "postcode": None,
+        "country": None,
+        "greenbelt": "Yes",
+        "siteviewablefromroad": None,
+        "input_file": None,
+        "ingested_by_process_name": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def case_site_strings_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casenodeid", StringType(), True),
+            StructField("landuse", StringType(), True),
+            StructField("areaofsite", StringType(), True),
+            StructField("addressline1", StringType(), True),
+            StructField("addressline2", StringType(), True),
+            StructField("town", StringType(), True),
+            StructField("county", StringType(), True),
+            StructField("postcode", StringType(), True),
+            StructField("country", StringType(), True),
+            StructField("greenbelt", StringType(), True),
+            StructField("siteviewablefromroad", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def type_of_procedure_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "id": None,
+        "displayorder": None,
+        "name": None,
+        "description": None,
+        "proccode": None,
+        "startdate": None,
+        "enddate": None,
+        "input_file": None,
+        "ingested_by_process_name": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": "TypeOfProcedure",
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def type_of_procedure_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("id", StringType(), True),
+            StructField("displayorder", StringType(), True),
+            StructField("name", StringType(), True),
+            StructField("description", StringType(), True),
+            StructField("proccode", StringType(), True),
+            StructField("startdate", StringType(), True),
+            StructField("enddate", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def vw_additional_data_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "appealrefnumber": None,
+        "caseprocess": None,
+        "caseworkmarker": None,
+        "costsappliedforindicator": None,
+        "level": None,
+        "procedureappellant": None,
+        "procedurelpa": None,
+        "proceduredetermineddate": None,
+        "targetdate": None,
+        "agriculturalholding": None,
+        "developmentaffectsettingoflistedbuilding": None,
+        "floorspaceinsquaremetres": None,
+        "sitegridreferenceeasting": None,
+        "sitegridreferencenorthing": None,
+        "historicbuildinggrantmade": None,
+        "incarelatestoca": None,
+        "inspectorneedtoentersite": None,
+        "isfloodinganissue": None,
+        "isthesitewithinanaonb": None,
+        "sitewithinsssi": None,
+        "input_file": None,
+        "ingested_by_process_name": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": "vw_AddAdditionalData",
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def vw_additional_data_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("caseprocess", StringType(), True),
+            StructField("caseworkmarker", StringType(), True),
+            StructField("costsappliedforindicator", StringType(), True),
+            StructField("level", StringType(), True),
+            StructField("procedureappellant", StringType(), True),
+            StructField("procedurelpa", StringType(), True),
+            StructField("proceduredetermineddate", StringType(), True),
+            StructField("targetdate", StringType(), True),
+            StructField("agriculturalholding", StringType(), True),
+            StructField("developmentaffectsettingoflistedbuilding", StringType(), True),
+            StructField("floorspaceinsquaremetres", StringType(), True),
+            StructField("sitegridreferenceeasting", StringType(), True),
+            StructField("sitegridreferencenorthing", StringType(), True),
+            StructField("historicbuildinggrantmade", StringType(), True),
+            StructField("incarelatestoca", StringType(), True),
+            StructField("inspectorneedtoentersite", StringType(), True),
+            StructField("isfloodinganissue", StringType(), True),
+            StructField("isthesitewithinanaonb", StringType(), True),
+            StructField("sitewithinsssi", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def vw_additional_fields_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "appealrefnumber": None,
+        "casereference": None,
+        "standardpriority": None,
+        "importantinformation": None,
+        "input_file": None,
+        "ingested_by_process_name": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def vw_additional_fields_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("casereference", StringType(), True),
+            StructField("standardpriority", StringType(), True),
+            StructField("importantinformation", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def horizon_advert_attributes_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "advertAttributeKey": None,
+        "caseNodeId": None,
+        "caseUniqueId": None,
+        "setRowNumber": 1,
+        "advertType": None,
+        "publicSafetyLpaIndicator": None,
+        "amenityLpaIndicator": None,
+        "publicSafetyGroundOutcome": None,
+        "amenityGroundOutcome": None,
+        "advertInPosition": None,
+        "siteOnHighwayLand": None,
+        "advertdescription": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def horizon_advert_attributes_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("advertAttributeKey", StringType(), True),
+            StructField("caseNodeId", IntegerType(), True),
+            StructField("caseUniqueId", IntegerType(), True),
+            StructField("setRowNumber", IntegerType(), True),
+            StructField("advertType", StringType(), True),
+            StructField("publicSafetyLpaIndicator", StringType(), True),
+            StructField("amenityLpaIndicator", StringType(), True),
+            StructField("publicSafetyGroundOutcome", StringType(), True),
+            StructField("amenityGroundOutcome", StringType(), True),
+            StructField("advertInPosition", StringType(), True),
+            StructField("siteOnHighwayLand", StringType(), True),
+            StructField("advertdescription", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def type_of_level_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "name": None,
+        "band": None,
+        "displayorder": 1,
+        "id": 1,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def type_of_level_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("name", StringType(), True),
+            StructField("band", StringType(), True),
+            StructField("displayorder", IntegerType(), True),
+            StructField("id", IntegerType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def horizon_specialist_case_dates_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "appealrefnumber": None,
+        "datecostsreportdespatched": None,
+        "datedecisionreportreceivedinpins": None,
+        "datepublicationprocedurecompleted": None,
+        "datereturnedfromreader": None,
+        "datesenttoreader": None,
+        "orderrejectedorreturned": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def horizon_specialist_case_dates_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("datecostsreportdespatched", StringType(), True),
+            StructField("datedecisionreportreceivedinpins", StringType(), True),
+            StructField("datepublicationprocedurecompleted", StringType(), True),
+            StructField("datereturnedfromreader", StringType(), True),
+            StructField("datesenttoreader", StringType(), True),
+            StructField("orderrejectedorreturned", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def planning_app_strings_row(**overrides):
+    base = {}
+    return base | overrides
+
+
+def planning_app_strings_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casenodeid", StringType(), True),
+            StructField("planningapplicationtype", StringType(), True),
+            StructField("lpaapplicationreference", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def planning_app_dates_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "casenodeid": None,
+        "dateoflpaddecision": None,
+        "dateofapplication": None,
+        "dateoflpadecision": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def planning_app_dates_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casenodeid", StringType(), True),
+            StructField("dateoflpaddecision", StringType(), True),
+            StructField("dateofapplication", StringType(), True),
+            StructField("dateoflpadecision", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def bis_lead_case_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "casenodeid": None,
+        "leadcasenodeid": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def bis_lead_case_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casenodeid", StringType(), True),
+            StructField("leadcasenodeid", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def case_strings_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "casenodeid": None,
+        "proceduretype": None,
+        "decision": None,
+        "linkedstatus": None,
+        "lpacode": None,
+        "lpaname": None,
+        "caseworkreason": None,
+        "casetype": None,
+        "redetermined": None,
+        "jurisdiction": None,
+        "developmenttype": None,
+        "bespokeindicator": None,
+        "processingstate": None,
+        "sourceindicator": None,
+        "englandwalesindicator": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def case_strings_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("casenodeid", StringType(), True),
+            StructField("proceduretype", StringType(), True),
+            StructField("decision", StringType(), True),
+            StructField("linkedstatus", StringType(), True),
+            StructField("lpacode", StringType(), True),
+            StructField("lpaname", StringType(), True),
+            StructField("caseworkreason", StringType(), True),
+            StructField("casetype", StringType(), True),
+            StructField("redetermined", StringType(), True),
+            StructField("jurisdiction", StringType(), True),
+            StructField("developmenttype", StringType(), True),
+            StructField("bespokeindicator", StringType(), True),
+            StructField("processingstate", StringType(), True),
+            StructField("sourceindicator", StringType(), True),
+            StructField("englandwalesindicator", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def horizon_case_info_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "appealrefnumber": None,
+        "casereference": None,
+        "validity": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def horizon_case_info_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("casereference", StringType(), True),
+            StructField("validity", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def horizon_case_dates_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "appealrefnumber": None,
+        "casereference": None,
+        "validitystatusdate": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def horizon_case_dates_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("casereference", StringType(), True),
+            StructField("validitystatusdate", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def horizon_appeals_additional_data_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "appealrefnumber": None,
+        "lastmodified": None,
+        "decisiondate": None,
+        "decisionsubmitdate": None,
+        "bespokeindicator": None,
+        "bespoketargetdate": None,
+        "processingstate": None,
+        "linkstatus": None,
+        "casecloseddate": None,
+        "appellant": None,
+        "pcsappealwithdrawndate": None,
+        "numberofresidences": None,
+        "appealsdocumentscomplete": None,
+        "questionnairereceived": None,
+        "lpaconditionsreceived": None,
+        "lpaconditionsforwarded": None,
+        "statementsdue": None,
+        "lpastatementsubmitted": None,
+        "lpastatementforwarded": None,
+        "appellantstatementsubmitted": None,
+        "appellantstatementforwarded": None,
+        "finalcommentsdue": None,
+        "lpacommentssubmitted": None,
+        "lpacommentsforwarded": None,
+        "statementofcommongrounddue": None,
+        "statementofcommongroundreceived": None,
+        "appellantcommentssubmitted": None,
+        "appellantcommentsforwarded": None,
+        "thirdpartyrepsdue": None,
+        "thirdpartyrepsforwarded": None,
+        "sitenoticesent": None,
+        "proofsdue": None,
+        "lpaproofssubmitted": None,
+        "lpaproofsforwarded": None,
+        "appellantsproofssubmitted": None,
+        "appellantsproofsforwarded": None,
+        "areaofsiteinhectares": None,
+        "dateofdecisionifissued": None,
+        "typeofapplication": None,
+        "appealsourceindicator": None,
+        "developmentorallegation": None,
+        "siteaddress1": None,
+        "siteaddress2": None,
+        "sitetown": None,
+        "sitecounty": None,
+        "sitecountry": None,
+        "sitepostcode": None,
+        "abeyanceenddate": None,
+        "amountdue": None,
+        "name": None,
+        "sitegreenbelt": None,
+        "lpaapplicationreference": None,
+        "lpaapplicationdate": None,
+        "datenotrecoveredorderecovered": None,
+        "daterecovered": None,
+        "callindate": None,
+        "englandwalesindicator": None,
+        "ingested_by_process_name": None,
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": None,
+        "entity_name": None,
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def horizon_appeals_additional_data_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("lastmodified", StringType(), True),
+            StructField("decisiondate", StringType(), True),
+            StructField("decisionsubmitdate", StringType(), True),
+            StructField("bespokeindicator", StringType(), True),
+            StructField("bespoketargetdate", StringType(), True),
+            StructField("processingstate", StringType(), True),
+            StructField("linkstatus", StringType(), True),
+            StructField("casecloseddate", StringType(), True),
+            StructField("appellant", StringType(), True),
+            StructField("pcsappealwithdrawndate", StringType(), True),
+            StructField("numberofresidences", StringType(), True),
+            StructField("appealsdocumentscomplete", StringType(), True),
+            StructField("questionnairereceived", StringType(), True),
+            StructField("lpaconditionsreceived", StringType(), True),
+            StructField("lpaconditionsforwarded", StringType(), True),
+            StructField("statementsdue", StringType(), True),
+            StructField("lpastatementsubmitted", StringType(), True),
+            StructField("lpastatementforwarded", StringType(), True),
+            StructField("appellantstatementsubmitted", StringType(), True),
+            StructField("appellantstatementforwarded", StringType(), True),
+            StructField("finalcommentsdue", StringType(), True),
+            StructField("lpacommentssubmitted", StringType(), True),
+            StructField("lpacommentsforwarded", StringType(), True),
+            StructField("statementofcommongrounddue", StringType(), True),
+            StructField("statementofcommongroundreceived", StringType(), True),
+            StructField("appellantcommentssubmitted", StringType(), True),
+            StructField("appellantcommentsforwarded", StringType(), True),
+            StructField("thirdpartyrepsdue", StringType(), True),
+            StructField("thirdpartyrepsforwarded", StringType(), True),
+            StructField("sitenoticesent", StringType(), True),
+            StructField("proofsdue", StringType(), True),
+            StructField("lpaproofssubmitted", StringType(), True),
+            StructField("lpaproofsforwarded", StringType(), True),
+            StructField("appellantsproofssubmitted", StringType(), True),
+            StructField("appellantsproofsforwarded", StringType(), True),
+            StructField("areaofsiteinhectares", StringType(), True),
+            StructField("dateofdecisionifissued", StringType(), True),
+            StructField("typeofapplication", StringType(), True),
+            StructField("appealsourceindicator", StringType(), True),
+            StructField("developmentorallegation", StringType(), True),
+            StructField("siteaddress1", StringType(), True),
+            StructField("siteaddress2", StringType(), True),
+            StructField("sitetown", StringType(), True),
+            StructField("sitecounty", StringType(), True),
+            StructField("sitecountry", StringType(), True),
+            StructField("sitepostcode", StringType(), True),
+            StructField("abeyanceenddate", StringType(), True),
+            StructField("amountdue", StringType(), True),
+            StructField("name", StringType(), True),
+            StructField("sitegreenbelt", StringType(), True),
+            StructField("lpaapplicationreference", StringType(), True),
+            StructField("lpaapplicationdate", StringType(), True),
+            StructField("datenotrecoveredorderecovered", StringType(), True),
+            StructField("daterecovered", StringType(), True),
+            StructField("callindate", StringType(), True),
+            StructField("englandwalesindicator", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def bis_case_site_category_additional_str_row(**overrides):
+    base = {
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "AppealRefNumber": None,
+        "AgriculturalHolding": None,
+        "DevelopmentAffectSettingOfListedBuilding": None,
+        "SiteGridReferenceEasting": None,
+        "SiteGridReferenceNorthing": None,
+        "HistoricBuildingGrantMade": None,
+        "InCARelatesToCA": None,
+        "InspectorNeedToEnterSite": None,
+        "IsFloodingAnIssue": None,
+        "IsTheSiteWithinAnAONB": None,
+        "SiteWithinAGreenBelt": None,
+        "SiteWithinSSSI": None,
+        "ingested_by_process_name": "py_horizon_raw_to_std",
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": "py_horizon_raw_to_std",
+        "entity_name": "BIS_CaseSiteCategoryAdditionalStr",
+        "file_id": None,
+    }
+    return base | overrides
+
+
+def bis_case_site_category_additional_str_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("AppealRefNumber", StringType(), True),
+            StructField("AgriculturalHolding", StringType(), True),
+            StructField("DevelopmentAffectSettingOfListedBuilding", StringType(), True),
+            StructField("SiteGridReferenceEasting", StringType(), True),
+            StructField("SiteGridReferenceNorthing", StringType(), True),
+            StructField("HistoricBuildingGrantMade", StringType(), True),
+            StructField("InCARelatesToCA", StringType(), True),
+            StructField("InspectorNeedToEnterSite", StringType(), True),
+            StructField("IsFloodingAnIssue", StringType(), True),
+            StructField("IsTheSiteWithinAnAONB", StringType(), True),
+            StructField("SiteWithinAGreenBelt", StringType(), True),
+            StructField("SiteWithinSSSI", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def horizon_inspector_cases_row(**overrides):
     return {
-        "hzn_cases_has_df": hzn_cases_has_df,
-        "cases_specialism_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casereference", T.StringType(), True),
-                    T.StructField("casespecialism", T.StringType(), True),
-                ]
-            ),
-        ),
-        "vw_case_dates_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("receiptdate", T.StringType(), True),
-                    T.StructField("appealdocscomplete", T.StringType(), True),
-                    T.StructField("startdate", T.StringType(), True),
-                    T.StructField("appealwithdrawndate", T.StringType(), True),
-                    T.StructField("casedecisiondate", T.StringType(), True),
-                    T.StructField("datenotrecoveredorderecovered", T.StringType(), True),
-                    T.StructField("daterecovered", T.StringType(), True),
-                    T.StructField("originalcasedecisiondate", T.StringType(), True),
-                ]
-            ),
-        ),
-        "CaseDocumentDatesDates_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("questionnairedue", T.StringType(), True),
-                    T.StructField("questionnairereceived", T.StringType(), True),
-                    T.StructField("interestedpartyrepsduedate", T.StringType(), True),
-                    T.StructField("proofsdue", T.StringType(), True),
-                ]
-            ),
-        ),
-        "CaseSiteStrings_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("siteviewablefromroad", T.StringType(), True),
-                    T.StructField("addressline1", T.StringType(), True),
-                    T.StructField("addressline2", T.StringType(), True),
-                    T.StructField("town", T.StringType(), True),
-                    T.StructField("county", T.StringType(), True),
-                    T.StructField("postcode", T.StringType(), True),
-                    T.StructField("country", T.StringType(), True),
-                ]
-            ),
-        ),
-        "vw_AddAdditionalData_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("floorspaceinsquaremetres", T.DoubleType(), True),
-                    T.StructField("costsappliedforindicator", T.StringType(), True),
-                    T.StructField("procedureappellant", T.StringType(), True),
-                    T.StructField("isthesitewithinanaonb", T.StringType(), True),
-                    T.StructField("procedurelpa", T.StringType(), True),
-                    T.StructField("inspectorneedtoentersite", T.StringType(), True),
-                    T.StructField("sitegridreferenceeasting", T.StringType(), True),
-                    T.StructField("sitegridreferencenorthing", T.StringType(), True),
-                    T.StructField("sitewithinsssi", T.StringType(), True),
-                    T.StructField("level", T.StringType(), True),
-                ]
-            ),
-        ),
-        "vw_AdditionalFields_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("importantinformation", T.StringType(), True),
-                ]
-            ),
-        ),
-        "horizon_advert_attributes_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("caseuniqueid", T.StringType(), True),
-                    T.StructField("advertAttributeKey", T.StringType(), True),
-                    T.StructField("advertType", T.StringType(), True),
-                    T.StructField("setRowNumber", T.IntegerType(), True),
-                    T.StructField("publicSafetyLpaIndicator", T.StringType(), True),
-                    T.StructField("amenityLPAIndicator", T.StringType(), True),
-                    T.StructField("publicSafetyGroundOutcome", T.StringType(), True),
-                    T.StructField("amenityGroundOutcome", T.StringType(), True),
-                    T.StructField("advertInPosition", T.StringType(), True),
-                    T.StructField("siteOnHighwayLand", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_curr_TypeOfLevel_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("name", T.StringType(), True),
-                    T.StructField("band", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_SpecialistCaseDates_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("datecostsreportdespatched", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_PlanningAppStrings_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("lpaapplicationreference", T.StringType(), True),
-                    T.StructField("planningapplicationtype", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_PlanningAppDates_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("dateofapplication", T.StringType(), True),
-                    T.StructField("dateoflpadecision", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_LeadCase_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("leadcasenodeid", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_CaseStrings_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("processingstate", T.StringType(), True),
-                    T.StructField("lpacode", T.StringType(), True),
-                    T.StructField("linkedstatus", T.StringType(), True),
-                    T.StructField("decision", T.StringType(), True),
-                    T.StructField("jurisdiction", T.StringType(), True),
-                    T.StructField("redetermined", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_CaseInfo_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("validity", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_CaseDates_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("validitystatusdate", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_AppealsAdditionalData_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("developmentorallegation", T.StringType(), True),
-                    T.StructField("appellantcommentssubmitted", T.StringType(), True),
-                    T.StructField("appellantstatementsubmitted", T.StringType(), True),
-                    T.StructField("lpacommentssubmitted", T.StringType(), True),
-                    T.StructField("lpaproofssubmitted", T.StringType(), True),
-                    T.StructField("lpastatementsubmitted", T.StringType(), True),
-                    T.StructField("sitenoticesent", T.StringType(), True),
-                    T.StructField("statementsdue", T.StringType(), True),
-                    T.StructField("areaofsiteinhectares", T.DoubleType(), True),
-                ]
-            ),
-        ),
-        "Horizon_vw_BIS_CaseSiteCategoryAdditionalStr_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("AppealRefNumber", T.StringType(), True),
-                    T.StructField("SiteWithinAGreenBelt", T.StringType(), True),
-                    T.StructField("InCARelatesToCA", T.StringType(), True),
-                ]
-            ),
-        ),
-        "Horizon_ODW_vw_Inspector_Cases_df": _empty_df(
-            spark,
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("contactid", T.StringType(), True),
-                ]
-            ),
-        ),
+        "ingested_datetime": datetime(2025, 1, 1),
+        "expected_from": datetime(2025, 1, 1),
+        "expected_to": datetime(2025, 1, 1),
+        "appealrefnumber": None,
+        "casereference": None,
+        "typeofinvolvement": "Inspector",
+        "inspectorname": None,
+        "contactid": None,
+        "parentkeyid": None,
+        "postname": None,
+        "firstname": None,
+        "lastname": None,
+        "email": None,
+        "ingested_by_process_name": "py_horizon_raw_to_std",
+        "input_file": None,
+        "modified_datetime": datetime(2025, 1, 1),
+        "modified_by_process_name": "py_horizon_raw_to_std",
+        "entity_name": "InspectorCases",
+        "file_id": None,
     }
 
 
+def horizon_inspector_cases_schema():
+    return StructType(
+        [
+            StructField("ingested_datetime", TimestampType(), True),
+            StructField("expected_from", TimestampType(), True),
+            StructField("expected_to", TimestampType(), True),
+            StructField("appealrefnumber", StringType(), True),
+            StructField("casereference", StringType(), True),
+            StructField("typeofinvolvement", StringType(), True),
+            StructField("inspectorname", StringType(), True),
+            StructField("contactid", StringType(), True),
+            StructField("parentkeyid", StringType(), True),
+            StructField("postname", StringType(), True),
+            StructField("firstname", StringType(), True),
+            StructField("lastname", StringType(), True),
+            StructField("email", StringType(), True),
+            StructField("ingested_by_process_name", StringType(), True),
+            StructField("input_file", StringType(), True),
+            StructField("modified_datetime", TimestampType(), True),
+            StructField("modified_by_process_name", StringType(), True),
+            StructField("entity_name", StringType(), True),
+            StructField("file_id", StringType(), True),
+        ]
+    )
+
+
+def appeal_has_standardised_row(**overrides):
+    base = {
+        "caseReference": "1",
+        "caseId": "1",
+        "caseType": "w",
+        "caseStatus": None,
+        "applicationReference": None,
+        "typeOfPlanningApplication": None,
+        "applicationDate": None,
+        "applicationDecisionDate": None,
+        "caseDecisionOutcome": None,
+        "jurisdiction": None,
+        "redeterminedIndicator": None,
+        "lpaCode": None,
+        "linkedCaseStatus": None,
+        "leadCaseReference": "10",
+        "siteAddressTown": "townA",
+        "siteAddressPostcode": "postcodeA",
+        "siteAddressLine2": None,
+        "siteAddressLine1": None,
+        "siteAddressCounty": "townA",
+        "isGreenBelt": None,
+        "inConservationArea": None,
+        "siteGridReferenceNorthing": None,
+        "siteGridReferenceEasting": None,
+        "isAonbNationalLandscape": None,
+        "caseValidationOutcome": "Valid",
+        "caseValidationDate": None,
+        "dateCostsReportDespatched": None,
+        "lpaQuestionnaireSubmittedDate": None,
+        "lpaQuestionnaireDueDate": None,
+        "originalCaseDecisionDate": None,
+        "dateRecovered": None,
+        "dateNotRecoveredOrDerecovered": None,
+        "caseWithdrawnDate": None,
+        "caseStartedDate": None,
+        "caseDecisionOutcomeDate": None,
+        "caseCreatedDate": None,
+        "caseCompletedDate": None,
+        "siteAreaSquareMetres": None,
+        "floorSpaceSquareMetres": None,
+        "originalDevelopmentDescription": None,
+        "importantinformation": "infoA",
+        "lpaProcedurePreference": None,
+        "caseProcedure": None,
+        "inspectorId": None,
+        "allocationLevel": "A",
+        "allocationBand": "bandA",
+        "caseSpecialisms": "Specialism A",
+        "caseUpdatedDate": datetime(2025, 1, 1, 0, 0),
+        "advertAttributeKey": None,
+        "advertType": "adTypeA",
+        "advertSetRowNumber": 1,
+        "publicSafetyLpaIndicator": None,
+        "amenityLpaIndicator": None,
+        "publicSafetyGroundOutcome": None,
+        "amenityGroundOutcome": None,
+        "advertInPosition": None,
+        "siteOnHighwayLand": None,
+    }
+    return base | overrides
+
+
+def appeal_has_standardised_schema():
+    return StructType(
+        [
+            StructField("caseReference", StringType(), True),
+            StructField("caseId", StringType(), True),
+            StructField("caseType", StringType(), True),
+            StructField("caseStatus", StringType(), True),
+            StructField("applicationReference", StringType(), True),
+            StructField("typeOfPlanningApplication", StringType(), True),
+            StructField("applicationDate", StringType(), True),
+            StructField("applicationDecisionDate", StringType(), True),
+            StructField("caseDecisionOutcome", StringType(), True),
+            StructField("jurisdiction", StringType(), True),
+            StructField("redeterminedIndicator", StringType(), True),
+            StructField("lpaCode", StringType(), True),
+            StructField("linkedCaseStatus", StringType(), True),
+            StructField("leadCaseReference", StringType(), True),
+            StructField("siteAddressTown", StringType(), True),
+            StructField("siteAddressPostcode", StringType(), True),
+            StructField("siteAddressLine2", StringType(), True),
+            StructField("siteAddressLine1", StringType(), True),
+            StructField("siteAddressCounty", StringType(), True),
+            StructField("isGreenBelt", StringType(), True),
+            StructField("inConservationArea", StringType(), True),
+            StructField("siteGridReferenceNorthing", StringType(), True),
+            StructField("siteGridReferenceEasting", StringType(), True),
+            StructField("isAonbNationalLandscape", StringType(), True),
+            StructField("caseValidationOutcome", StringType(), True),
+            StructField("caseValidationDate", StringType(), True),
+            StructField("dateCostsReportDespatched", StringType(), True),
+            StructField("lpaQuestionnaireSubmittedDate", StringType(), True),
+            StructField("lpaQuestionnaireDueDate", StringType(), True),
+            StructField("originalCaseDecisionDate", StringType(), True),
+            StructField("dateRecovered", StringType(), True),
+            StructField("dateNotRecoveredOrDerecovered", StringType(), True),
+            StructField("caseWithdrawnDate", StringType(), True),
+            StructField("caseStartedDate", StringType(), True),
+            StructField("caseDecisionOutcomeDate", StringType(), True),
+            StructField("caseCreatedDate", StringType(), True),
+            StructField("caseCompletedDate", StringType(), True),
+            StructField("siteAreaSquareMetres", DoubleType(), True),
+            StructField("floorSpaceSquareMetres", StringType(), True),
+            StructField("originalDevelopmentDescription", StringType(), True),
+            StructField("importantinformation", StringType(), True),
+            StructField("lpaProcedurePreference", StringType(), True),
+            StructField("caseProcedure", StringType(), True),
+            StructField("inspectorId", StringType(), True),
+            StructField("allocationLevel", StringType(), True),
+            StructField("allocationBand", StringType(), True),
+            StructField("caseSpecialisms", StringType(), True),
+            StructField("caseUpdatedDate", TimestampType(), True),
+            StructField("advertAttributeKey", StringType(), True),
+            StructField("advertType", StringType(), True),
+            StructField("advertSetRowNumber", IntegerType(), True),
+            StructField("publicSafetyLpaIndicator", StringType(), True),
+            StructField("amenityLpaIndicator", StringType(), True),
+            StructField("publicSafetyGroundOutcome", StringType(), True),
+            StructField("amenityGroundOutcome", StringType(), True),
+            StructField("advertInPosition", StringType(), True),
+            StructField("siteOnHighwayLand", StringType(), True),
+        ]
+    )
+
+
 class TestRefAppealHasStandardisationProcess(ETLTestCase):
-    def test__appeal_has_standardisation_process__run__standardises_end_to_end_and_matches_legacy(self):
+    def assert_standardisation_successful(self, test_case: str):
         spark = PytestSparkSessionUtil().get_spark_session()
 
-        hzn_cases_has_df = spark.createDataFrame(
-            [
-                ("HAS-001", 1001, "HAS", "2025-01-10", "2025-01-10", "2025-01-10", "2025-01-10", 1),
-                ("HAS-002", 1002, "HAS", "2025-01-11", "2025-01-11", "2025-01-11", "2025-01-11", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("caseuniqueid", T.StringType(), True),
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("abbreviation", T.StringType(), True),
-                    T.StructField("modifydate", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data = _minimal_source_data(spark, hzn_cases_has_df)
-
-        source_data["cases_specialism_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "Listed Building", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-001", "Advertisements", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "Enforcement", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casereference", T.StringType(), True),
-                    T.StructField("casespecialism", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["vw_case_dates_df"] = spark.createDataFrame(
-            [
-                (
-                    1001,
-                    "2025-01-01",
-                    "2025-01-02",
-                    "2025-01-03",
-                    "2025-01-04",
-                    "2025-01-05",
-                    "2025-01-06",
-                    "2025-01-07",
-                    "2025-01-08",
-                    "2025-01-01",
-                    "2025-01-01",
-                    "2025-01-01",
-                    1,
+        horizon_cases_has = spark.createDataFrame(
+            (
+                horizon_cases_has_row(
+                    CaseNodeId="1",
+                    subType="1",
+                    Abbreviation="w",
+                    caseReference="1",
+                    caseUniqueId="1",
                 ),
-                (
-                    1002,
-                    "2025-02-01",
-                    "2025-02-02",
-                    "2025-02-03",
-                    "2025-02-04",
-                    "2025-02-05",
-                    "2025-02-06",
-                    "2025-02-07",
-                    "2025-02-08",
-                    "2025-02-01",
-                    "2025-02-01",
-                    "2025-02-01",
-                    1,
+                horizon_cases_has_row(
+                    CaseNodeId="2",
+                    subType="2",
+                    Abbreviation="w",
+                    caseReference="2",
+                    caseUniqueId="2",
                 ),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("receiptdate", T.StringType(), True),
-                    T.StructField("appealdocscomplete", T.StringType(), True),
-                    T.StructField("startdate", T.StringType(), True),
-                    T.StructField("appealwithdrawndate", T.StringType(), True),
-                    T.StructField("casedecisiondate", T.StringType(), True),
-                    T.StructField("datenotrecoveredorderecovered", T.StringType(), True),
-                    T.StructField("daterecovered", T.StringType(), True),
-                    T.StructField("originalcasedecisiondate", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["CaseDocumentDatesDates_df"] = spark.createDataFrame(
-            [
-                (1001, "2025-03-01", "2025-03-02", "2025-03-03", "2025-03-04", "2025-03-01", "2025-03-01", "2025-03-01", 1),
-                (1002, "2025-04-01", "2025-04-02", "2025-04-03", "2025-04-04", "2025-04-01", "2025-04-01", "2025-04-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("questionnairedue", T.StringType(), True),
-                    T.StructField("questionnairereceived", T.StringType(), True),
-                    T.StructField("interestedpartyrepsduedate", T.StringType(), True),
-                    T.StructField("proofsdue", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["vw_AddAdditionalData_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", 50.0, None, "Written Reps", "Y", None, None, "123", "456", "N", "Level 1", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", 75.0, None, None, "N", "Inquiry", None, "789", "012", "Y", "Level 2", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("floorspaceinsquaremetres", T.DoubleType(), True),
-                    T.StructField("costsappliedforindicator", T.StringType(), True),
-                    T.StructField("procedureappellant", T.StringType(), True),
-                    T.StructField("isthesitewithinanaonb", T.StringType(), True),
-                    T.StructField("procedurelpa", T.StringType(), True),
-                    T.StructField("inspectorneedtoentersite", T.StringType(), True),
-                    T.StructField("sitegridreferenceeasting", T.StringType(), True),
-                    T.StructField("sitegridreferencenorthing", T.StringType(), True),
-                    T.StructField("sitewithinsssi", T.StringType(), True),
-                    T.StructField("level", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["vw_AdditionalFields_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "Important info 1", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "Important info 2", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("importantinformation", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_curr_TypeOfLevel_df"] = spark.createDataFrame(
-            [
-                ("Level 1", "Band A", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("Level 2", "Band B", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("name", T.StringType(), True),
-                    T.StructField("band", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["CaseSiteStrings_df"] = spark.createDataFrame(
-            [
-                (1001, "Y", "Line 1", "Line 2", "Town 1", "County 1", "AA1 1AA", "UK", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                (1002, "N", "Line 3", "Line 4", "Town 2", "County 2", "BB1 1BB", "UK", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("siteviewablefromroad", T.StringType(), True),
-                    T.StructField("addressline1", T.StringType(), True),
-                    T.StructField("addressline2", T.StringType(), True),
-                    T.StructField("town", T.StringType(), True),
-                    T.StructField("county", T.StringType(), True),
-                    T.StructField("postcode", T.StringType(), True),
-                    T.StructField("country", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_PlanningAppStrings_df"] = spark.createDataFrame(
-            [
-                (1001, "APP-REF-001", "Full Planning", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                (1002, "APP-REF-002", "Householder", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("lpaapplicationreference", T.StringType(), True),
-                    T.StructField("planningapplicationtype", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_PlanningAppDates_df"] = spark.createDataFrame(
-            [
-                (1001, "2025-05-01", "2025-05-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                (1002, "2025-06-01", "2025-06-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("dateofapplication", T.StringType(), True),
-                    T.StructField("dateoflpadecision", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_CaseStrings_df"] = spark.createDataFrame(
-            [
-                (1001, "Valid", "LPA01", "Linked", "Allowed", "HAS", "N", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                (1002, "Started", "LPA02", "Not linked", "Dismissed", "HAS", "Y", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("processingstate", T.StringType(), True),
-                    T.StructField("lpacode", T.StringType(), True),
-                    T.StructField("linkedstatus", T.StringType(), True),
-                    T.StructField("decision", T.StringType(), True),
-                    T.StructField("jurisdiction", T.StringType(), True),
-                    T.StructField("redetermined", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_LeadCase_df"] = spark.createDataFrame(
-            [
-                (1001, "LEAD-001", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                (1002, "LEAD-002", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("casenodeid", T.IntegerType(), True),
-                    T.StructField("leadcasenodeid", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_CaseInfo_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "Valid appeal", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "Invalid appeal", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("validity", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_CaseDates_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "2025-07-01", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "2025-07-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("validitystatusdate", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_SpecialistCaseDates_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "2025-08-01", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "2025-08-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("datecostsreportdespatched", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_AppealsAdditionalData_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "Development 1", None, None, None, None, None, None, None, 1.5, "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "Development 2", None, None, None, None, None, None, None, 2.0, "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("developmentorallegation", T.StringType(), True),
-                    T.StructField("appellantcommentssubmitted", T.StringType(), True),
-                    T.StructField("appellantstatementsubmitted", T.StringType(), True),
-                    T.StructField("lpacommentssubmitted", T.StringType(), True),
-                    T.StructField("lpaproofssubmitted", T.StringType(), True),
-                    T.StructField("lpastatementsubmitted", T.StringType(), True),
-                    T.StructField("sitenoticesent", T.StringType(), True),
-                    T.StructField("statementsdue", T.StringType(), True),
-                    T.StructField("areaofsiteinhectares", T.DoubleType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_vw_BIS_CaseSiteCategoryAdditionalStr_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "Y", "N", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "N", "Y", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("AppealRefNumber", T.StringType(), True),
-                    T.StructField("SiteWithinAGreenBelt", T.StringType(), True),
-                    T.StructField("InCARelatesToCA", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["Horizon_ODW_vw_Inspector_Cases_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "INSPECTOR-001", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "INSPECTOR-002", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("appealrefnumber", T.StringType(), True),
-                    T.StructField("contactid", T.StringType(), True),
-                ]
-            ),
-        )
-
-        source_data["horizon_advert_attributes_df"] = spark.createDataFrame(
-            [
-                ("HAS-001", "ATTR-001", "Poster", 1, "Y", "N", "Safety 1", "Amenity 1", "Y", "N", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-                ("HAS-002", "ATTR-002", "Display", 2, "N", "Y", "Safety 2", "Amenity 2", "N", "Y", "2025-01-01", "2025-01-01", "2025-01-01", 1),
-            ],
-            _metadata_schema(
-                [
-                    T.StructField("caseuniqueid", T.StringType(), True),
-                    T.StructField("advertAttributeKey", T.StringType(), True),
-                    T.StructField("advertType", T.StringType(), True),
-                    T.StructField("setRowNumber", T.IntegerType(), True),
-                    T.StructField("publicSafetyLpaIndicator", T.StringType(), True),
-                    T.StructField("amenityLPAIndicator", T.StringType(), True),
-                    T.StructField("publicSafetyGroundOutcome", T.StringType(), True),
-                    T.StructField("amenityGroundOutcome", T.StringType(), True),
-                    T.StructField("advertInPosition", T.StringType(), True),
-                    T.StructField("siteOnHighwayLand", T.StringType(), True),
-                ]
-            ),
-        )
-
-        inst = AppealHasStandardisationProcess(spark)
-
-        with (
-            mock.patch.object(inst, "load_data", return_value=source_data),
-            mock.patch.object(inst, "write_data") as mock_write,
-        ):
-            result = inst.run()
-
-        data_to_write = mock_write.call_args[0][0]
-        actual_df = data_to_write[inst.OUTPUT_TABLE]["data"]
-
-        actual_result_df = actual_df.select(
-            "caseReference",
-            "caseId",
-            "caseType",
-            "caseProcedure",
-            "allocationLevel",
-            "allocationBand",
-            "caseSpecialisms",
-            "siteAddressLine1",
-            "siteAddressTown",
-            "siteAddressPostcode",
-            "siteAreaSquareMetres",
-            "floorSpaceSquareMetres",
-            "originalDevelopmentDescription",
-            "caseStatus",
-            "lpaCode",
-            "leadCaseReference",
-            "caseValidationOutcome",
-            "caseValidationDate",
-            "dateCostsReportDespatched",
-            "isGreenBelt",
-            "inConservationArea",
-            "inspectorId",
-            "importantinformation",
-            "advertAttributeKey",
-        )
-
-        expected_result_df = spark.createDataFrame(
-            [
-                (
-                    "HAS-001",
-                    1001,
-                    "HAS",
-                    "WR",
-                    "Level 1",
-                    "Band A",
-                    "Advertisements, Listed Building",
-                    "Line 1",
-                    "Town 1",
-                    "AA1 1AA",
-                    15000.0,
-                    50.0,
-                    "Development 1",
-                    "Valid",
-                    "LPA01",
-                    "LEAD-001",
-                    "Valid appeal",
-                    "2025-07-01",
-                    "2025-08-01",
-                    "Y",
-                    "N",
-                    "INSPECTOR-001",
-                    "Important info 1",
-                    "ATTR-001",
+                horizon_cases_has_row(
+                    CaseNodeId="3",
+                    subType="3",
+                    Abbreviation="w",
+                    caseReference="3",
+                    caseUniqueId="3",
                 ),
-                (
-                    "HAS-002",
-                    1002,
-                    "HAS",
-                    "LI",
-                    "Level 2",
-                    "Band B",
-                    "Enforcement",
-                    "Line 3",
-                    "Town 2",
-                    "BB1 1BB",
-                    20000.0,
-                    75.0,
-                    "Development 2",
-                    "Started",
-                    "LPA02",
-                    "LEAD-002",
-                    "Invalid appeal",
-                    "2025-07-02",
-                    "2025-08-02",
-                    "N",
-                    "Y",
-                    "INSPECTOR-002",
-                    "Important info 2",
-                    "ATTR-002",
+                horizon_cases_has_row(
+                    CaseNodeId="4",
+                    subType="4",
+                    Abbreviation="w",
+                    caseReference="4",
+                    caseUniqueId="4",
                 ),
-            ],
-            actual_result_df.schema,
+                horizon_cases_has_row(
+                    CaseNodeId="5",
+                    subType="5",
+                    Abbreviation="w",
+                    caseReference="5",
+                    caseUniqueId="5",
+                ),
+                horizon_cases_has_row(
+                    CaseNodeId="6",
+                    subType="6",
+                    Abbreviation="w",
+                    caseReference="6",
+                    caseUniqueId="6",
+                ),
+                horizon_cases_has_row(
+                    CaseNodeId="7",
+                    subType="7",
+                    Abbreviation="w",
+                    caseReference="7",
+                    caseUniqueId="7",
+                ),
+                horizon_cases_has_row(
+                    CaseNodeId="8",
+                    subType="8",
+                    Abbreviation="w",
+                    caseReference="8",
+                    caseUniqueId="8",
+                ),
+                horizon_cases_has_row(
+                    CaseNodeId="9",
+                    subType="9",
+                    Abbreviation="w",
+                    caseReference="9",
+                    caseUniqueId="9",
+                ),
+                horizon_cases_has_row(
+                    CaseNodeId="10",
+                    subType="10",
+                    Abbreviation="w",
+                    caseReference="10",
+                    caseUniqueId="10",
+                ),
+            ),
+            schema=horizon_cases_has_schema(),
         )
-
-        assert_dataframes_equal(actual_result_df, expected_result_df)
-
-        assert {
-            "insert_count": result.metadata.insert_count,
-            "update_count": result.metadata.update_count,
-            "delete_count": result.metadata.delete_count,
-        } == {
-            "insert_count": 2,
-            "update_count": 0,
-            "delete_count": 0,
+        horizon_cases_has_table = f"{test_case}_horizon_cases_has"
+        self.write_existing_table(
+            spark,
+            horizon_cases_has,
+            horizon_cases_has_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            horizon_cases_has_table,
+            "overwrite",
+        )
+        # cs
+        cases_specialisms = spark.createDataFrame(
+            (
+                cases_specialisms_row(casereference="1", casespecialism="Specialism A"),
+                cases_specialisms_row(casereference="2", casespecialism="Specialism B"),
+                cases_specialisms_row(casereference="3", casespecialism="Specialism C"),
+                cases_specialisms_row(casereference="4", casespecialism="Specialism D"),
+                cases_specialisms_row(casereference="5", casespecialism="Specialism E"),
+                cases_specialisms_row(casereference="6", casespecialism="Specialism F"),
+                cases_specialisms_row(casereference="7", casespecialism="Specialism G"),
+                cases_specialisms_row(casereference="8", casespecialism="Specialism H"),
+                cases_specialisms_row(casereference="9", casespecialism="Specialism I"),
+                cases_specialisms_row(casereference="10", casespecialism="Specialism J"),
+            ),
+            schema=cases_specialisms_schema(),
+        )
+        cases_specialisms_table = f"{test_case}_cases_specialisms"
+        self.write_existing_table(
+            spark,
+            cases_specialisms,
+            cases_specialisms_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            cases_specialisms_table,
+            "overwrite",
+        )
+        # cd
+        vw_case_dates = spark.createDataFrame(
+            (
+                vw_cases_dates_row(casenodeid="1"),
+                vw_cases_dates_row(casenodeid="2"),
+                vw_cases_dates_row(casenodeid="3"),
+                vw_cases_dates_row(casenodeid="4"),
+                vw_cases_dates_row(casenodeid="5"),
+                vw_cases_dates_row(casenodeid="6"),
+                vw_cases_dates_row(casenodeid="7"),
+                vw_cases_dates_row(casenodeid="8"),
+                vw_cases_dates_row(casenodeid="9"),
+                vw_cases_dates_row(casenodeid="10"),
+            ),
+            schema=vw_cases_dates_schema(),
+        )
+        vw_case_dates_table = f"{test_case}_vw_case_dates"
+        self.write_existing_table(
+            spark,
+            vw_case_dates,
+            vw_case_dates_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            vw_case_dates_table,
+            "overwrite",
+        )
+        # cdd
+        casedocumentdatesdates = spark.createDataFrame(
+            (
+                case_document_dates_dates_row(casenodeid="1", appealrefnumber="1"),
+                case_document_dates_dates_row(casenodeid="2", appealrefnumber="2"),
+                case_document_dates_dates_row(casenodeid="3", appealrefnumber="3"),
+                case_document_dates_dates_row(casenodeid="4", appealrefnumber="4"),
+                case_document_dates_dates_row(casenodeid="5", appealrefnumber="5"),
+                case_document_dates_dates_row(casenodeid="6", appealrefnumber="6"),
+                case_document_dates_dates_row(casenodeid="7", appealrefnumber="7"),
+                case_document_dates_dates_row(casenodeid="8", appealrefnumber="8"),
+                case_document_dates_dates_row(casenodeid="9", appealrefnumber="9"),
+                case_document_dates_dates_row(casenodeid="10", appealrefnumber="10"),
+            ),
+            schema=case_document_dates_dates_schema(),
+        )
+        casedocumentdatesdates_table = f"{test_case}_casedocumentdatesdates"
+        self.write_existing_table(
+            spark,
+            casedocumentdatesdates,
+            casedocumentdatesdates_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            casedocumentdatesdates_table,
+            "overwrite",
+        )
+        # css
+        casesitestrings = spark.createDataFrame(
+            (
+                case_site_strings_row(
+                    casenodeid="1",
+                    town="townA",
+                    county="townA",
+                    postcode="postcodeA",
+                    country="countryA",
+                ),
+                case_site_strings_row(
+                    casenodeid="2",
+                    town="townB",
+                    county="townB",
+                    postcode="postcodeB",
+                    country="countryB",
+                ),
+                case_site_strings_row(
+                    casenodeid="3",
+                    town="townC",
+                    county="townC",
+                    postcode="postcodeC",
+                    country="countryC",
+                ),
+                case_site_strings_row(
+                    casenodeid="4",
+                    town="townD",
+                    county="townD",
+                    postcode="postcodeD",
+                    country="countryD",
+                ),
+                case_site_strings_row(
+                    casenodeid="5",
+                    town="townE",
+                    county="townE",
+                    postcode="postcodeE",
+                    country="countryE",
+                ),
+                case_site_strings_row(
+                    casenodeid="6",
+                    town="townF",
+                    county="townF",
+                    postcode="postcodeF",
+                    country="countryF",
+                ),
+                case_site_strings_row(
+                    casenodeid="7",
+                    town="townG",
+                    county="townG",
+                    postcode="postcodeG",
+                    country="countryG",
+                ),
+                case_site_strings_row(
+                    casenodeid="8",
+                    town="townH",
+                    county="townH",
+                    postcode="postcodeH",
+                    country="countryH",
+                ),
+                case_site_strings_row(
+                    casenodeid="9",
+                    town="townI",
+                    county="townI",
+                    postcode="postcodeI",
+                    country="countryI",
+                ),
+                case_site_strings_row(
+                    casenodeid="10",
+                    town="townJ",
+                    county="townJ",
+                    postcode="postcodeJ",
+                    country="countrJ",
+                ),
+            ),
+            schema=case_site_strings_schema(),
+        )
+        casesitestrings_table = f"{test_case}_casesitestrings"
+        self.write_existing_table(
+            spark,
+            casesitestrings,
+            casesitestrings_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            casesitestrings_table,
+            "overwrite",
+        )
+        # tp
+        typeofprocedure = spark.createDataFrame(
+            (
+                type_of_procedure_row(id="1", name="nameA", proccode="codeA"),
+                type_of_procedure_row(id="2", name="nameB", proccode="codeB"),
+                type_of_procedure_row(id="3", name="nameC", proccode="codeC"),
+                type_of_procedure_row(id="4", name="nameD", proccode="codeD"),
+                type_of_procedure_row(id="5", name="nameE", proccode="codeE"),
+                type_of_procedure_row(id="6", name="nameF", proccode="codeF"),
+                type_of_procedure_row(id="7", name="nameG", proccode="codeG"),
+                type_of_procedure_row(id="8", name="nameH", proccode="codeH"),
+                type_of_procedure_row(id="9", name="nameI", proccode="codeI"),
+                type_of_procedure_row(id="10", name="nameJ", proccode="codeJ"),
+            ),
+            schema=type_of_procedure_schema(),
+        )
+        typeofprocedure_table = f"{test_case}_typeofprocedure"
+        self.write_existing_table(
+            spark,
+            typeofprocedure,
+            typeofprocedure_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            typeofprocedure_table,
+            "overwrite",
+        )
+        # aad_old
+        vw_addadditionaldata = spark.createDataFrame(
+            (
+                vw_additional_data_row(appealrefnumber="1", level="A"),
+                vw_additional_data_row(appealrefnumber="2", level="B"),
+                vw_additional_data_row(appealrefnumber="3", level="C"),
+                vw_additional_data_row(appealrefnumber="4", level="D"),
+                vw_additional_data_row(appealrefnumber="5", level="E"),
+                vw_additional_data_row(appealrefnumber="6", level="F"),
+                vw_additional_data_row(appealrefnumber="7", level="G"),
+                vw_additional_data_row(appealrefnumber="8", level="H"),
+                vw_additional_data_row(appealrefnumber="9", level="I"),
+                vw_additional_data_row(appealrefnumber="10", level="J"),
+            ),
+            schema=vw_additional_data_schema(),
+        )
+        vw_addadditionaldata_table = f"{test_case}_vw_addadditionaldata"
+        self.write_existing_table(
+            spark,
+            vw_addadditionaldata,
+            vw_addadditionaldata_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            vw_addadditionaldata_table,
+            "overwrite",
+        )
+        # af
+        vw_additionalfields = spark.createDataFrame(
+            (
+                vw_additional_fields_row(
+                    appealrefnumber="1",
+                    casereference="1",
+                    importantinformation="infoA",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="2",
+                    casereference="2",
+                    importantinformation="infoB",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="3",
+                    casereference="3",
+                    importantinformation="infoC",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="4",
+                    casereference="4",
+                    importantinformation="infoD",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="5",
+                    casereference="5",
+                    importantinformation="infoE",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="6",
+                    casereference="6",
+                    importantinformation="infoF",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="7",
+                    casereference="7",
+                    importantinformation="infoG",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="8",
+                    casereference="8",
+                    importantinformation="infoH",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="9",
+                    casereference="9",
+                    importantinformation="infoI",
+                ),
+                vw_additional_fields_row(
+                    appealrefnumber="10",
+                    casereference="10",
+                    importantinformation="infoJ",
+                ),
+            ),
+            schema=vw_additional_fields_schema(),
+        )
+        vw_additionalfields_table = f"{test_case}_vw_additionalfields"
+        self.write_existing_table(
+            spark,
+            vw_additionalfields,
+            vw_additionalfields_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            vw_additionalfields_table,
+            "overwrite",
+        )
+        # haa
+        horizon_advert_attributes = spark.createDataFrame(
+            (
+                horizon_advert_attributes_row(caseNodeId=1, caseUniqueId=1, advertType="adTypeA"),
+                horizon_advert_attributes_row(caseNodeId=2, caseUniqueId=2, advertType="adTypeB"),
+                horizon_advert_attributes_row(caseNodeId=3, caseUniqueId=3, advertType="adTypeC"),
+                horizon_advert_attributes_row(caseNodeId=4, caseUniqueId=4, advertType="adTypeD"),
+                horizon_advert_attributes_row(caseNodeId=5, caseUniqueId=5, advertType="adTypeE"),
+                horizon_advert_attributes_row(caseNodeId=6, caseUniqueId=6, advertType="adTypeF"),
+                horizon_advert_attributes_row(caseNodeId=7, caseUniqueId=7, advertType="adTypeG"),
+                horizon_advert_attributes_row(caseNodeId=8, caseUniqueId=8, advertType="adTypeH"),
+                horizon_advert_attributes_row(caseNodeId=9, caseUniqueId=9, advertType="adTypeI"),
+                horizon_advert_attributes_row(caseNodeId=10, caseUniqueId=10, advertType="adTypeJ"),
+            ),
+            schema=horizon_advert_attributes_schema(),
+        )
+        horizon_advert_attributes_table = f"{test_case}_horizon_advert_attributes"
+        self.write_existing_table(
+            spark,
+            horizon_advert_attributes,
+            horizon_advert_attributes_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            horizon_advert_attributes_table,
+            "overwrite",
+        )
+        # ctl
+        typeoflevel = spark.createDataFrame(
+            (
+                type_of_level_row(id=1, name="A", band="bandA"),
+                type_of_level_row(id=2, name="B", band="bandB"),
+                type_of_level_row(id=3, name="C", band="bandC"),
+                type_of_level_row(id=4, name="D", band="bandD"),
+                type_of_level_row(id=5, name="E", band="bandE"),
+                type_of_level_row(id=6, name="F", band="bandF"),
+                type_of_level_row(id=7, name="G", band="bandG"),
+                type_of_level_row(id=8, name="H", band="bandH"),
+                type_of_level_row(id=9, name="I", band="bandI"),
+                type_of_level_row(id=10, name="J", band="bandJ"),
+            ),
+            schema=type_of_level_schema(),
+        )
+        typeoflevel_table = f"{test_case}_TypeOfLevel"
+        self.write_existing_table(
+            spark,
+            typeoflevel,
+            typeoflevel_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            typeoflevel_table,
+            "overwrite",
+        )
+        # scd
+        horizon_specialist_case_dates = spark.createDataFrame(
+            (
+                horizon_specialist_case_dates_row(appealrefnumber="1"),
+                horizon_specialist_case_dates_row(appealrefnumber="2"),
+                horizon_specialist_case_dates_row(appealrefnumber="3"),
+                horizon_specialist_case_dates_row(appealrefnumber="4"),
+                horizon_specialist_case_dates_row(appealrefnumber="5"),
+                horizon_specialist_case_dates_row(appealrefnumber="6"),
+                horizon_specialist_case_dates_row(appealrefnumber="7"),
+                horizon_specialist_case_dates_row(appealrefnumber="8"),
+                horizon_specialist_case_dates_row(appealrefnumber="9"),
+                horizon_specialist_case_dates_row(appealrefnumber="10"),
+            ),
+            schema=horizon_specialist_case_dates_schema(),
+        )
+        horizon_specialist_case_dates_table = f"{test_case}_horizon_specialist_case_dates"
+        self.write_existing_table(
+            spark,
+            horizon_specialist_case_dates,
+            horizon_specialist_case_dates_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            horizon_specialist_case_dates_table,
+            "overwrite",
+        )
+        # pas
+        planningappstrings = spark.createDataFrame(
+            (
+                planning_app_strings_row(casenodeid="1", planningapplicationtype="appTypeA"),
+                planning_app_strings_row(casenodeid="2", planningapplicationtype="appTypeB"),
+                planning_app_strings_row(casenodeid="3", planningapplicationtype="appTypeC"),
+                planning_app_strings_row(casenodeid="4", planningapplicationtype="appTypeD"),
+                planning_app_strings_row(casenodeid="5", planningapplicationtype="appTypeE"),
+                planning_app_strings_row(casenodeid="6", planningapplicationtype="appTypeF"),
+                planning_app_strings_row(casenodeid="7", planningapplicationtype="appTypeG"),
+                planning_app_strings_row(casenodeid="8", planningapplicationtype="appTypeH"),
+                planning_app_strings_row(casenodeid="9", planningapplicationtype="appTypeI"),
+                planning_app_strings_row(casenodeid="10", planningapplicationtype="appTypeJ"),
+            ),
+            schema=planning_app_strings_schema(),
+        )
+        planningappstrings_table = f"{test_case}_PlanningAppStrings"
+        self.write_existing_table(
+            spark,
+            planningappstrings,
+            planningappstrings_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            planningappstrings_table,
+            "overwrite",
+        )
+        # pad
+        planningappdates = spark.createDataFrame(
+            (
+                planning_app_dates_row(casenodeid="1"),
+                planning_app_dates_row(casenodeid="2"),
+                planning_app_dates_row(casenodeid="3"),
+                planning_app_dates_row(casenodeid="4"),
+                planning_app_dates_row(casenodeid="5"),
+                planning_app_dates_row(casenodeid="6"),
+                planning_app_dates_row(casenodeid="7"),
+                planning_app_dates_row(casenodeid="8"),
+                planning_app_dates_row(casenodeid="9"),
+                planning_app_dates_row(casenodeid="10"),
+            ),
+            schema=planning_app_dates_schema(),
+        )
+        planningappdates_table = f"{test_case}_PlanningAppDates"
+        self.write_existing_table(
+            spark,
+            planningappdates,
+            planningappdates_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            planningappdates_table,
+            "overwrite",
+        )
+        # lc
+        bis_leadcase = spark.createDataFrame(
+            (
+                bis_lead_case_row(casenodeid="1", leadcasenodeid="10"),
+                bis_lead_case_row(casenodeid="2", leadcasenodeid="9"),
+                bis_lead_case_row(casenodeid="3", leadcasenodeid="8"),
+                bis_lead_case_row(casenodeid="4", leadcasenodeid="7"),
+                bis_lead_case_row(casenodeid="5", leadcasenodeid="6"),
+                bis_lead_case_row(casenodeid="6", leadcasenodeid="5"),
+                bis_lead_case_row(casenodeid="7", leadcasenodeid="4"),
+                bis_lead_case_row(casenodeid="8", leadcasenodeid="3"),
+                bis_lead_case_row(casenodeid="9", leadcasenodeid="2"),
+                bis_lead_case_row(casenodeid="10", leadcasenodeid="1"),
+            ),
+            schema=bis_lead_case_schema(),
+        )
+        bis_leadcase_table = f"{test_case}_BIS_LeadCase"
+        self.write_existing_table(
+            spark,
+            bis_leadcase,
+            bis_leadcase_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            bis_leadcase_table,
+            "overwrite",
+        )
+        # cs2
+        casestrings = spark.createDataFrame(
+            (
+                case_strings_row(casenodeid="1", proceduretype="procTypeA"),
+                case_strings_row(casenodeid="2", proceduretype="procTypeB"),
+                case_strings_row(casenodeid="3", proceduretype="procTypeC"),
+                case_strings_row(casenodeid="4", proceduretype="procTypeD"),
+                case_strings_row(casenodeid="5", proceduretype="procTypeE"),
+                case_strings_row(casenodeid="6", proceduretype="procTypeF"),
+                case_strings_row(casenodeid="7", proceduretype="procTypeG"),
+                case_strings_row(casenodeid="8", proceduretype="procTypeH"),
+                case_strings_row(casenodeid="9", proceduretype="procTypeI"),
+                case_strings_row(casenodeid="10", proceduretype="procTypeJ"),
+            ),
+            schema=case_strings_schema(),
+        )
+        casestrings_table = f"{test_case}_CaseStrings"
+        self.write_existing_table(
+            spark,
+            casestrings,
+            casestrings_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            casestrings_table,
+            "overwrite",
+        )
+        # ci
+        horizon_case_info = spark.createDataFrame(
+            (
+                horizon_case_info_row(appealrefnumber="1", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="2", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="3", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="4", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="5", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="6", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="7", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="8", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="9", validity="Valid"),
+                horizon_case_info_row(appealrefnumber="10", validity="Valid"),
+            ),
+            schema=horizon_case_info_schema(),
+        )
+        horizon_case_info_table = f"{test_case}_horizon_case_info"
+        self.write_existing_table(
+            spark,
+            horizon_case_info,
+            horizon_case_info_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            horizon_case_info_table,
+            "overwrite",
+        )
+        # cdh
+        horizon_case_dates = spark.createDataFrame(
+            (
+                horizon_case_dates_row(appealrefnumber="1"),
+                horizon_case_dates_row(appealrefnumber="2"),
+                horizon_case_dates_row(appealrefnumber="3"),
+                horizon_case_dates_row(appealrefnumber="4"),
+                horizon_case_dates_row(appealrefnumber="5"),
+                horizon_case_dates_row(appealrefnumber="6"),
+                horizon_case_dates_row(appealrefnumber="7"),
+                horizon_case_dates_row(appealrefnumber="8"),
+                horizon_case_dates_row(appealrefnumber="9"),
+                horizon_case_dates_row(appealrefnumber="10"),
+            ),
+            schema=horizon_case_dates_schema(),
+        )
+        horizon_case_dates_table = f"{test_case}_horizon_case_dates"
+        self.write_existing_table(
+            spark,
+            horizon_case_dates,
+            horizon_case_dates_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            horizon_case_dates_table,
+            "overwrite",
+        )
+        # aad
+        horizon_appeals_additional_data = spark.createDataFrame(
+            (
+                horizon_appeals_additional_data_row(appealrefnumber="1", processingstate="Complete", appellant="Alice"),
+                horizon_appeals_additional_data_row(appealrefnumber="2", processingstate="Complete", appellant="Bob"),
+                horizon_appeals_additional_data_row(appealrefnumber="3", processingstate="Complete", appellant="Charlie"),
+                horizon_appeals_additional_data_row(appealrefnumber="4", processingstate="Complete", appellant="Dave"),
+                horizon_appeals_additional_data_row(appealrefnumber="5", processingstate="Complete", appellant="Emily"),
+                horizon_appeals_additional_data_row(appealrefnumber="6", processingstate="Complete", appellant="Frank"),
+                horizon_appeals_additional_data_row(appealrefnumber="7", processingstate="Complete", appellant="Garry"),
+                horizon_appeals_additional_data_row(appealrefnumber="8", processingstate="Complete", appellant="Harry"),
+                horizon_appeals_additional_data_row(appealrefnumber="9", processingstate="Complete", appellant="Ivy"),
+                horizon_appeals_additional_data_row(appealrefnumber="10", processingstate="Complete", appellant="Jim"),
+            ),
+            schema=horizon_appeals_additional_data_schema(),
+        )
+        horizon_appeals_additional_data_table = f"{test_case}_horizon_appeals_additional_data"
+        self.write_existing_table(
+            spark,
+            horizon_appeals_additional_data,
+            horizon_appeals_additional_data_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            horizon_appeals_additional_data_table,
+            "overwrite",
+        )
+        bis_case_site_category_additional_str = spark.createDataFrame(
+            (bis_case_site_category_additional_str_row(),), schema=bis_case_site_category_additional_str_schema()
+        )
+        bis_case_site_category_additional_str_table = f"{test_case}_bis_case_site_category_additional_str_table"
+        self.write_existing_table(
+            spark,
+            bis_case_site_category_additional_str,
+            bis_case_site_category_additional_str_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            bis_case_site_category_additional_str_table,
+            "overwrite",
+        )
+        horizon_inspector_cases = spark.createDataFrame((horizon_inspector_cases_row(),), schema=horizon_inspector_cases_schema())
+        horizon_inspector_cases_table = f"{test_case}_horizon_inspector_cases"
+        self.write_existing_table(
+            spark,
+            horizon_inspector_cases,
+            horizon_inspector_cases_table,
+            "odw_standardised_db",
+            "odw-standardised",
+            horizon_inspector_cases_table,
+            "overwrite",
+        )
+        # This was generated by feeding the above test data through the original notebook
+        expected_data_after_writing = spark.createDataFrame(
+            (
+                appeal_has_standardised_row(),
+                appeal_has_standardised_row(
+                    caseReference="10",
+                    caseId="10",
+                    leadCaseReference="1",
+                    siteAddressTown="townJ",
+                    siteAddressPostcode="postcodeJ",
+                    siteAddressCounty="townJ",
+                    importantinformation="infoJ",
+                    allocationLevel="J",
+                    allocationBand="bandJ",
+                    caseSpecialisms="Specialism J",
+                    advertType="adTypeJ",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="2",
+                    caseId="2",
+                    leadCaseReference="9",
+                    siteAddressTown="townB",
+                    siteAddressPostcode="postcodeB",
+                    siteAddressCounty="townB",
+                    importantinformation="infoB",
+                    allocationLevel="B",
+                    allocationBand="bandB",
+                    caseSpecialisms="Specialism B",
+                    advertType="adTypeB",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="3",
+                    caseId="3",
+                    leadCaseReference="8",
+                    siteAddressTown="townC",
+                    siteAddressPostcode="postcodeC",
+                    siteAddressCounty="townC",
+                    importantinformation="infoC",
+                    allocationLevel="C",
+                    allocationBand="bandC",
+                    caseSpecialisms="Specialism C",
+                    advertType="adTypeC",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="4",
+                    caseId="4",
+                    leadCaseReference="7",
+                    siteAddressTown="townD",
+                    siteAddressPostcode="postcodeD",
+                    siteAddressCounty="townD",
+                    importantinformation="infoD",
+                    allocationLevel="D",
+                    allocationBand="bandD",
+                    caseSpecialisms="Specialism D",
+                    advertType="adTypeD",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="5",
+                    caseId="5",
+                    leadCaseReference="6",
+                    siteAddressTown="townE",
+                    siteAddressPostcode="postcodeE",
+                    siteAddressCounty="townE",
+                    importantinformation="infoE",
+                    allocationLevel="E",
+                    allocationBand="bandE",
+                    caseSpecialisms="Specialism E",
+                    advertType="adTypeE",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="6",
+                    caseId="6",
+                    leadCaseReference="5",
+                    siteAddressTown="townF",
+                    siteAddressPostcode="postcodeF",
+                    siteAddressCounty="townF",
+                    importantinformation="infoF",
+                    allocationLevel="F",
+                    allocationBand="bandF",
+                    caseSpecialisms="Specialism F",
+                    advertType="adTypeF",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="7",
+                    caseId="7",
+                    leadCaseReference="4",
+                    siteAddressTown="townG",
+                    siteAddressPostcode="postcodeG",
+                    siteAddressCounty="townG",
+                    importantinformation="infoG",
+                    allocationLevel="G",
+                    allocationBand="bandG",
+                    caseSpecialisms="Specialism G",
+                    advertType="adTypeG",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="8",
+                    caseId="8",
+                    leadCaseReference="3",
+                    siteAddressTown="townH",
+                    siteAddressPostcode="postcodeH",
+                    siteAddressCounty="townH",
+                    importantinformation="infoH",
+                    allocationLevel="H",
+                    allocationBand="bandH",
+                    caseSpecialisms="Specialism H",
+                    advertType="adTypeH",
+                ),
+                appeal_has_standardised_row(
+                    caseReference="9",
+                    caseId="9",
+                    leadCaseReference="2",
+                    siteAddressTown="townI",
+                    siteAddressPostcode="postcodeI",
+                    siteAddressCounty="townI",
+                    importantinformation="infoI",
+                    allocationLevel="I",
+                    allocationBand="bandI",
+                    caseSpecialisms="Specialism I",
+                    advertType="adTypeI",
+                ),
+            ),
+            schema=appeal_has_standardised_schema(),
+        )
+        output_table = f"{test_case}_horizon_appeal_has"
+        property_override_map = {
+            "STANDARDISED_HORIZON_CASES_S78": horizon_cases_has,
+            "STANDARDISED_CASES_SPECIALISMS": cases_specialisms_table,
+            "STANDARDISED_VW_CASE_DATES": vw_case_dates_table,
+            "STANDARDISED_CASE_DOCUMENT_DATES_DATES": casedocumentdatesdates_table,
+            "STANDARDISED_CASE_SITE_STRINGS": casesitestrings_table,
+            "STANDARDISED_TYPE_OF_PROCEDURE": typeofprocedure_table,
+            "STANDARDISED_ADD_ADDITIONAL_DATA": vw_addadditionaldata_table,
+            "STANDARDISED_ADDITIONAL_FIELDS": vw_additionalfields_table,
+            "STANDARDISED_HORIZON_ADVERT_ATTRIBUTES": horizon_advert_attributes_table,
+            "STANDARDISED_TYPE_OF_LEVEL": typeoflevel_table,
+            "STANDARDISED_HORIZON_SPECIALIST_CASE_DATES": horizon_specialist_case_dates_table,
+            "STANDARDISED_PLANNING_APP_STRINGS": planningappstrings_table,
+            "STANDARDISED_PLANNING_APP_DATES": planningappdates_table,
+            "STANDARDISED_LEAD_CASE": bis_leadcase_table,
+            "STANDARDISED_CASE_STRINGS": casestrings_table,
+            "STANDARDISED_HORIZON_CASE_INFO": horizon_case_info_table,
+            "STANDARDISED_HORIZON_CASE_DATES": horizon_case_dates_table,
+            "STANDARDISED_HORIZON_APPEALS_ADDITIONAL_DATA": horizon_appeals_additional_data_table,
+            "OUTPUT_TABLE": output_table,
         }
+        with ExitStack() as stack:
+            for s78_property, override_value in property_override_map.items():
+                stack.enter_context(mock.patch.object(AppealHasStandardisationProcess, s78_property, override_value))
+            inst = AppealHasStandardisationProcess(spark)
+            result = inst.run()
+            assert_etl_result_successful(result)
+            actual_table_data = spark.table(f"odw_standardised_db.{output_table}")
+            assert_dataframes_equal(expected_data_after_writing, actual_table_data)
 
-        assert actual_df.count() == 2
-        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"
+    def test__ref_appeal_has_standardisation_process__run__with_no_existing_data(self):
+        """
+        - Given there are existing standardised tables related to appeal has
+        - When I call AppealHasStandardisationProcess.run
+        - Then the appeal has table should be created in the standardised layer
+        """
+        self.assert_standardisation_successful("t_rahsp_r_wned")
+
+    def test__ref_appeal_has_standardisation_process__run__with_existing_data(self):
+        """
+        - Given there are existing standardised tables related to appeal has and an existing standardised appeal has table
+        - When I call AppealHasStandardisationProcess.run
+        - Then the appeal has table should be created in the standardised layer and the old appeal has data overwritten
+        """
+        test_case = "t_rahsp_r_wed"
+        spark = PytestSparkSessionUtil().get_spark_session()
+        existing_appeal_has = spark.createDataFrame((appeal_has_standardised_row(caseReference="25"),), schema=appeal_has_standardised_schema())
+        output_table = f"{test_case}_horizon_appeal_has"
+        self.write_existing_table(spark, existing_appeal_has, output_table, "odw_standardised_db", "odw-standardised", output_table, "overwrite")
+        self.assert_standardisation_successful("t_rahsp_r_wed")

--- a/odw/test/integration_test/etl/standardised/test_appeal_has_standardisation_process.py
+++ b/odw/test/integration_test/etl/standardised/test_appeal_has_standardisation_process.py
@@ -1,6 +1,5 @@
 import mock
 import pytest
-import pyspark.sql.types as T
 from odw.test.util.assertion import assert_etl_result_successful, assert_dataframes_equal
 import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
 from odw.core.etl.transformation.standardised.appeal_has_standardisation_process import AppealHasStandardisationProcess

--- a/odw/test/integration_test/etl/standardised/test_appeal_has_standardisation_process.py
+++ b/odw/test/integration_test/etl/standardised/test_appeal_has_standardisation_process.py
@@ -2007,7 +2007,7 @@ class TestRefAppealHasStandardisationProcess(ETLTestCase):
         )
         output_table = f"{test_case}_horizon_appeal_has"
         property_override_map = {
-            "STANDARDISED_HORIZON_CASES_S78": horizon_cases_has,
+            "STANDARDISED_HORIZON_CASES_HAS": horizon_cases_has,
             "STANDARDISED_CASES_SPECIALISMS": cases_specialisms_table,
             "STANDARDISED_VW_CASE_DATES": vw_case_dates_table,
             "STANDARDISED_CASE_DOCUMENT_DATES_DATES": casedocumentdatesdates_table,

--- a/odw/test/unit_test/etl/standardised/test_appeal_has_standardisation_process.py
+++ b/odw/test/unit_test/etl/standardised/test_appeal_has_standardisation_process.py
@@ -1392,3 +1392,446 @@ class TestRefAppealHasStandardisationProcess(SparkTestCase):
 
         assert row["lpaProcedurePreference"] == "Written Reps"
         assert row["caseProcedure"] is None
+
+    def test__appeal_has_standardisation_process__run__standardises_end_to_end_and_matches_legacy(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        hzn_cases_has_df = spark.createDataFrame(
+            [
+                ("HAS-001", 1001, "HAS", "2025-01-10", "2025-01-10", "2025-01-10", "2025-01-10", 1),
+                ("HAS-002", 1002, "HAS", "2025-01-11", "2025-01-11", "2025-01-11", "2025-01-11", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("caseuniqueid", T.StringType(), True),
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("abbreviation", T.StringType(), True),
+                    T.StructField("modifydate", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data = _minimal_source_data(spark, hzn_cases_has_df)
+
+        source_data["cases_specialism_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "Listed Building", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-001", "Advertisements", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "Enforcement", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casereference", T.StringType(), True),
+                    T.StructField("casespecialism", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["vw_case_dates_df"] = spark.createDataFrame(
+            [
+                (
+                    1001,
+                    "2025-01-01",
+                    "2025-01-02",
+                    "2025-01-03",
+                    "2025-01-04",
+                    "2025-01-05",
+                    "2025-01-06",
+                    "2025-01-07",
+                    "2025-01-08",
+                    "2025-01-01",
+                    "2025-01-01",
+                    "2025-01-01",
+                    1,
+                ),
+                (
+                    1002,
+                    "2025-02-01",
+                    "2025-02-02",
+                    "2025-02-03",
+                    "2025-02-04",
+                    "2025-02-05",
+                    "2025-02-06",
+                    "2025-02-07",
+                    "2025-02-08",
+                    "2025-02-01",
+                    "2025-02-01",
+                    "2025-02-01",
+                    1,
+                ),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("receiptdate", T.StringType(), True),
+                    T.StructField("appealdocscomplete", T.StringType(), True),
+                    T.StructField("startdate", T.StringType(), True),
+                    T.StructField("appealwithdrawndate", T.StringType(), True),
+                    T.StructField("casedecisiondate", T.StringType(), True),
+                    T.StructField("datenotrecoveredorderecovered", T.StringType(), True),
+                    T.StructField("daterecovered", T.StringType(), True),
+                    T.StructField("originalcasedecisiondate", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["CaseDocumentDatesDates_df"] = spark.createDataFrame(
+            [
+                (1001, "2025-03-01", "2025-03-02", "2025-03-03", "2025-03-04", "2025-03-01", "2025-03-01", "2025-03-01", 1),
+                (1002, "2025-04-01", "2025-04-02", "2025-04-03", "2025-04-04", "2025-04-01", "2025-04-01", "2025-04-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("questionnairedue", T.StringType(), True),
+                    T.StructField("questionnairereceived", T.StringType(), True),
+                    T.StructField("interestedpartyrepsduedate", T.StringType(), True),
+                    T.StructField("proofsdue", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["vw_AddAdditionalData_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", 50.0, None, "Written Reps", "Y", None, None, "123", "456", "N", "Level 1", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", 75.0, None, None, "N", "Inquiry", None, "789", "012", "Y", "Level 2", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("appealrefnumber", T.StringType(), True),
+                    T.StructField("floorspaceinsquaremetres", T.DoubleType(), True),
+                    T.StructField("costsappliedforindicator", T.StringType(), True),
+                    T.StructField("procedureappellant", T.StringType(), True),
+                    T.StructField("isthesitewithinanaonb", T.StringType(), True),
+                    T.StructField("procedurelpa", T.StringType(), True),
+                    T.StructField("inspectorneedtoentersite", T.StringType(), True),
+                    T.StructField("sitegridreferenceeasting", T.StringType(), True),
+                    T.StructField("sitegridreferencenorthing", T.StringType(), True),
+                    T.StructField("sitewithinsssi", T.StringType(), True),
+                    T.StructField("level", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["vw_AdditionalFields_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "Important info 1", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "Important info 2", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("appealrefnumber", T.StringType(), True),
+                    T.StructField("importantinformation", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_curr_TypeOfLevel_df"] = spark.createDataFrame(
+            [
+                ("Level 1", "Band A", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("Level 2", "Band B", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("name", T.StringType(), True),
+                    T.StructField("band", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["CaseSiteStrings_df"] = spark.createDataFrame(
+            [
+                (1001, "Y", "Line 1", "Line 2", "Town 1", "County 1", "AA1 1AA", "UK", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                (1002, "N", "Line 3", "Line 4", "Town 2", "County 2", "BB1 1BB", "UK", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("siteviewablefromroad", T.StringType(), True),
+                    T.StructField("addressline1", T.StringType(), True),
+                    T.StructField("addressline2", T.StringType(), True),
+                    T.StructField("town", T.StringType(), True),
+                    T.StructField("county", T.StringType(), True),
+                    T.StructField("postcode", T.StringType(), True),
+                    T.StructField("country", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_PlanningAppStrings_df"] = spark.createDataFrame(
+            [
+                (1001, "APP-REF-001", "Full Planning", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                (1002, "APP-REF-002", "Householder", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("lpaapplicationreference", T.StringType(), True),
+                    T.StructField("planningapplicationtype", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_PlanningAppDates_df"] = spark.createDataFrame(
+            [
+                (1001, "2025-05-01", "2025-05-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                (1002, "2025-06-01", "2025-06-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("dateofapplication", T.StringType(), True),
+                    T.StructField("dateoflpadecision", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_CaseStrings_df"] = spark.createDataFrame(
+            [
+                (1001, "Valid", "LPA01", "Linked", "Allowed", "HAS", "N", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                (1002, "Started", "LPA02", "Not linked", "Dismissed", "HAS", "Y", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("processingstate", T.StringType(), True),
+                    T.StructField("lpacode", T.StringType(), True),
+                    T.StructField("linkedstatus", T.StringType(), True),
+                    T.StructField("decision", T.StringType(), True),
+                    T.StructField("jurisdiction", T.StringType(), True),
+                    T.StructField("redetermined", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_LeadCase_df"] = spark.createDataFrame(
+            [
+                (1001, "LEAD-001", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                (1002, "LEAD-002", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("casenodeid", T.IntegerType(), True),
+                    T.StructField("leadcasenodeid", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_CaseInfo_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "Valid appeal", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "Invalid appeal", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("appealrefnumber", T.StringType(), True),
+                    T.StructField("validity", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_CaseDates_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "2025-07-01", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "2025-07-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("appealrefnumber", T.StringType(), True),
+                    T.StructField("validitystatusdate", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_SpecialistCaseDates_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "2025-08-01", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "2025-08-02", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("appealrefnumber", T.StringType(), True),
+                    T.StructField("datecostsreportdespatched", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_AppealsAdditionalData_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "Development 1", None, None, None, None, None, None, None, 1.5, "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "Development 2", None, None, None, None, None, None, None, 2.0, "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("appealrefnumber", T.StringType(), True),
+                    T.StructField("developmentorallegation", T.StringType(), True),
+                    T.StructField("appellantcommentssubmitted", T.StringType(), True),
+                    T.StructField("appellantstatementsubmitted", T.StringType(), True),
+                    T.StructField("lpacommentssubmitted", T.StringType(), True),
+                    T.StructField("lpaproofssubmitted", T.StringType(), True),
+                    T.StructField("lpastatementsubmitted", T.StringType(), True),
+                    T.StructField("sitenoticesent", T.StringType(), True),
+                    T.StructField("statementsdue", T.StringType(), True),
+                    T.StructField("areaofsiteinhectares", T.DoubleType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_vw_BIS_CaseSiteCategoryAdditionalStr_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "Y", "N", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "N", "Y", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("AppealRefNumber", T.StringType(), True),
+                    T.StructField("SiteWithinAGreenBelt", T.StringType(), True),
+                    T.StructField("InCARelatesToCA", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["Horizon_ODW_vw_Inspector_Cases_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "INSPECTOR-001", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "INSPECTOR-002", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("appealrefnumber", T.StringType(), True),
+                    T.StructField("contactid", T.StringType(), True),
+                ]
+            ),
+        )
+
+        source_data["horizon_advert_attributes_df"] = spark.createDataFrame(
+            [
+                ("HAS-001", "ATTR-001", "Poster", 1, "Y", "N", "Safety 1", "Amenity 1", "Y", "N", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+                ("HAS-002", "ATTR-002", "Display", 2, "N", "Y", "Safety 2", "Amenity 2", "N", "Y", "2025-01-01", "2025-01-01", "2025-01-01", 1),
+            ],
+            _metadata_schema(
+                [
+                    T.StructField("caseuniqueid", T.StringType(), True),
+                    T.StructField("advertAttributeKey", T.StringType(), True),
+                    T.StructField("advertType", T.StringType(), True),
+                    T.StructField("setRowNumber", T.IntegerType(), True),
+                    T.StructField("publicSafetyLpaIndicator", T.StringType(), True),
+                    T.StructField("amenityLPAIndicator", T.StringType(), True),
+                    T.StructField("publicSafetyGroundOutcome", T.StringType(), True),
+                    T.StructField("amenityGroundOutcome", T.StringType(), True),
+                    T.StructField("advertInPosition", T.StringType(), True),
+                    T.StructField("siteOnHighwayLand", T.StringType(), True),
+                ]
+            ),
+        )
+
+        inst = AppealHasStandardisationProcess(spark)
+
+        with (
+            mock.patch.object(inst, "load_data", return_value=source_data),
+            mock.patch.object(inst, "write_data") as mock_write,
+        ):
+            result = inst.run()
+
+        data_to_write = mock_write.call_args[0][0]
+        actual_df = data_to_write[inst.OUTPUT_TABLE]["data"]
+
+        actual_result_df = actual_df.select(
+            "caseReference",
+            "caseId",
+            "caseType",
+            "caseProcedure",
+            "allocationLevel",
+            "allocationBand",
+            "caseSpecialisms",
+            "siteAddressLine1",
+            "siteAddressTown",
+            "siteAddressPostcode",
+            "siteAreaSquareMetres",
+            "floorSpaceSquareMetres",
+            "originalDevelopmentDescription",
+            "caseStatus",
+            "lpaCode",
+            "leadCaseReference",
+            "caseValidationOutcome",
+            "caseValidationDate",
+            "dateCostsReportDespatched",
+            "isGreenBelt",
+            "inConservationArea",
+            "inspectorId",
+            "importantinformation",
+            "advertAttributeKey",
+        )
+
+        expected_result_df = spark.createDataFrame(
+            [
+                (
+                    "HAS-001",
+                    1001,
+                    "HAS",
+                    "WR",
+                    "Level 1",
+                    "Band A",
+                    "Advertisements, Listed Building",
+                    "Line 1",
+                    "Town 1",
+                    "AA1 1AA",
+                    15000.0,
+                    50.0,
+                    "Development 1",
+                    "Valid",
+                    "LPA01",
+                    "LEAD-001",
+                    "Valid appeal",
+                    "2025-07-01",
+                    "2025-08-01",
+                    "Y",
+                    "N",
+                    "INSPECTOR-001",
+                    "Important info 1",
+                    "ATTR-001",
+                ),
+                (
+                    "HAS-002",
+                    1002,
+                    "HAS",
+                    "LI",
+                    "Level 2",
+                    "Band B",
+                    "Enforcement",
+                    "Line 3",
+                    "Town 2",
+                    "BB1 1BB",
+                    20000.0,
+                    75.0,
+                    "Development 2",
+                    "Started",
+                    "LPA02",
+                    "LEAD-002",
+                    "Invalid appeal",
+                    "2025-07-02",
+                    "2025-08-02",
+                    "N",
+                    "Y",
+                    "INSPECTOR-002",
+                    "Important info 2",
+                    "ATTR-002",
+                ),
+            ],
+            actual_result_df.schema,
+        )
+
+        assert_dataframes_equal(actual_result_df, expected_result_df)
+
+        assert {
+            "insert_count": result.metadata.insert_count,
+            "update_count": result.metadata.update_count,
+            "delete_count": result.metadata.delete_count,
+        } == {
+            "insert_count": 2,
+            "update_count": 0,
+            "delete_count": 0,
+        }
+
+        assert actual_df.count() == 2
+        assert data_to_write[inst.OUTPUT_TABLE]["write_mode"] == "overwrite"


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-3103

- Update appeal has integration tests to test that input data correctly flows through the ETL process
- Migrate old some integration tests to the unit test folder (since there were more like unit tests than integration tests, and it is good to keep these) - Not all integration tests were migrated because there was overlapping logic with the existing unit tests