### PR TITLE
Fix/theodw 3217 optimise nsip project

### DIFF
--- a/odw/core/etl/transformation/harmonised/nsip_project_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/nsip_project_harmonisation_process.py
@@ -881,7 +881,7 @@ class NsipProjectHarmonisationProcess(HarmonisationProcess):
         grouping_cols_map = {"region": "regions"} | {x: x for x in grouping_cols}
         # This deviates from the original notebook, which has performance issues
         w = Window.partitionBy(horizon_data["caseid"], "IngestionDate")
-        horizon_data = horizon_data.withColumns({alias: F.collect_list(col).over(w).alias(alias) for col, alias in grouping_cols_map.items()})
+        horizon_data = horizon_data.withColumns({alias: F.collect_list(col).over(w) for col, alias in grouping_cols_map.items()})
         # Sort columns into same order as service bus
         horizon_data = horizon_data.select(service_bus_data.columns)
 

--- a/odw/core/etl/transformation/harmonised/nsip_project_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/nsip_project_harmonisation_process.py
@@ -498,10 +498,11 @@ class NsipProjectHarmonisationProcess(HarmonisationProcess):
         """
         # Need to read the original table
         w_reverse_per_case = Window.partitionBy("caseid").orderBy(F.col("IngestionDate").desc())
+        w_internal_id = Window.orderBy(F.col("IngestionDate").asc(), F.col("caseid").asc())
 
         out_df = combined_data.select(
             F.row_number().over(w_reverse_per_case).alias("ReverseOrderProcessed"),
-            F.monotonically_increasing_id().cast("int").alias("NSIPProjectInfoInternalID"),
+            F.row_number().over(w_internal_id).alias("NSIPProjectInfoInternalID"),
             F.col("caseid"),
             F.col("IngestionDate"),
             F.col("ValidTo"),
@@ -866,7 +867,6 @@ class NsipProjectHarmonisationProcess(HarmonisationProcess):
         )
 
         # Build Ids
-        horizon_data_grouped = horizon_data.groupBy(horizon_data["caseid"], "IngestionDate")
         grouping_cols = (
             "nsipOfficerIds",
             "nsipAdministrationOfficerIds",
@@ -879,10 +879,9 @@ class NsipProjectHarmonisationProcess(HarmonisationProcess):
             "environmentalServicesOfficerIds",
         )
         grouping_cols_map = {"region": "regions"} | {x: x for x in grouping_cols}
-        for col, alias in grouping_cols_map.items():
-            sub_grouping = horizon_data_grouped.agg(F.collect_list(col).alias(alias))
-            horizon_data = horizon_data.drop(col).join(sub_grouping, on=["caseid", "IngestionDate"], how="inner")
-
+        # This deviates from the original notebook, which has performance issues
+        w = Window.partitionBy(horizon_data["caseid"], "IngestionDate")
+        horizon_data = horizon_data.withColumns({alias: F.collect_list(col).over(w).alias(alias) for col, alias in grouping_cols_map.items()})
         # Sort columns into same order as service bus
         horizon_data = horizon_data.select(service_bus_data.columns)
 

--- a/odw/core/etl/transformation/harmonised/nsip_project_harmonisation_process.py
+++ b/odw/core/etl/transformation/harmonised/nsip_project_harmonisation_process.py
@@ -498,17 +498,15 @@ class NsipProjectHarmonisationProcess(HarmonisationProcess):
         """
         # Need to read the original table
         w_reverse_per_case = Window.partitionBy("caseid").orderBy(F.col("IngestionDate").desc())
-        w_internal_id = Window.orderBy(F.col("IngestionDate").asc(), F.col("caseid").asc())
 
         out_df = combined_data.select(
             F.row_number().over(w_reverse_per_case).alias("ReverseOrderProcessed"),
-            F.row_number().over(w_internal_id).alias("NSIPProjectInfoInternalID"),
+            F.monotonically_increasing_id().cast("int").alias("NSIPProjectInfoInternalID"),
             F.col("caseid"),
             F.col("IngestionDate"),
             F.col("ValidTo"),
             F.lit("0").alias("migrated"),
-            F.when(F.row_number().over(w_reverse_per_case) == 1, F.lit("Y")).otherwise(F.lit("N")).alias("IsActive"),
-        )
+        ).withColumn("IsActive", F.when(F.col("ReverseOrderProcessed") == 1, F.lit("Y")).otherwise("N"))
         df_calcs = (
             out_df.alias("current")
             .join(

--- a/odw/test/unit_test/etl/harmonised/test_nsip_project_harmonisation_process.py
+++ b/odw/test/unit_test/etl/harmonised/test_nsip_project_harmonisation_process.py
@@ -854,6 +854,36 @@ class TestNsipProjectHarmonisationProcess(SparkTestCase):
                 caseManagerIds=["caseManagerIds2"],
                 leadInspectorIds=["leadInspectorIds2"],
                 environmentalServicesOfficerIds=["environmentalServicesOfficerIds2"],
+            ),  # Duplicate entry
+            _horizon_row(
+                caseid=3003,
+                Region="wales",
+                IngestionDate=datetime(2025, 3, 1, 10, 0, 0),
+                RowID=2,
+                nsipOfficerIds=["nsipOfficerId1"],
+                nsipAdministrationOfficerIds=["nsipAdministrationOfficerIds1"],
+                inspectorIds=["inspectorIds1"],
+                operationsManagerIds=["operationsManagerIds1"],
+                legalOfficerIds=["legalOfficerIds1"],
+                operationsLeadIds=["operationsLeadIds1"],
+                caseManagerIds=["caseManagerIds1"],
+                leadInspectorIds=["leadInspectorIds1"],
+                environmentalServicesOfficerIds=["environmentalServicesOfficerIds1"],
+            ),
+            _horizon_row(  # Different caseid
+                caseid=3004,
+                Region="wales",
+                IngestionDate=datetime(2025, 3, 1, 10, 0, 0),
+                RowID=1,
+                nsipOfficerIds=["nsipOfficerId3"],
+                nsipAdministrationOfficerIds=["nsipAdministrationOfficerIds3"],
+                inspectorIds=["inspectorIds3"],
+                operationsManagerIds=["operationsManagerIds3"],
+                legalOfficerIds=["legalOfficerIds3"],
+                operationsLeadIds=["operationsLeadIds3"],
+                caseManagerIds=["caseManagerIds3"],
+                leadInspectorIds=["leadInspectorIds3"],
+                environmentalServicesOfficerIds=["environmentalServicesOfficerIds3"],
             ),
         ]
 
@@ -892,15 +922,40 @@ class TestNsipProjectHarmonisationProcess(SparkTestCase):
             .collect()[0]
         )
 
-        assert len(row["nsipOfficerIds"]) == 2
-        assert len(row["nsipAdministrationOfficerIds"]) == 2
-        assert len(row["inspectorIds"]) == 2
-        assert len(row["operationsManagerIds"]) == 2
-        assert len(row["legalOfficerIds"]) == 2
-        assert len(row["operationsLeadIds"]) == 2
-        assert len(row["caseManagerIds"]) == 2
-        assert len(row["leadInspectorIds"]) == 2
-        assert len(row["environmentalServicesOfficerIds"]) == 2
+        assert len(row["nsipOfficerIds"]) == 3
+        assert len(row["nsipAdministrationOfficerIds"]) == 3
+        assert len(row["inspectorIds"]) == 3
+        assert len(row["operationsManagerIds"]) == 3
+        assert len(row["legalOfficerIds"]) == 3
+        assert len(row["operationsLeadIds"]) == 3
+        assert len(row["caseManagerIds"]) == 3
+        assert len(row["leadInspectorIds"]) == 3
+        assert len(row["environmentalServicesOfficerIds"]) == 3
+
+        row = (
+            df.where((F.col("caseId") == 3004) & (F.col("sourceSystem") == "Horizon"))
+            .select(
+                "nsipOfficerIds",
+                "nsipAdministrationOfficerIds",
+                "inspectorIds",
+                "operationsManagerIds",
+                "legalOfficerIds",
+                "operationsLeadIds",
+                "caseManagerIds",
+                "leadInspectorIds",
+                "environmentalServicesOfficerIds",
+            )
+            .collect()[0]
+        )
+        assert len(row["nsipOfficerIds"]) == 1
+        assert len(row["nsipAdministrationOfficerIds"]) == 1
+        assert len(row["inspectorIds"]) == 1
+        assert len(row["operationsManagerIds"]) == 1
+        assert len(row["legalOfficerIds"]) == 1
+        assert len(row["operationsLeadIds"]) == 1
+        assert len(row["caseManagerIds"]) == 1
+        assert len(row["leadInspectorIds"]) == 1
+        assert len(row["environmentalServicesOfficerIds"]) == 1
 
     def test__nsip_project_harmonisation_process__process__parses_invoices_and_meetings_json_from_horizon(self):
         spark = PytestSparkSessionUtil().get_spark_session()


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/THEODW-3217

Replace inefficient aggregations in the NSIP project ETLProcess (inherited from the source notebook) with a window function - cutting down test runtime from ~10m to ~1m