### PR TITLE
Feature/theodw 2959 test

### DIFF
--- a/odw/core/etl/transformation/curated/appeal_folder_curation_process.py
+++ b/odw/core/etl/transformation/curated/appeal_folder_curation_process.py
@@ -16,4 +16,3 @@ class AppealFolderCurationProcess(CurationProcess):
 
     def process(self, source_data: dict[str, Any]):
         raise NotImplementedError("AppealFolderCurationProcess.process() has not been implemented yet.")
-

--- a/odw/core/etl/transformation/curated/appeal_folder_curation_process.py
+++ b/odw/core/etl/transformation/curated/appeal_folder_curation_process.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from odw.core.etl.transformation.curated.curation_process import CurationProcess
+
+
+class AppealFolderCurationProcess(CurationProcess):
+    HARMONISED_TABLE = "odw_harmonised_db.appeals_folder"
+    OUTPUT_TABLE = "odw_curated_db.appeal_folder"
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "Appeal Folder Curation Process"
+
+    def load_data(self, **kwargs) -> dict[str, Any]:
+        raise NotImplementedError("AppealFolderCurationProcess.load_data() has not been implemented yet.")
+
+    def process(self, source_data: dict[str, Any]):
+        raise NotImplementedError("AppealFolderCurationProcess.process() has not been implemented yet.")
+

--- a/odw/core/etl/transformation/curated/legacy_folder_data_curation_process.py
+++ b/odw/core/etl/transformation/curated/legacy_folder_data_curation_process.py
@@ -16,4 +16,3 @@ class LegacyFolderDataCurationProcess(CurationProcess):
 
     def process(self, source_data: dict[str, Any]):
         raise NotImplementedError("LegacyFolderDataCurationProcess.process() has not been implemented yet.")
-

--- a/odw/core/etl/transformation/curated/legacy_folder_data_curation_process.py
+++ b/odw/core/etl/transformation/curated/legacy_folder_data_curation_process.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from odw.core.etl.transformation.curated.curation_process import CurationProcess
+
+
+class LegacyFolderDataCurationProcess(CurationProcess):
+    HARMONISED_TABLE = "odw_harmonised_db.horizon_folder"
+    OUTPUT_TABLE = "odw_curated_db.legacy_folder_data"
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "Legacy Folder Data Curation Process"
+
+    def load_data(self, **kwargs) -> dict[str, Any]:
+        raise NotImplementedError("LegacyFolderDataCurationProcess.load_data() has not been implemented yet.")
+
+    def process(self, source_data: dict[str, Any]):
+        raise NotImplementedError("LegacyFolderDataCurationProcess.process() has not been implemented yet.")
+

--- a/odw/test/integration_test/etl/curated/test_appeal_folder_curation_process.py
+++ b/odw/test/integration_test/etl/curated/test_appeal_folder_curation_process.py
@@ -1,0 +1,264 @@
+from datetime import datetime
+
+import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
+import pyspark.sql.types as T
+import pytest
+from odw.core.etl.transformation.curated.appeal_folder_curation_process import AppealFolderCurationProcess
+from odw.test.integration_test.etl.etl_test_case import ETLTestCase
+from odw.test.util.assertion import assert_dataframes_equal, assert_etl_result_successful
+from odw.test.util.session_util import PytestSparkSessionUtil
+
+
+pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
+
+
+class TestAppealFolderCurationProcess(ETLTestCase):
+    ACTIVE_HARMONISED_DATA = [
+        (
+            "100",
+            "APP/100",
+            "Core Documents",
+            "Dogfennau Craidd",
+            "10",
+            "11",
+            "Decision",
+            datetime(2025, 1, 1, 0, 0, 0, 0).isoformat(),
+            None,
+            "row-100",
+            "Y",
+            "message-100",
+        ),
+        (
+            "101",
+            "APP/101",
+            "Case Admin",
+            "Gweinyddu Achos",
+            "20",
+            "20",
+            "Post decision",
+            datetime(2025, 1, 2, 0, 0, 0, 0).isoformat(),
+            None,
+            "row-101",
+            "N",
+            "message-101",
+        ),
+        (
+            "102",
+            "APP/102",
+            "Inquiry",
+            "Ymchwiliad",
+            "30",
+            "31",
+            "Pre-examination",
+            datetime(2025, 1, 3, 0, 0, 0, 0).isoformat(),
+            None,
+            "row-102",
+            None,
+            "message-102",
+        ),
+    ]
+
+    def generate_harmonised_table(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+        return spark.createDataFrame(
+            data=self.ACTIVE_HARMONISED_DATA
+            + [
+                (
+                    "102",
+                    "APP/102",
+                    "Inquiry",
+                    "Ymchwiliad",
+                    "30",
+                    "31",
+                    "Pre-examination",
+                    datetime(2025, 1, 3, 0, 0, 0, 0).isoformat(),
+                    None,
+                    "row-102-dupe",
+                    None,
+                    "message-102-dupe",
+                )
+            ],
+            schema=T.StructType(
+                [
+                    T.StructField("ID", T.StringType(), True),
+                    T.StructField("CaseReference", T.StringType(), True),
+                    T.StructField("DisplayNameEnglish", T.StringType(), True),
+                    T.StructField("DisplayNameWelsh", T.StringType(), True),
+                    T.StructField("ParentFolderID", T.StringType(), True),
+                    T.StructField("CaseNodeId", T.StringType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                    T.StructField("IngestionDate", T.StringType(), True),
+                    T.StructField("ValidTo", T.StringType(), True),
+                    T.StructField("RowID", T.StringType(), True),
+                    T.StructField("IsActive", T.StringType(), True),
+                    T.StructField("message_id", T.StringType(), True),
+                ]
+            ),
+        )
+
+    def generate_curated_data_schema(self):
+        return T.StructType(
+            [
+                T.StructField("id", T.IntegerType(), True),
+                T.StructField("caseReference", T.StringType(), True),
+                T.StructField("displayNameEnglish", T.StringType(), True),
+                T.StructField("displayNameWelsh", T.StringType(), True),
+                T.StructField("parentFolderId", T.IntegerType(), True),
+                T.StructField("caseStage", T.StringType(), True),
+            ]
+        )
+
+    def generate_curated_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+        return spark.createDataFrame(
+            data=(
+                (100, "APP/100", "Core Documents", "Dogfennau Craidd", 10, "decision"),
+                (101, "APP/101", "Case Admin", "Gweinyddu Achos", None, "post_decision"),
+                (102, "APP/102", "Inquiry", "Ymchwiliad", 30, "pre-examination"),
+            ),
+            schema=self.generate_curated_data_schema(),
+        )
+
+    def test__appeal_folder_curation_process__run__with_existing_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        self.write_existing_table(
+            spark,
+            self.generate_harmonised_table(),
+            "appeals_folder",
+            "odw_harmonised_db",
+            "odw-harmonised",
+            "appeals_folder",
+            "overwrite",
+        )
+
+        existing_curated_data = spark.createDataFrame(
+            [
+                (999, "APP/999", "Old", "Hen", None, "decision"),
+            ],
+            self.generate_curated_data_schema(),
+        )
+
+        self.write_existing_table(
+            spark,
+            existing_curated_data,
+            "appeal_folder",
+            "odw_curated_db",
+            "odw-curated",
+            "appeal_folder",
+            "overwrite",
+        )
+
+        expected_curated_data_after_writing = self.generate_curated_data()
+
+        inst = AppealFolderCurationProcess(spark)
+        result = inst.run(
+            orchestration_run_id="t_afcp_r_wed",
+            orchestration_entity_name="appeal_folder",
+            orchestration_stage_name="curate",
+        )
+        assert_etl_result_successful(result)
+        actual_table_data = spark.table("odw_curated_db.appeal_folder")
+        assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
+
+    def test__appeal_folder_curation_process__run__with_no_existing_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        spark.sql("DROP TABLE IF EXISTS odw_curated_db.appeal_folder")
+
+        self.write_existing_table(
+            spark,
+            self.generate_harmonised_table(),
+            "appeals_folder",
+            "odw_harmonised_db",
+            "odw-harmonised",
+            "appeals_folder",
+            "overwrite",
+        )
+
+        expected_curated_data_after_writing = self.generate_curated_data()
+
+        inst = AppealFolderCurationProcess(spark)
+        result = inst.run(
+            orchestration_run_id="t_afcp_r_wned",
+            orchestration_entity_name="appeal_folder",
+            orchestration_stage_name="curate",
+        )
+        assert_etl_result_successful(result)
+        actual_table_data = spark.table("odw_curated_db.appeal_folder")
+        assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
+
+    def test__appeal_folder_curation_process__run__maps_all_case_stage_values_and_lowercases_unmapped(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        harmonised_data = spark.createDataFrame(
+            data=[
+                ("301", "APP/301", "Folder 1", "Ffolder 1", "1", "9", "Pre-application", None, None, "row-301", "Y", "m-301"),
+                ("302", "APP/302", "Folder 2", "Ffolder 2", "2", "9", "Acceptance", None, None, "row-302", "Y", "m-302"),
+                ("303", "APP/303", "Folder 3", "Ffolder 3", "3", "9", "Pre-examination", None, None, "row-303", "Y", "m-303"),
+                ("304", "APP/304", "Folder 4", "Ffolder 4", "4", "9", "Examination", None, None, "row-304", "Y", "m-304"),
+                ("305", "APP/305", "Folder 5", "Ffolder 5", "5", "9", "Recommendation", None, None, "row-305", "Y", "m-305"),
+                ("306", "APP/306", "Folder 6", "Ffolder 6", "6", "9", "Decision", None, None, "row-306", "Y", "m-306"),
+                ("307", "APP/307", "Folder 7", "Ffolder 7", "7", "9", "Post decision", None, None, "row-307", "Y", "m-307"),
+                ("308", "APP/308", "Folder 8", "Ffolder 8", "8", "9", "Withdrawn", None, None, "row-308", "Y", "m-308"),
+                ("309", "APP/309", "Folder 9", "Ffolder 9", "9", "10", "Some Mixed Stage", None, None, "row-309", "Y", "m-309"),
+            ],
+            schema=T.StructType(
+                [
+                    T.StructField("ID", T.StringType(), True),
+                    T.StructField("CaseReference", T.StringType(), True),
+                    T.StructField("DisplayNameEnglish", T.StringType(), True),
+                    T.StructField("DisplayNameWelsh", T.StringType(), True),
+                    T.StructField("ParentFolderID", T.StringType(), True),
+                    T.StructField("CaseNodeId", T.StringType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                    T.StructField("IngestionDate", T.StringType(), True),
+                    T.StructField("ValidTo", T.StringType(), True),
+                    T.StructField("RowID", T.StringType(), True),
+                    T.StructField("IsActive", T.StringType(), True),
+                    T.StructField("message_id", T.StringType(), True),
+                ]
+            ),
+        )
+
+        self.write_existing_table(
+            spark,
+            harmonised_data,
+            "appeals_folder",
+            "odw_harmonised_db",
+            "odw-harmonised",
+            "appeals_folder",
+            "overwrite",
+        )
+
+        inst = AppealFolderCurationProcess(spark)
+        result = inst.run(
+            orchestration_run_id="t_afcp_stage_map",
+            orchestration_entity_name="appeal_folder",
+            orchestration_stage_name="curate",
+        )
+        assert_etl_result_successful(result)
+        actual_stage_data = spark.table("odw_curated_db.appeal_folder").select("id", "caseStage")
+
+        expected_stage_data = spark.createDataFrame(
+            [
+                (301, "pre-application"),
+                (302, "acceptance"),
+                (303, "pre-examination"),
+                (304, "examination"),
+                (305, "recommendation"),
+                (306, "decision"),
+                (307, "post_decision"),
+                (308, "withdrawn"),
+                (309, "some mixed stage"),
+            ],
+            schema=T.StructType(
+                [
+                    T.StructField("id", T.IntegerType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                ]
+            ),
+        )
+
+        assert_dataframes_equal(expected_stage_data, actual_stage_data)
+

--- a/odw/test/integration_test/etl/curated/test_appeal_folder_curation_process.py
+++ b/odw/test/integration_test/etl/curated/test_appeal_folder_curation_process.py
@@ -261,4 +261,3 @@ class TestAppealFolderCurationProcess(ETLTestCase):
         )
 
         assert_dataframes_equal(expected_stage_data, actual_stage_data)
-

--- a/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
+++ b/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
@@ -25,7 +25,20 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
         return spark.createDataFrame(
             data=self.ACTIVE_HARMONISED_DATA
             + [
-                ("102", "LFD/102", "Inquiry", "Inquiry CY", "30", "31", "Pre-examination", datetime(2025, 1, 3).isoformat(), None, "row-102-dupe", None, "m-102-dupe")
+                (
+                    "102",
+                    "LFD/102",
+                    "Inquiry",
+                    "Inquiry CY",
+                    "30",
+                    "31",
+                    "Pre-examination",
+                    datetime(2025, 1, 3).isoformat(),
+                    None,
+                    "row-102-dupe",
+                    None,
+                    "m-102-dupe",
+                )
             ],
             schema=T.StructType(
                 [
@@ -223,4 +236,3 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
         )
 
         assert_dataframes_equal(expected_stage_data, actual_stage_data)
-

--- a/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
+++ b/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
@@ -1,0 +1,226 @@
+from datetime import datetime
+
+import mock
+import odw.test.util.mock.import_mock_notebook_utils  # noqa: F401
+import pyspark.sql.types as T
+import pytest
+from odw.core.etl.transformation.curated.legacy_folder_data_curation_process import LegacyFolderDataCurationProcess
+from odw.test.integration_test.etl.etl_test_case import ETLTestCase
+from odw.test.util.assertion import assert_dataframes_equal, assert_etl_result_successful
+from odw.test.util.session_util import PytestSparkSessionUtil
+
+
+pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
+
+
+class TestLegacyFolderDataCurationProcess(ETLTestCase):
+    ACTIVE_HARMONISED_DATA = [
+        ("100", "LFD/100", "Core Docs", "Core Docs CY", "10", "11", "Decision", datetime(2025, 1, 1).isoformat(), None, "row-100", "Y", "m-100"),
+        ("101", "LFD/101", "Admin", "Admin CY", "20", "20", "Post decision", datetime(2025, 1, 2).isoformat(), None, "row-101", "N", "m-101"),
+        ("102", "LFD/102", "Inquiry", "Inquiry CY", "30", "31", "Pre-examination", datetime(2025, 1, 3).isoformat(), None, "row-102", None, "m-102"),
+    ]
+
+    def generate_harmonised_table(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+        return spark.createDataFrame(
+            data=self.ACTIVE_HARMONISED_DATA
+            + [
+                ("102", "LFD/102", "Inquiry", "Inquiry CY", "30", "31", "Pre-examination", datetime(2025, 1, 3).isoformat(), None, "row-102-dupe", None, "m-102-dupe")
+            ],
+            schema=T.StructType(
+                [
+                    T.StructField("ID", T.StringType(), True),
+                    T.StructField("CaseReference", T.StringType(), True),
+                    T.StructField("DisplayNameEnglish", T.StringType(), True),
+                    T.StructField("DisplayNameWelsh", T.StringType(), True),
+                    T.StructField("ParentFolderID", T.StringType(), True),
+                    T.StructField("CaseNodeId", T.StringType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                    T.StructField("IngestionDate", T.StringType(), True),
+                    T.StructField("ValidTo", T.StringType(), True),
+                    T.StructField("RowID", T.StringType(), True),
+                    T.StructField("IsActive", T.StringType(), True),
+                    T.StructField("message_id", T.StringType(), True),
+                ]
+            ),
+        )
+
+    def generate_curated_data_schema(self):
+        return T.StructType(
+            [
+                T.StructField("id", T.IntegerType(), True),
+                T.StructField("caseReference", T.StringType(), True),
+                T.StructField("displayNameEnglish", T.StringType(), True),
+                T.StructField("displayNameWelsh", T.StringType(), True),
+                T.StructField("parentFolderId", T.IntegerType(), True),
+                T.StructField("caseStage", T.StringType(), True),
+            ]
+        )
+
+    def generate_curated_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+        return spark.createDataFrame(
+            data=(
+                (100, "LFD/100", "Core Docs", "Core Docs CY", 10, "decision"),
+                (101, "LFD/101", "Admin", "Admin CY", None, "post_decision"),
+                (102, "LFD/102", "Inquiry", "Inquiry CY", 30, "pre-examination"),
+            ),
+            schema=self.generate_curated_data_schema(),
+        )
+
+    def test__legacy_folder_data_curation_process__run__with_existing_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        self.write_existing_table(
+            spark,
+            self.generate_harmonised_table(),
+            "horizon_folder",
+            "odw_harmonised_db",
+            "odw-harmonised",
+            "horizon_folder",
+            "overwrite",
+        )
+
+        existing_curated_data = spark.createDataFrame(
+            [(999, "LFD/999", "Old", "Old CY", None, "decision")],
+            self.generate_curated_data_schema(),
+        )
+
+        self.write_existing_table(
+            spark,
+            existing_curated_data,
+            "legacy_folder_data",
+            "odw_curated_db",
+            "odw-curated",
+            "legacy_folder_data",
+            "overwrite",
+        )
+
+        expected_curated_data_after_writing = self.generate_curated_data()
+
+        with mock.patch.object(
+            LegacyFolderDataCurationProcess,
+            "HARMONISED_TABLE",
+            "odw_harmonised_db.horizon_folder",
+        ):
+            inst = LegacyFolderDataCurationProcess(spark)
+            result = inst.run(
+                orchestration_run_id="t_lfdcp_r_wed",
+                orchestration_entity_name="legacy_folder_data",
+                orchestration_stage_name="curate",
+            )
+        assert_etl_result_successful(result)
+        actual_table_data = spark.table("odw_curated_db.legacy_folder_data")
+        assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
+
+    def test__legacy_folder_data_curation_process__run__with_no_existing_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        spark.sql("DROP TABLE IF EXISTS odw_curated_db.legacy_folder_data")
+
+        self.write_existing_table(
+            spark,
+            self.generate_harmonised_table(),
+            "horizon_folder",
+            "odw_harmonised_db",
+            "odw-harmonised",
+            "horizon_folder",
+            "overwrite",
+        )
+
+        expected_curated_data_after_writing = self.generate_curated_data()
+
+        with mock.patch.object(
+            LegacyFolderDataCurationProcess,
+            "HARMONISED_TABLE",
+            "odw_harmonised_db.horizon_folder",
+        ):
+            inst = LegacyFolderDataCurationProcess(spark)
+            result = inst.run(
+                orchestration_run_id="t_lfdcp_r_wned",
+                orchestration_entity_name="legacy_folder_data",
+                orchestration_stage_name="curate",
+            )
+        assert_etl_result_successful(result)
+        actual_table_data = spark.table("odw_curated_db.legacy_folder_data")
+        assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
+
+    def test__legacy_folder_data_curation_process__run__maps_all_case_stage_values_and_lowercases_unmapped(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        harmonised_data = spark.createDataFrame(
+            data=[
+                ("301", "LFD/301", "Folder 1", "Folder 1 CY", "1", "9", "Pre-application", None, None, "row-301", "Y", "m-301"),
+                ("302", "LFD/302", "Folder 2", "Folder 2 CY", "2", "9", "Acceptance", None, None, "row-302", "Y", "m-302"),
+                ("303", "LFD/303", "Folder 3", "Folder 3 CY", "3", "9", "Pre-examination", None, None, "row-303", "Y", "m-303"),
+                ("304", "LFD/304", "Folder 4", "Folder 4 CY", "4", "9", "Examination", None, None, "row-304", "Y", "m-304"),
+                ("305", "LFD/305", "Folder 5", "Folder 5 CY", "5", "9", "Recommendation", None, None, "row-305", "Y", "m-305"),
+                ("306", "LFD/306", "Folder 6", "Folder 6 CY", "6", "9", "Decision", None, None, "row-306", "Y", "m-306"),
+                ("307", "LFD/307", "Folder 7", "Folder 7 CY", "7", "9", "Post decision", None, None, "row-307", "Y", "m-307"),
+                ("308", "LFD/308", "Folder 8", "Folder 8 CY", "8", "9", "Withdrawn", None, None, "row-308", "Y", "m-308"),
+                ("309", "LFD/309", "Folder 9", "Folder 9 CY", "9", "10", "Some Mixed Stage", None, None, "row-309", "Y", "m-309"),
+            ],
+            schema=T.StructType(
+                [
+                    T.StructField("ID", T.StringType(), True),
+                    T.StructField("CaseReference", T.StringType(), True),
+                    T.StructField("DisplayNameEnglish", T.StringType(), True),
+                    T.StructField("DisplayNameWelsh", T.StringType(), True),
+                    T.StructField("ParentFolderID", T.StringType(), True),
+                    T.StructField("CaseNodeId", T.StringType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                    T.StructField("IngestionDate", T.StringType(), True),
+                    T.StructField("ValidTo", T.StringType(), True),
+                    T.StructField("RowID", T.StringType(), True),
+                    T.StructField("IsActive", T.StringType(), True),
+                    T.StructField("message_id", T.StringType(), True),
+                ]
+            ),
+        )
+
+        self.write_existing_table(
+            spark,
+            harmonised_data,
+            "horizon_folder",
+            "odw_harmonised_db",
+            "odw-harmonised",
+            "horizon_folder",
+            "overwrite",
+        )
+
+        with mock.patch.object(
+            LegacyFolderDataCurationProcess,
+            "HARMONISED_TABLE",
+            "odw_harmonised_db.horizon_folder",
+        ):
+            inst = LegacyFolderDataCurationProcess(spark)
+            result = inst.run(
+                orchestration_run_id="t_lfdcp_stage_map",
+                orchestration_entity_name="legacy_folder_data",
+                orchestration_stage_name="curate",
+            )
+        assert_etl_result_successful(result)
+        actual_stage_data = spark.table("odw_curated_db.legacy_folder_data").select("id", "caseStage")
+
+        expected_stage_data = spark.createDataFrame(
+            [
+                (301, "pre-application"),
+                (302, "acceptance"),
+                (303, "pre-examination"),
+                (304, "examination"),
+                (305, "recommendation"),
+                (306, "decision"),
+                (307, "post_decision"),
+                (308, "withdrawn"),
+                (309, "some mixed stage"),
+            ],
+            schema=T.StructType(
+                [
+                    T.StructField("id", T.IntegerType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                ]
+            ),
+        )
+
+        assert_dataframes_equal(expected_stage_data, actual_stage_data)
+

--- a/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
+++ b/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
@@ -114,11 +114,14 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
 
         expected_curated_data_after_writing = self.generate_curated_data()
 
-        with mock.patch.object(
-            LegacyFolderDataCurationProcess,
-            "HARMONISED_TABLE",
-            f"odw_harmonised_db.{harmonised_table}",
-        ), mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table):
+        with (
+            mock.patch.object(
+                LegacyFolderDataCurationProcess,
+                "HARMONISED_TABLE",
+                f"odw_harmonised_db.{harmonised_table}",
+            ),
+            mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table),
+        ):
             inst = LegacyFolderDataCurationProcess(spark)
             result = inst.run(
                 orchestration_run_id=test_case,
@@ -149,11 +152,14 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
 
         expected_curated_data_after_writing = self.generate_curated_data()
 
-        with mock.patch.object(
-            LegacyFolderDataCurationProcess,
-            "HARMONISED_TABLE",
-            f"odw_harmonised_db.{harmonised_table}",
-        ), mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table):
+        with (
+            mock.patch.object(
+                LegacyFolderDataCurationProcess,
+                "HARMONISED_TABLE",
+                f"odw_harmonised_db.{harmonised_table}",
+            ),
+            mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table),
+        ):
             inst = LegacyFolderDataCurationProcess(spark)
             result = inst.run(
                 orchestration_run_id=test_case,
@@ -210,11 +216,14 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
             "overwrite",
         )
 
-        with mock.patch.object(
-            LegacyFolderDataCurationProcess,
-            "HARMONISED_TABLE",
-            f"odw_harmonised_db.{harmonised_table}",
-        ), mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table):
+        with (
+            mock.patch.object(
+                LegacyFolderDataCurationProcess,
+                "HARMONISED_TABLE",
+                f"odw_harmonised_db.{harmonised_table}",
+            ),
+            mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table),
+        ):
             inst = LegacyFolderDataCurationProcess(spark)
             result = inst.run(
                 orchestration_run_id=test_case,

--- a/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
+++ b/odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py
@@ -82,15 +82,18 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
         )
 
     def test__legacy_folder_data_curation_process__run__with_existing_data(self):
+        test_case = "t_lfdcp_r_wed"
+        harmonised_table = f"{test_case}_horizon_folder"
+        curated_table = f"{test_case}_legacy_folder_data"
         spark = PytestSparkSessionUtil().get_spark_session()
 
         self.write_existing_table(
             spark,
             self.generate_harmonised_table(),
-            "horizon_folder",
+            harmonised_table,
             "odw_harmonised_db",
             "odw-harmonised",
-            "horizon_folder",
+            harmonised_table,
             "overwrite",
         )
 
@@ -102,10 +105,10 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
         self.write_existing_table(
             spark,
             existing_curated_data,
-            "legacy_folder_data",
+            curated_table,
             "odw_curated_db",
             "odw-curated",
-            "legacy_folder_data",
+            curated_table,
             "overwrite",
         )
 
@@ -114,30 +117,33 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
         with mock.patch.object(
             LegacyFolderDataCurationProcess,
             "HARMONISED_TABLE",
-            "odw_harmonised_db.horizon_folder",
-        ):
+            f"odw_harmonised_db.{harmonised_table}",
+        ), mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table):
             inst = LegacyFolderDataCurationProcess(spark)
             result = inst.run(
-                orchestration_run_id="t_lfdcp_r_wed",
+                orchestration_run_id=test_case,
                 orchestration_entity_name="legacy_folder_data",
                 orchestration_stage_name="curate",
             )
         assert_etl_result_successful(result)
-        actual_table_data = spark.table("odw_curated_db.legacy_folder_data")
+        actual_table_data = spark.table(f"odw_curated_db.{curated_table}")
         assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
 
     def test__legacy_folder_data_curation_process__run__with_no_existing_data(self):
+        test_case = "t_lfdcp_r_wned"
+        harmonised_table = f"{test_case}_horizon_folder"
+        curated_table = f"{test_case}_legacy_folder_data"
         spark = PytestSparkSessionUtil().get_spark_session()
 
-        spark.sql("DROP TABLE IF EXISTS odw_curated_db.legacy_folder_data")
+        spark.sql(f"DROP TABLE IF EXISTS odw_curated_db.{curated_table}")
 
         self.write_existing_table(
             spark,
             self.generate_harmonised_table(),
-            "horizon_folder",
+            harmonised_table,
             "odw_harmonised_db",
             "odw-harmonised",
-            "horizon_folder",
+            harmonised_table,
             "overwrite",
         )
 
@@ -146,19 +152,22 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
         with mock.patch.object(
             LegacyFolderDataCurationProcess,
             "HARMONISED_TABLE",
-            "odw_harmonised_db.horizon_folder",
-        ):
+            f"odw_harmonised_db.{harmonised_table}",
+        ), mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table):
             inst = LegacyFolderDataCurationProcess(spark)
             result = inst.run(
-                orchestration_run_id="t_lfdcp_r_wned",
+                orchestration_run_id=test_case,
                 orchestration_entity_name="legacy_folder_data",
                 orchestration_stage_name="curate",
             )
         assert_etl_result_successful(result)
-        actual_table_data = spark.table("odw_curated_db.legacy_folder_data")
+        actual_table_data = spark.table(f"odw_curated_db.{curated_table}")
         assert_dataframes_equal(expected_curated_data_after_writing, actual_table_data)
 
     def test__legacy_folder_data_curation_process__run__maps_all_case_stage_values_and_lowercases_unmapped(self):
+        test_case = "t_lfdcp_stage_map"
+        harmonised_table = f"{test_case}_horizon_folder"
+        curated_table = f"{test_case}_legacy_folder_data"
         spark = PytestSparkSessionUtil().get_spark_session()
 
         harmonised_data = spark.createDataFrame(
@@ -194,26 +203,26 @@ class TestLegacyFolderDataCurationProcess(ETLTestCase):
         self.write_existing_table(
             spark,
             harmonised_data,
-            "horizon_folder",
+            harmonised_table,
             "odw_harmonised_db",
             "odw-harmonised",
-            "horizon_folder",
+            harmonised_table,
             "overwrite",
         )
 
         with mock.patch.object(
             LegacyFolderDataCurationProcess,
             "HARMONISED_TABLE",
-            "odw_harmonised_db.horizon_folder",
-        ):
+            f"odw_harmonised_db.{harmonised_table}",
+        ), mock.patch.object(LegacyFolderDataCurationProcess, "OUTPUT_TABLE", curated_table):
             inst = LegacyFolderDataCurationProcess(spark)
             result = inst.run(
-                orchestration_run_id="t_lfdcp_stage_map",
+                orchestration_run_id=test_case,
                 orchestration_entity_name="legacy_folder_data",
                 orchestration_stage_name="curate",
             )
         assert_etl_result_successful(result)
-        actual_stage_data = spark.table("odw_curated_db.legacy_folder_data").select("id", "caseStage")
+        actual_stage_data = spark.table(f"odw_curated_db.{curated_table}").select("id", "caseStage")
 
         expected_stage_data = spark.createDataFrame(
             [

--- a/odw/test/unit_test/etl/curated/test_appeal_folder_curation_process.py
+++ b/odw/test/unit_test/etl/curated/test_appeal_folder_curation_process.py
@@ -1,0 +1,238 @@
+
+import mock
+import pyspark.sql.types as T
+import pytest
+from odw.core.etl.transformation.curated.appeal_folder_curation_process import AppealFolderCurationProcess
+from odw.core.util.util import Util
+from odw.test.util.assertion import assert_dataframes_equal
+from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.test.util.test_case import SparkTestCase
+
+
+pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
+
+
+def _harmonised_schema():
+    return T.StructType(
+        [
+            T.StructField("ID", T.StringType(), True),
+            T.StructField("CaseReference", T.StringType(), True),
+            T.StructField("DisplayNameEnglish", T.StringType(), True),
+            T.StructField("DisplayNameWelsh", T.StringType(), True),
+            T.StructField("ParentFolderID", T.StringType(), True),
+            T.StructField("CaseNodeId", T.StringType(), True),
+            T.StructField("caseStage", T.StringType(), True),
+            T.StructField("IsActive", T.StringType(), True),
+            T.StructField("extraCol", T.StringType(), True),
+        ]
+    )
+
+
+def _curated_schema():
+    return T.StructType(
+        [
+            T.StructField("id", T.IntegerType(), True),
+            T.StructField("caseReference", T.StringType(), True),
+            T.StructField("displayNameEnglish", T.StringType(), True),
+            T.StructField("displayNameWelsh", T.StringType(), True),
+            T.StructField("parentFolderId", T.IntegerType(), True),
+            T.StructField("caseStage", T.StringType(), True),
+        ]
+    )
+
+
+def _harmonised_rows():
+    return (
+        (
+            "100",
+            "APP/100",
+            "Core Documents",
+            "Dogfennau Craidd",
+            "10",
+            "11",
+            "Decision",
+            "Y",
+            "ignored",
+        ),
+        (
+            "101",
+            "APP/101",
+            "Case Admin",
+            "Gweinyddu Achos",
+            "20",
+            "20",
+            "Post decision",
+            "N",
+            "ignored",
+        ),
+        (
+            "102",
+            "APP/102",
+            "Inquiry",
+            "Ymchwiliad",
+            "30",
+            "31",
+            "Pre-examination",
+            None,
+            "ignored",
+        ),
+        # Duplicate row should be removed by DISTINCT logic.
+        (
+            "102",
+            "APP/102",
+            "Inquiry",
+            "Ymchwiliad",
+            "30",
+            "31",
+            "Pre-examination",
+            None,
+            "ignored",
+        ),
+    )
+
+
+def _expected_curated_rows():
+    return (
+        (100, "APP/100", "Core Documents", "Dogfennau Craidd", 10, "decision"),
+        (101, "APP/101", "Case Admin", "Gweinyddu Achos", None, "post_decision"),
+        (102, "APP/102", "Inquiry", "Ymchwiliad", 30, "pre-examination"),
+    )
+
+
+def _all_case_stage_harmonised_rows():
+    return (
+        ("201", "APP/201", "Folder 1", "Ffolder 1", "1", "9", "Pre-application", "Y", "ignored"),
+        ("202", "APP/202", "Folder 2", "Ffolder 2", "2", "9", "Acceptance", "Y", "ignored"),
+        ("203", "APP/203", "Folder 3", "Ffolder 3", "3", "9", "Pre-examination", "Y", "ignored"),
+        ("204", "APP/204", "Folder 4", "Ffolder 4", "4", "9", "Examination", "Y", "ignored"),
+        ("205", "APP/205", "Folder 5", "Ffolder 5", "5", "9", "Recommendation", "Y", "ignored"),
+        ("206", "APP/206", "Folder 6", "Ffolder 6", "6", "9", "Decision", "Y", "ignored"),
+        ("207", "APP/207", "Folder 7", "Ffolder 7", "7", "9", "Post decision", "Y", "ignored"),
+        ("208", "APP/208", "Folder 8", "Ffolder 8", "8", "9", "Withdrawn", "Y", "ignored"),
+        ("209", "APP/209", "Folder 9", "Ffolder 9", "9", "10", "Some Mixed Stage", "Y", "ignored"),
+    )
+
+
+class TestAppealFolderCurationProcess(SparkTestCase):
+    def test__appeal_folder__load_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+        harmonised_data = spark.createDataFrame(data=_harmonised_rows(), schema=_harmonised_schema())
+
+        self.write_existing_table(
+            spark,
+            harmonised_data,
+            table_name="tu_afcp_ld__harmonised",
+            database_name="odw_harmonised_db",
+            container="odw-harmonised",
+            blob_path="tu_afcp_ld__harmonised",
+            mode="overwrite",
+        )
+
+        expected_fetched_harmonised_data = spark.createDataFrame(
+            data=_expected_curated_rows(),
+            schema=_curated_schema(),
+        )
+
+        expected_output_keys = {"harmonised_data"}
+
+        with mock.patch.object(
+            AppealFolderCurationProcess,
+            "HARMONISED_TABLE",
+            "odw_harmonised_db.tu_afcp_ld__harmonised",
+        ):
+            inst = AppealFolderCurationProcess(spark)
+            actual_output = inst.load_data()
+            actual_keys = set(actual_output.keys())
+
+            assert expected_output_keys == actual_keys, (
+                f"Expected a dictionary with keys {expected_output_keys} to be returned by load_data(), but received the keys {actual_keys} instead"
+            )
+            assert_dataframes_equal(expected_fetched_harmonised_data, actual_output["harmonised_data"])
+
+    def test__appeal_folder__process(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        mock_data = {
+            "harmonised_data": spark.createDataFrame(
+                data=_expected_curated_rows(),
+                schema=_curated_schema(),
+            )
+        }
+
+        with mock.patch.object(Util, "get_storage_account", return_value="pinsstodwdevuks9h80mb.dfs.core.windows.net"):
+            expected_data_to_write = {
+                "odw_curated_db.appeal_folder": {
+                    "data": mock_data["harmonised_data"],
+                    "storage_kind": "ADLSG2-Table",
+                    "database_name": "odw_curated_db",
+                    "table_name": "appeal_folder",
+                    "storage_endpoint": Util.get_storage_account(),
+                    "container_name": "odw-curated",
+                    "blob_path": "appeal_folder",
+                    "file_format": "parquet",
+                    "write_mode": "overwrite",
+                    "write_options": {},
+                }
+            }
+
+            with mock.patch.object(AppealFolderCurationProcess, "__init__", return_value=None):
+                inst = AppealFolderCurationProcess()
+                actual_data_to_write, _ = inst.process(mock_data)
+
+                expected_data_to_write_without_data = {
+                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in expected_data_to_write.items()
+                }
+                actual_data_to_write_without_data = {
+                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in actual_data_to_write.items()
+                }
+
+                assert expected_data_to_write_without_data == actual_data_to_write_without_data
+                assert_dataframes_equal(
+                    expected_data_to_write["odw_curated_db.appeal_folder"]["data"],
+                    actual_data_to_write["odw_curated_db.appeal_folder"]["data"],
+                )
+
+    def test__appeal_folder__load_data__maps_all_legacy_case_stage_values_and_lowercases_unmapped(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        harmonised_data = spark.createDataFrame(data=_all_case_stage_harmonised_rows(), schema=_harmonised_schema())
+        self.write_existing_table(
+            spark,
+            harmonised_data,
+            table_name="tu_afcp_stage_map__harmonised",
+            database_name="odw_harmonised_db",
+            container="odw-harmonised",
+            blob_path="tu_afcp_stage_map__harmonised",
+            mode="overwrite",
+        )
+
+        expected_case_stage_df = spark.createDataFrame(
+            data=(
+                (201, "pre-application"),
+                (202, "acceptance"),
+                (203, "pre-examination"),
+                (204, "examination"),
+                (205, "recommendation"),
+                (206, "decision"),
+                (207, "post_decision"),
+                (208, "withdrawn"),
+                (209, "some mixed stage"),
+            ),
+            schema=T.StructType(
+                [
+                    T.StructField("id", T.IntegerType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                ]
+            ),
+        )
+
+        with mock.patch.object(
+            AppealFolderCurationProcess,
+            "HARMONISED_TABLE",
+            "odw_harmonised_db.tu_afcp_stage_map__harmonised",
+        ):
+            inst = AppealFolderCurationProcess(spark)
+            actual_output = inst.load_data()
+            actual_case_stage_df = actual_output["harmonised_data"].select("id", "caseStage")
+            assert_dataframes_equal(expected_case_stage_df, actual_case_stage_df)
+

--- a/odw/test/unit_test/etl/curated/test_appeal_folder_curation_process.py
+++ b/odw/test/unit_test/etl/curated/test_appeal_folder_curation_process.py
@@ -1,4 +1,3 @@
-
 import mock
 import pyspark.sql.types as T
 import pytest
@@ -179,12 +178,8 @@ class TestAppealFolderCurationProcess(SparkTestCase):
                 inst = AppealFolderCurationProcess()
                 actual_data_to_write, _ = inst.process(mock_data)
 
-                expected_data_to_write_without_data = {
-                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in expected_data_to_write.items()
-                }
-                actual_data_to_write_without_data = {
-                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in actual_data_to_write.items()
-                }
+                expected_data_to_write_without_data = {k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in expected_data_to_write.items()}
+                actual_data_to_write_without_data = {k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in actual_data_to_write.items()}
 
                 assert expected_data_to_write_without_data == actual_data_to_write_without_data
                 assert_dataframes_equal(
@@ -235,4 +230,3 @@ class TestAppealFolderCurationProcess(SparkTestCase):
             actual_output = inst.load_data()
             actual_case_stage_df = actual_output["harmonised_data"].select("id", "caseStage")
             assert_dataframes_equal(expected_case_stage_df, actual_case_stage_df)
-

--- a/odw/test/unit_test/etl/curated/test_legacy_folder_data_curation_process.py
+++ b/odw/test/unit_test/etl/curated/test_legacy_folder_data_curation_process.py
@@ -1,0 +1,196 @@
+import mock
+import pyspark.sql.types as T
+import pytest
+from odw.core.etl.transformation.curated.legacy_folder_data_curation_process import LegacyFolderDataCurationProcess
+from odw.core.util.util import Util
+from odw.test.util.assertion import assert_dataframes_equal
+from odw.test.util.session_util import PytestSparkSessionUtil
+from odw.test.util.test_case import SparkTestCase
+
+
+pytestmark = pytest.mark.xfail(reason="Curated logic not implemented yet")
+
+
+def _harmonised_schema():
+    return T.StructType(
+        [
+            T.StructField("ID", T.StringType(), True),
+            T.StructField("CaseReference", T.StringType(), True),
+            T.StructField("DisplayNameEnglish", T.StringType(), True),
+            T.StructField("DisplayNameWelsh", T.StringType(), True),
+            T.StructField("ParentFolderID", T.StringType(), True),
+            T.StructField("CaseNodeId", T.StringType(), True),
+            T.StructField("caseStage", T.StringType(), True),
+            T.StructField("IsActive", T.StringType(), True),
+            T.StructField("extraCol", T.StringType(), True),
+        ]
+    )
+
+
+def _curated_schema():
+    return T.StructType(
+        [
+            T.StructField("id", T.IntegerType(), True),
+            T.StructField("caseReference", T.StringType(), True),
+            T.StructField("displayNameEnglish", T.StringType(), True),
+            T.StructField("displayNameWelsh", T.StringType(), True),
+            T.StructField("parentFolderId", T.IntegerType(), True),
+            T.StructField("caseStage", T.StringType(), True),
+        ]
+    )
+
+
+def _harmonised_rows():
+    return (
+        ("100", "LFD/100", "Core Docs", "Core Docs CY", "10", "11", "Decision", "Y", "ignored"),
+        ("101", "LFD/101", "Admin", "Admin CY", "20", "20", "Post decision", "N", "ignored"),
+        ("102", "LFD/102", "Inquiry", "Inquiry CY", "30", "31", "Pre-examination", None, "ignored"),
+        ("102", "LFD/102", "Inquiry", "Inquiry CY", "30", "31", "Pre-examination", None, "ignored"),
+    )
+
+
+def _expected_curated_rows():
+    return (
+        (100, "LFD/100", "Core Docs", "Core Docs CY", 10, "decision"),
+        (101, "LFD/101", "Admin", "Admin CY", None, "post_decision"),
+        (102, "LFD/102", "Inquiry", "Inquiry CY", 30, "pre-examination"),
+    )
+
+
+def _all_case_stage_harmonised_rows():
+    return (
+        ("201", "LFD/201", "Folder 1", "Folder 1 CY", "1", "9", "Pre-application", "Y", "ignored"),
+        ("202", "LFD/202", "Folder 2", "Folder 2 CY", "2", "9", "Acceptance", "Y", "ignored"),
+        ("203", "LFD/203", "Folder 3", "Folder 3 CY", "3", "9", "Pre-examination", "Y", "ignored"),
+        ("204", "LFD/204", "Folder 4", "Folder 4 CY", "4", "9", "Examination", "Y", "ignored"),
+        ("205", "LFD/205", "Folder 5", "Folder 5 CY", "5", "9", "Recommendation", "Y", "ignored"),
+        ("206", "LFD/206", "Folder 6", "Folder 6 CY", "6", "9", "Decision", "Y", "ignored"),
+        ("207", "LFD/207", "Folder 7", "Folder 7 CY", "7", "9", "Post decision", "Y", "ignored"),
+        ("208", "LFD/208", "Folder 8", "Folder 8 CY", "8", "9", "Withdrawn", "Y", "ignored"),
+        ("209", "LFD/209", "Folder 9", "Folder 9 CY", "9", "10", "Some Mixed Stage", "Y", "ignored"),
+    )
+
+
+class TestLegacyFolderDataCurationProcess(SparkTestCase):
+    def test__legacy_folder_data__load_data(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+        harmonised_data = spark.createDataFrame(data=_harmonised_rows(), schema=_harmonised_schema())
+
+        self.write_existing_table(
+            spark,
+            harmonised_data,
+            table_name="horizon_folder",
+            database_name="odw_harmonised_db",
+            container="odw-harmonised",
+            blob_path="horizon_folder",
+            mode="overwrite",
+        )
+
+        expected_fetched_harmonised_data = spark.createDataFrame(
+            data=_expected_curated_rows(),
+            schema=_curated_schema(),
+        )
+
+        expected_output_keys = {"harmonised_data"}
+
+        with mock.patch.object(
+            LegacyFolderDataCurationProcess,
+            "HARMONISED_TABLE",
+            "odw_harmonised_db.horizon_folder",
+        ):
+            inst = LegacyFolderDataCurationProcess(spark)
+            actual_output = inst.load_data()
+            actual_keys = set(actual_output.keys())
+
+            assert expected_output_keys == actual_keys, (
+                f"Expected a dictionary with keys {expected_output_keys} to be returned by load_data(), but received the keys {actual_keys} instead"
+            )
+            assert_dataframes_equal(expected_fetched_harmonised_data, actual_output["harmonised_data"])
+
+    def test__legacy_folder_data__process(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        mock_data = {
+            "harmonised_data": spark.createDataFrame(
+                data=_expected_curated_rows(),
+                schema=_curated_schema(),
+            )
+        }
+
+        with mock.patch.object(Util, "get_storage_account", return_value="pinsstodwdevuks9h80mb.dfs.core.windows.net"):
+            expected_data_to_write = {
+                "odw_curated_db.legacy_folder_data": {
+                    "data": mock_data["harmonised_data"],
+                    "storage_kind": "ADLSG2-Table",
+                    "database_name": "odw_curated_db",
+                    "table_name": "legacy_folder_data",
+                    "storage_endpoint": Util.get_storage_account(),
+                    "container_name": "odw-curated",
+                    "blob_path": "legacy_folder_data",
+                    "file_format": "parquet",
+                    "write_mode": "overwrite",
+                    "write_options": {},
+                }
+            }
+
+            with mock.patch.object(LegacyFolderDataCurationProcess, "__init__", return_value=None):
+                inst = LegacyFolderDataCurationProcess()
+                actual_data_to_write, _ = inst.process(mock_data)
+
+                expected_data_to_write_without_data = {
+                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in expected_data_to_write.items()
+                }
+                actual_data_to_write_without_data = {
+                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in actual_data_to_write.items()
+                }
+
+                assert expected_data_to_write_without_data == actual_data_to_write_without_data
+                assert_dataframes_equal(
+                    expected_data_to_write["odw_curated_db.legacy_folder_data"]["data"],
+                    actual_data_to_write["odw_curated_db.legacy_folder_data"]["data"],
+                )
+
+    def test__legacy_folder_data__load_data__maps_all_legacy_case_stage_values_and_lowercases_unmapped(self):
+        spark = PytestSparkSessionUtil().get_spark_session()
+
+        harmonised_data = spark.createDataFrame(data=_all_case_stage_harmonised_rows(), schema=_harmonised_schema())
+        self.write_existing_table(
+            spark,
+            harmonised_data,
+            table_name="horizon_folder",
+            database_name="odw_harmonised_db",
+            container="odw-harmonised",
+            blob_path="horizon_folder",
+            mode="overwrite",
+        )
+
+        expected_case_stage_df = spark.createDataFrame(
+            data=(
+                (201, "pre-application"),
+                (202, "acceptance"),
+                (203, "pre-examination"),
+                (204, "examination"),
+                (205, "recommendation"),
+                (206, "decision"),
+                (207, "post_decision"),
+                (208, "withdrawn"),
+                (209, "some mixed stage"),
+            ),
+            schema=T.StructType(
+                [
+                    T.StructField("id", T.IntegerType(), True),
+                    T.StructField("caseStage", T.StringType(), True),
+                ]
+            ),
+        )
+
+        with mock.patch.object(
+            LegacyFolderDataCurationProcess,
+            "HARMONISED_TABLE",
+            "odw_harmonised_db.horizon_folder",
+        ):
+            inst = LegacyFolderDataCurationProcess(spark)
+            actual_output = inst.load_data()
+            actual_case_stage_df = actual_output["harmonised_data"].select("id", "caseStage")
+            assert_dataframes_equal(expected_case_stage_df, actual_case_stage_df)
+

--- a/odw/test/unit_test/etl/curated/test_legacy_folder_data_curation_process.py
+++ b/odw/test/unit_test/etl/curated/test_legacy_folder_data_curation_process.py
@@ -137,12 +137,8 @@ class TestLegacyFolderDataCurationProcess(SparkTestCase):
                 inst = LegacyFolderDataCurationProcess()
                 actual_data_to_write, _ = inst.process(mock_data)
 
-                expected_data_to_write_without_data = {
-                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in expected_data_to_write.items()
-                }
-                actual_data_to_write_without_data = {
-                    k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in actual_data_to_write.items()
-                }
+                expected_data_to_write_without_data = {k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in expected_data_to_write.items()}
+                actual_data_to_write_without_data = {k: {sk: sv for sk, sv in v.items() if sk != "data"} for k, v in actual_data_to_write.items()}
 
                 assert expected_data_to_write_without_data == actual_data_to_write_without_data
                 assert_dataframes_equal(
@@ -193,4 +189,3 @@ class TestLegacyFolderDataCurationProcess(SparkTestCase):
             actual_output = inst.load_data()
             actual_case_stage_df = actual_output["harmonised_data"].select("id", "caseStage")
             assert_dataframes_equal(expected_case_stage_df, actual_case_stage_df)
-

--- a/odw/test/unit_test/etl/curated/test_legacy_folder_data_curation_process.py
+++ b/odw/test/unit_test/etl/curated/test_legacy_folder_data_curation_process.py
@@ -73,16 +73,18 @@ def _all_case_stage_harmonised_rows():
 
 class TestLegacyFolderDataCurationProcess(SparkTestCase):
     def test__legacy_folder_data__load_data(self):
+        test_case = "t_lfdcp_ld"
         spark = PytestSparkSessionUtil().get_spark_session()
         harmonised_data = spark.createDataFrame(data=_harmonised_rows(), schema=_harmonised_schema())
 
+        table_name = f"{test_case}_horizon_folder"
         self.write_existing_table(
             spark,
             harmonised_data,
-            table_name="horizon_folder",
+            table_name=table_name,
             database_name="odw_harmonised_db",
             container="odw-harmonised",
-            blob_path="horizon_folder",
+            blob_path=table_name,
             mode="overwrite",
         )
 
@@ -96,7 +98,7 @@ class TestLegacyFolderDataCurationProcess(SparkTestCase):
         with mock.patch.object(
             LegacyFolderDataCurationProcess,
             "HARMONISED_TABLE",
-            "odw_harmonised_db.horizon_folder",
+            f"odw_harmonised_db.{test_case}_horizon_folder",
         ):
             inst = LegacyFolderDataCurationProcess(spark)
             actual_output = inst.load_data()
@@ -147,16 +149,18 @@ class TestLegacyFolderDataCurationProcess(SparkTestCase):
                 )
 
     def test__legacy_folder_data__load_data__maps_all_legacy_case_stage_values_and_lowercases_unmapped(self):
+        test_case = "t_lfdcp_ld_mlcsvlu"
         spark = PytestSparkSessionUtil().get_spark_session()
 
         harmonised_data = spark.createDataFrame(data=_all_case_stage_harmonised_rows(), schema=_harmonised_schema())
+        table_name = f"{test_case}_horizon_folder"
         self.write_existing_table(
             spark,
             harmonised_data,
-            table_name="horizon_folder",
+            table_name=table_name,
             database_name="odw_harmonised_db",
             container="odw-harmonised",
-            blob_path="horizon_folder",
+            blob_path=table_name,
             mode="overwrite",
         )
 
@@ -183,7 +187,7 @@ class TestLegacyFolderDataCurationProcess(SparkTestCase):
         with mock.patch.object(
             LegacyFolderDataCurationProcess,
             "HARMONISED_TABLE",
-            "odw_harmonised_db.horizon_folder",
+            f"odw_harmonised_db.{test_case}_horizon_folder",
         ):
             inst = LegacyFolderDataCurationProcess(spark)
             actual_output = inst.load_data()


### PR DESCRIPTION
Jira : https://pins-ds.atlassian.net/browse/THEODW-2959

PR Summary : 
1) Appeals Folder Curation (appeals_folder_curated)
Added new process:
odw/core/etl/transformation/curated/appeal_folder_curation_process.py
Added unit tests:
odw/test/unit_test/etl/curated/test_appeal_folder_curation_process.py
Added integration tests:
odw/test/integration_test/etl/curated/test_appeal_folder_curation_process.py
2) Legacy Folder Data Curation (legacy_folder_data)
Added new process :
odw/core/etl/transformation/curated/legacy_folder_data_curation_process.py
Added unit tests:
odw/test/unit_test/etl/curated/test_legacy_folder_data_curation_process.py
Added integration tests:
odw/test/integration_test/etl/curated/test_legacy_folder_data_curation_process.py

**PR Template**

Note: Run the correct ADO pipeline for this PR - check the list here:
[ODW Repositories](https://pins-ds.atlassian.net/wiki/spaces/ODW/pages/2285764637/ODW+repositories)
 1. JIRA Ticket Reference  :
         <!-- Replace with JIRA ticket number and title -->
    [ Enter JIRA ticket number and Title here]

 2.  Summary of the work : 
         <!-- Replace with a short summary of changes -->
    [ Enter Summary here]
 
 3.  New Source-to-Raw Datasets
	
	 - [ ] New source data has been added
  	    - A trigger has been attached at the appropriate frequency

 4.  New Tables in Standardised Layer

   	 - [ ] New standardised tables have been created
		 -  orchestration.json is updated and tested in Dev, and PR is open or merged to main
		 -  Schema exists in odw-config/standardised-table-definitions or is about to be PRd
 
 5.   New Tables in Harmonised or Curated Layers

      - [ ] New harmonised or curated tables have been created
 		- Script is configured in the pipeline pln_post_deployments
        - Schema exists in odw-config/harmonised-table-definitions or curated-table-definitions or is about to be PRd
 
 6.  Schema or Column Changes
    (Only new columns or columns with changed data types are in scope)

     - [ ] Changes to table structure or columns
		  - py_change_table is set to run in pln_post_deployments
	      - A script has been created to backfill or populate new column(s) in Test and Prod
			 - [ ] Avoid dropping and recreating tables unless strictly necessary

 7. Script Execution in Build
	 - [ ] Scripts have run in isolation in Build
		-  Script has been added to pln_post_deployments
	    -  Script is now part of a scheduled pipeline with correct triggers
	 - [ ] No scripts have run or no action required in Test/Prod

8. Table Creation and Schema Validation
   
  	 - [ ] All required tables have been created
  	 - [ ] Schema has been validated against the requirements

9.  Deployment and Schema Change Documentation
	
  	 - [ ] Deployment steps and rollback procedures are documented
  	 - [ ] Schema change handling is outlined and tested

10. Archiving Process Review

  	 - [ ] Automatic archiving logic has been reviewed
  	 - [ ] Archiving schedules and retention policies are validated
 
