### PR TITLE
Updating pipeline: pln_curated

### DIFF
--- a/workspace/pipeline/pln_curated.json
+++ b/workspace/pipeline/pln_curated.json
@@ -1191,22 +1191,6 @@
 				}
 			},
 			{
-				"name": "pln_curated_migration",
-				"type": "ExecutePipeline",
-				"dependsOn": [],
-				"policy": {
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"pipeline": {
-						"referenceName": "pln_curated_migration",
-						"type": "PipelineReference"
-					},
-					"waitOnCompletion": true
-				}
-			},
-			{
 				"name": "Listed building",
 				"type": "SynapseNotebook",
 				"dependsOn": [],


### PR DESCRIPTION
⁠
Gareth  As confirmed, no one is currently using the migrated table, so we can stop loading it. 

I have removed the `pln_curated_migration` component from the `pln_curated` pipeline accordingly.
<img width="727" height="133" alt="image" src="https://github.com/user-attachments/assets/68113e00-08ad-4cc3-be5b-67bf555810ab" />
