### PR TITLE
Fix/theodw 3306 anonymisation failure in dev test

### DIFF
--- a/odw/core/anonymisation/engine.py
+++ b/odw/core/anonymisation/engine.py
@@ -192,7 +192,7 @@ def _build_asset_qualified_name_from_params(*, storage_host: str, source_folder:
     Notes:
     - ServiceBus assets are JSON files with a timestamp in the filename. The pattern must
       include literal Purview placeholders (e.g. {Year}, {Month}, {Day}, {Hour}, {N}).
-    - Horizon assets are stored under odw-raw/archive/Horizon/ in ADLS. The filename is
+    - Horizon assets are stored under odw-raw/Horizon/ in ADLS. The filename is
       converted to a resource set pattern by replacing numeric sequences with {N}.
     - entraid assets are JSON files named after the entity under a dated folder.
     """
@@ -212,7 +212,7 @@ def _build_asset_qualified_name_from_params(*, storage_host: str, source_folder:
         if not file_name:
             raise ValueError("file_name is required for source_folder='Horizon'")
         pattern_name = _horizon_filename_to_purview_pattern(file_name)
-        return f"https://{host}/odw-raw/archive/{source_folder}/{{Year}}-{{Month}}-{{Day}}/{pattern_name}"
+        return f"https://{host}/odw-raw/{source_folder}/{{Year}}-{{Month}}-{{Day}}/{pattern_name}"
     if source_folder == "entraid":
         if not entity_name:
             raise ValueError("entity_name is required for source_folder='entraid'")

--- a/odw/core/etl/transformation/standardised/service_bus_standardisation_process.py
+++ b/odw/core/etl/transformation/standardised/service_bus_standardisation_process.py
@@ -159,11 +159,12 @@ class ServiceBusStandardisationProcess(StandardisationProcess):
             raise ValueError("ServiceBusStandardisationProcess.process requires new_raw_messages dataframe to be provided, but was missing")
         table_row_count = table_df.count()
         new_raw_messages = self.remove_data_duplicates(new_raw_messages)
+        insert_count = new_raw_messages.count()
 
         _anon_enabled = Util.is_non_production_environment()
         LoggingUtil().log_info(f"anonymisation_gate: environment={Util.get_environment()} enabled={_anon_enabled} entity={entity_name}")
-        # Apply anonymisation only in DEV/TEST environments
-        if _anon_enabled:
+        # Apply anonymisation only in DEV/TEST environments, and only when there are rows to process
+        if _anon_enabled and insert_count > 0:
             try:
                 anon_config = AnonymisationConfig()
                 try:
@@ -184,7 +185,6 @@ class ServiceBusStandardisationProcess(StandardisationProcess):
                 LoggingUtil().log_error(f"Anonymisation failed for {entity_name}: {str(e)}")
                 raise
 
-        insert_count = new_raw_messages.count()
         LoggingUtil().log_info(f"Rows to append: {insert_count}")
         expected_new_count = table_row_count + insert_count
         LoggingUtil().log_info(f"Expected new count: {expected_new_count}")

--- a/odw/test/unit_test/anonymisation/test_unit_anonymisation_engine.py
+++ b/odw/test/unit_test/anonymisation/test_unit_anonymisation_engine.py
@@ -795,14 +795,14 @@ class TestHorizonPurviewFQNBuilder:
     def test__filename_to_purview_pattern__no_extension(self):
         assert _horizon_filename_to_purview_pattern("HorizonCases78") == "HorizonCases{N}"
 
-    def test__build_fqn__horizon_uses_archive_prefix(self):
+    def test__build_fqn__horizon_path(self):
         fqn = _build_asset_qualified_name_from_params(
             storage_host="pinsstodwdevuks9h80mb.dfs.core.windows.net",
             source_folder="Horizon",
             entity_name=None,
             file_name="HorizonCases_s78.csv",
         )
-        assert fqn == ("https://pinsstodwdevuks9h80mb.dfs.core.windows.net/odw-raw/archive/Horizon/{Year}-{Month}-{Day}/HorizonCases_s{N}.csv")
+        assert fqn == ("https://pinsstodwdevuks9h80mb.dfs.core.windows.net/odw-raw/Horizon/{Year}-{Month}-{Day}/HorizonCases_s{N}.csv")
 
     def test__build_fqn__horizon_converts_filename_to_pattern(self):
         fqn = _build_asset_qualified_name_from_params(
@@ -812,7 +812,7 @@ class TestHorizonPurviewFQNBuilder:
             file_name="HorizonAppeals42.csv",
         )
         assert "/HorizonAppeals{N}.csv" in fqn
-        assert "/archive/Horizon/" in fqn
+        assert "/odw-raw/Horizon/" in fqn
 
     def test__extract_classified_columns__reads_tab_schema_guid(self):
         """tabSchema (single dict) must be followed when attachedSchema is absent."""

--- a/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
+++ b/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
@@ -95,8 +95,6 @@ class TestServiceBusStandardisationAnonymisation(SparkTestCase):
             mock.patch.object(Util, "is_non_production_environment", return_value=True),
             mock.patch.object(Util, "get_storage_account", return_value="test-storage.dfs.core.windows.net"),
             mock.patch.object(LoggingUtil, "__new__"),
-            mock.patch.object(LoggingUtil, "log_info", return_value=None),
-            mock.patch.object(LoggingUtil, "log_error", return_value=None),
             mock.patch(
                 "odw.core.etl.transformation.standardised.service_bus_standardisation_process.AnonymisationEngine.apply_from_purview",
                 return_value=anonymised_df,
@@ -138,8 +136,6 @@ class TestServiceBusStandardisationAnonymisation(SparkTestCase):
             mock.patch.object(Util, "is_non_production_environment", return_value=False),
             mock.patch.object(Util, "get_storage_account", return_value="test-storage.dfs.core.windows.net"),
             mock.patch.object(LoggingUtil, "__new__"),
-            mock.patch.object(LoggingUtil, "log_info", return_value=None),
-            mock.patch.object(LoggingUtil, "log_error", return_value=None),
             mock.patch(
                 "odw.core.etl.transformation.standardised.service_bus_standardisation_process.AnonymisationEngine.apply_from_purview"
             ) as mock_apply,
@@ -178,8 +174,6 @@ class TestServiceBusStandardisationAnonymisation(SparkTestCase):
             mock.patch.object(Util, "is_non_production_environment", return_value=True),
             mock.patch.object(Util, "get_storage_account", return_value="test-storage.dfs.core.windows.net"),
             mock.patch.object(LoggingUtil, "__new__"),
-            mock.patch.object(LoggingUtil, "log_info", return_value=None),
-            mock.patch.object(LoggingUtil, "log_error", return_value=None),
             mock.patch(
                 "odw.core.etl.transformation.standardised.service_bus_standardisation_process.AnonymisationEngine.apply_from_purview",
                 return_value=anonymised_df,
@@ -219,8 +213,6 @@ class TestServiceBusStandardisationAnonymisation(SparkTestCase):
             mock.patch.object(Util, "is_non_production_environment", return_value=True),
             mock.patch.object(Util, "get_storage_account", return_value="test-storage.dfs.core.windows.net"),
             mock.patch.object(LoggingUtil, "__new__"),
-            mock.patch.object(LoggingUtil, "log_info", return_value=None),
-            mock.patch.object(LoggingUtil, "log_error", return_value=None),
             mock.patch(
                 "odw.core.etl.transformation.standardised.service_bus_standardisation_process.AnonymisationEngine.apply_from_purview",
                 side_effect=RuntimeError("Purview anonymisation failed"),
@@ -252,8 +244,6 @@ class TestServiceBusStandardisationAnonymisation(SparkTestCase):
             mock.patch.object(Util, "is_non_production_environment", return_value=True),
             mock.patch.object(Util, "get_storage_account", return_value="test-storage.dfs.core.windows.net"),
             mock.patch.object(LoggingUtil, "__new__"),
-            mock.patch.object(LoggingUtil, "log_info", return_value=None),
-            mock.patch.object(LoggingUtil, "log_error", return_value=None),
             mock.patch(
                 "odw.core.etl.transformation.standardised.service_bus_standardisation_process.AnonymisationEngine.apply_from_purview"
             ) as mock_apply,

--- a/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
+++ b/odw/test/unit_test/etl/test_service_bus_standardisation_anonymisation.py
@@ -234,3 +234,33 @@ class TestServiceBusStandardisationAnonymisation(SparkTestCase):
                 assert False, "Expected process() to raise when anonymisation fails"
             except RuntimeError as ex:
                 assert str(ex) == "Purview anonymisation failed"
+
+    def test__service_bus_standardisation__process_skips_anonymisation_when_no_new_rows(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        table_df = _build_existing_table_df(spark)
+        empty_df = _build_raw_messages_df(spark).filter(F.lit(False))
+
+        process = ServiceBusStandardisationProcess(spark=spark)
+
+        source_data = {
+            "odw_standardised_db.sb_service_user": table_df,
+            "raw_messages": empty_df,
+        }
+
+        with (
+            mock.patch.object(Util, "is_non_production_environment", return_value=True),
+            mock.patch.object(Util, "get_storage_account", return_value="test-storage.dfs.core.windows.net"),
+            mock.patch.object(LoggingUtil, "__new__"),
+            mock.patch.object(LoggingUtil, "log_info", return_value=None),
+            mock.patch.object(LoggingUtil, "log_error", return_value=None),
+            mock.patch(
+                "odw.core.etl.transformation.standardised.service_bus_standardisation_process.AnonymisationEngine.apply_from_purview"
+            ) as mock_apply,
+        ):
+            process.process(
+                source_data=source_data.copy(),
+                entity_name="service-user",
+            )
+
+        mock_apply.assert_not_called()

--- a/workspace/notebook/py_horizon_raw_to_std.json
+++ b/workspace/notebook/py_horizon_raw_to_std.json
@@ -561,6 +561,7 @@
 					"    row_count = 0\n",
 					"    error_message = \"\"\n",
 					"    start_exec_time = datetime.now()\n",
+					"    end_exec_time = datetime.now()\n",
 					"    try:\n",
 					"        spark = SparkSession.builder.getOrCreate()\n",
 					"\n",


### PR DESCRIPTION
## Summary

- Removes the erroneous `archive/` segment from the Horizon ADLS path used when looking up Purview classifications — the correct qualified name path is `odw-raw/Horizon/{Year}-{Month}-{Day}/<filename>`, not `odw-raw/archive/Horizon/...`
- Fixes an `UnboundLocalError` in `ingest_horizon` where `end_exec_time` was referenced on the exception path before being assigned; it is now initialised alongside `start_exec_time`
- Updates unit tests to reflect the corrected Horizon Purview path

## Test plan

- [ ] Unit tests pass: `poetry run pytest odw/test/unit_test/anonymisation/test_unit_anonymisation_engine.py`
- [ ] `pln_horizon_to_std` pipeline runs successfully in DEV for `BIS_CaseSiteCategoryAdditionalStr.csv`
- [ ] Confirm Purview lookup resolves to `odw-raw/Horizon/{Year}-{Month}-{Day}/BIS_CaseSiteCategoryAdditionalStr.csv`
- [ ] No regressions in other Horizon files