### PR TITLE
Updating notebook: py_sb_harmonised_nsip_meeting

### DIFF
--- a/workspace/notebook/py_sb_harmonised_nsip_meeting.json
+++ b/workspace/notebook/py_sb_harmonised_nsip_meeting.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "91cea692-3b1d-4b1c-92cb-1eedc4f8586f"
+				"spark.autotune.trackingId": "836d817d-2fa2-4220-9658-f6ea01059f5c"
 			}
 		},
 		"metadata": {
@@ -108,7 +108,7 @@
 					"insert_count = 0\n",
 					"update_count = 0\n",
 					"delete_count = 0\n",
-					"error_message = None"
+					"error_message=''"
 				],
 				"execution_count": null
 			},
@@ -364,6 +364,7 @@
 					"            \n",
 					"            initial_load.write.format(\"delta\").mode(\"overwrite\").option(\"overwriteSchema\",True).saveAsTable(spark_table_final)\n",
 					"            print(f\"Initial load completed. Created {initial_load.count()} records.\")\n",
+					"            end_exec_time = datetime.now()\n",
 					"        else:\n",
 					"            # Get max NSIPMeetingId from target table\n",
 					"            max_id_result = spark.read.format(\"delta\").table(spark_table_final) \\\n",
@@ -467,7 +468,10 @@
 			{
 				"cell_type": "code",
 				"source": [
+					"if end_exec_time is None:\n",
+					"    end_exec_time = datetime.now()\n",
 					"duration_seconds = (end_exec_time - start_exec_time).total_seconds()\n",
+					"print(duration_seconds)\n",
 					"activity_type = f\"{mssparkutils.runtime.context['currentNotebookName']} Notebook\"\n",
 					"stage = \"Success\" if not error_message else \"Failed\"\n",
 					"status_message = (\n",
@@ -476,10 +480,6 @@
 					"    else f\"Failed to load data into {spark_table_final} table\"\n",
 					")\n",
 					"status_code = \"200\" if stage == \"Success\" else \"500\"\n",
-					"print(duration_seconds)\n",
-					"if end_exec_time is None:\n",
-					"    end_exec_time = datetime.now()\n",
-					"\n",
 					"\n",
 					"log_telemetry_and_exit(\n",
 					"    stage,\n",

--- a/workspace/notebook/py_sb_harmonised_nsip_meeting.json
+++ b/workspace/notebook/py_sb_harmonised_nsip_meeting.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "836d817d-2fa2-4220-9658-f6ea01059f5c"
+				"spark.autotune.trackingId": "505d2230-d0da-4722-8125-d181240530fb"
 			}
 		},
 		"metadata": {
@@ -105,6 +105,7 @@
 					"spark_table_final = \"odw_harmonised_db.sb_nsip_meeting\"\n",
 					"\n",
 					"start_exec_time = datetime.now()\n",
+					"end_exec_time = None\n",
 					"insert_count = 0\n",
 					"update_count = 0\n",
 					"delete_count = 0\n",

--- a/workspace/notebook/py_sb_harmonised_nsip_meeting.json
+++ b/workspace/notebook/py_sb_harmonised_nsip_meeting.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "505d2230-d0da-4722-8125-d181240530fb"
+				"spark.autotune.trackingId": "20314b64-87ef-46bd-8b04-c312bc0ce12b"
 			}
 		},
 		"metadata": {
@@ -472,7 +472,6 @@
 					"if end_exec_time is None:\n",
 					"    end_exec_time = datetime.now()\n",
 					"duration_seconds = (end_exec_time - start_exec_time).total_seconds()\n",
-					"print(duration_seconds)\n",
 					"activity_type = f\"{mssparkutils.runtime.context['currentNotebookName']} Notebook\"\n",
 					"stage = \"Success\" if not error_message else \"Failed\"\n",
 					"status_message = (\n",


### PR DESCRIPTION
Jira  :
https://pins-ds.atlassian.net/browse/THEODW-3199

Changes summary 

1.  end_exec_time = datetime.now() was added inside the isEmpty() branch in the SCD cell, right after the initial load write completes, so the variable is always assigned when that path is taken.

2.  in the final telemetry cell the if end_exec_time is None guard was moved to sit before the duration_seconds calculation rather than after it, so it actually acts as a safety net instead of being unreachable.

3.  error_message was changed from None to an empty string '' in the variable initialisation cell. This is because later in the column drop cell the code does error_message += column_drop_error, which requires error_message to already be a string. If it were None, this would throw a TypeError on concatenation.

**PR Template**

Note: Run the correct ADO pipeline for this PR - check the list here:
[ODW Repositories](https://pins-ds.atlassian.net/wiki/spaces/ODW/pages/2285764637/ODW+repositories)
 1. JIRA Ticket Reference  :
         <!-- Replace with JIRA ticket number and title -->
    [ Enter JIRA ticket number and Title here]

 2.  Summary of the work : 
         <!-- Replace with a short summary of changes -->
    [ Enter Summary here]
 
 4.  New Source-to-Raw Datasets
	
	 - [ ] New source data has been added
  	    - A trigger has been attached at the appropriate frequency

 5.  New Tables in Standardised Layer

   	 - [ ] New standardised tables have been created
		 -  orchestration.json is updated and tested in Dev, and PR is open or merged to main
		 -  Schema exists in odw-config/standardised-table-definitions or is about to be PRd
 
 6.   New Tables in Harmonised or Curated Layers

      - [ ] New harmonised or curated tables have been created
 		- Script is configured in the pipeline pln_post_deployments
        - Schema exists in odw-config/harmonised-table-definitions or curated-table-definitions or is about to be PRd
 
 7.  Schema or Column Changes
    (Only new columns or columns with changed data types are in scope)

     - [ ] Changes to table structure or columns
		  - py_change_table is set to run in pln_post_deployments
	      - A script has been created to backfill or populate new column(s) in Test and Prod
			 - [ ] Avoid dropping and recreating tables unless strictly necessary

 8. Script Execution in Build
	 - [ ] Scripts have run in isolation in Build
		-  Script has been added to pln_post_deployments
	    -  Script is now part of a scheduled pipeline with correct triggers
	 - [ ] No scripts have run or no action required in Test/Prod

9. Table Creation and Schema Validation
   
  	 - [ ] All required tables have been created
  	 - [ ] Schema has been validated against the requirements

10.  Deployment and Schema Change Documentation
	
  	 - [ ] Deployment steps and rollback procedures are documented
  	 - [ ] Schema change handling is outlined and tested

11. Archiving Process Review

  	 - [ ] Automatic archiving logic has been reviewed
  	 - [ ] Archiving schedules and retention policies are validated
 
