### PR TITLE
Updating notebook: py_sb_raw_to_std

### DIFF
--- a/workspace/notebook/py_sb_raw_to_std.json
+++ b/workspace/notebook/py_sb_raw_to_std.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8480c675-9fe8-4e76-85cb-ab013d672eec"
+				"spark.autotune.trackingId": "ffc04348-6376-4fa6-bc9e-17c14c712eb2"
 			}
 		},
 		"metadata": {
@@ -123,7 +123,8 @@
 					"entity_name = 'appeal-has'\n",
 					"raw_entity_path = ''\n",
 					"standardised_table = ''\n",
-					"watermark_column = 'message_enqueued_time_utc'\n"
+					"watermark_column = 'message_enqueued_time_utc'\n",
+					""
 				],
 				"execution_count": null
 			},
@@ -133,7 +134,7 @@
 					"import json\n",
 					"from pyspark.sql import SparkSession\n",
 					"from notebookutils import mssparkutils\n",
-					"from datetime import datetime\n",
+					"from datetime import datetime, timedelta\n",
 					"from pyspark.sql import DataFrame\n",
 					"from pyspark.sql.types import StructType\n",
 					"import pyspark.sql.functions as F\n",
@@ -234,9 +235,12 @@
 			{
 				"cell_type": "code",
 				"source": [
-					"def read_raw_messages(source_path: str) -> DataFrame:\n",
+					"def read_raw_messages(source_path: str, last_ingest_time: str = None) -> DataFrame:\n",
 					"    \"\"\"\n",
-					"    Reads all service bus messages stored as JSON files under the entity raw path.\n",
+					"    Reads service bus messages stored as JSON files under the entity raw path.\n",
+					"    When a watermark (last_ingest_time) is provided and the entity is in the\n",
+					"    rollout list, uses Spark's modifiedAfter option to skip reading historical\n",
+					"    files at the storage level before parsing any JSON.\n",
 					"    Returns an empty DataFrame (with schema if provided) when no files exist.\n",
 					"    \"\"\"\n",
 					"    reader = (\n",
@@ -244,6 +248,27 @@
 					"        .option(\"multiline\", \"true\")\n",
 					"        .option(\"recursiveFileLookup\", \"true\")\n",
 					"    )\n",
+					"\n",
+					"    # ── PHASED ROLLOUT GUARD ──────────────────────────────────────────\n",
+					"    # Phase 1: Only appeal-document uses file-level filtering\n",
+					"    # Phase 2: Add more entities to the list after validation\n",
+					"    # Phase 3: Set to None to enable for ALL entities\n",
+					"    # Phase 4: Remove the guard entirely and keep only the modifiedAfter logic\n",
+					"    ENABLE_FILE_FILTER_ENTITIES = [\"appeal-document\"]\n",
+					"\n",
+					"    if last_ingest_time:\n",
+					"        if ENABLE_FILE_FILTER_ENTITIES is None or entity_name in ENABLE_FILE_FILTER_ENTITIES:\n",
+					"            try:\n",
+					"                wm_dt = datetime.strptime(last_ingest_time[:19], \"%Y-%m-%d %H:%M:%S\")\n",
+					"                buffer_dt = wm_dt - timedelta(days=1)\n",
+					"                modified_after_str = buffer_dt.strftime(\"%Y-%m-%dT%H:%M:%S\")\n",
+					"                reader = reader.option(\"modifiedAfter\", modified_after_str)\n",
+					"                logInfo(f\"modifiedAfter filter applied: only reading files modified after {modified_after_str}\")\n",
+					"            except Exception as parse_err:\n",
+					"                logInfo(f\"Could not parse watermark for modifiedAfter, reading all files: {parse_err}\")\n",
+					"        else:\n",
+					"            logInfo(f\"modifiedAfter filter NOT applied for {entity_name} (not in rollout list)\")\n",
+					"\n",
 					"    if spark_schema:\n",
 					"        reader = reader.schema(spark_schema)\n",
 					"\n",
@@ -259,12 +284,12 @@
 					"\n",
 					"    df = (\n",
 					"        df.withColumn(\"expected_from\", F.current_timestamp())\n",
-					"          .withColumn(\"expected_to\", F.expr(\"current_timestamp() + INTERVAL 1 DAY\"))\n",
-					"          .withColumn(\"ingested_datetime\", F.to_timestamp(watermark_column))\n",
-					"          .withColumn(\"input_file\", F.input_file_name())\n",
+					"        .withColumn(\"expected_to\", F.expr(\"current_timestamp() + INTERVAL 1 DAY\"))\n",
+					"        .withColumn(\"ingested_datetime\", F.to_timestamp(watermark_column))\n",
+					"        .withColumn(\"input_file\", F.input_file_name())\n",
 					"    )\n",
 					"\n",
-					"    logInfo(f\"Read {df.count()} rows from {source_path}\")\n",
+					"    logInfo(f\"Read rows from {source_path} (file-level filter active: {last_ingest_time is not None and (ENABLE_FILE_FILTER_ENTITIES is None or entity_name in ENABLE_FILE_FILTER_ENTITIES)})\")\n",
 					"    return df\n",
 					""
 				],
@@ -295,7 +320,8 @@
 					"        a deduped DataFrame\n",
 					"    \"\"\"\n",
 					"    # Handle empty or missing DataFrame\n",
-					"    if df is None or df.rdd.isEmpty():\n",
+					"    # Using head(1) instead of rdd.isEmpty() to avoid expensive RDD materialisation\n",
+					"    if df is None or not df.head(1):\n",
 					"        logInfo(\"No rows found. Skipping dedupe step\")\n",
 					"        return df\n",
 					"    # removing duplicates while ignoring the ingestion dates columns\n",
@@ -367,17 +393,6 @@
 			{
 				"cell_type": "code",
 				"source": [
-					"df = run_step(\n",
-					"    \"Read raw messages from source path\",\n",
-					"    lambda: read_raw_messages(source_path=source_path)\n",
-					")\n",
-					""
-				],
-				"execution_count": null
-			},
-			{
-				"cell_type": "code",
-				"source": [
 					"last_ingest_time = None\n",
 					"try:\n",
 					"    wm_row = spark.sql(\n",
@@ -391,7 +406,17 @@
 					"    else:\n",
 					"        logInfo(f\"No watermark found for {entity_name} — all RAW records will be processed\")\n",
 					"except Exception as e:\n",
-					"    logInfo(f\"Watermark table not accessible, processing all RAW records: {str(e)[:200]}\")\n",
+					"    logInfo(f\"Watermark table not accessible, processing all RAW records: {str(e)[:200]}\")"
+				],
+				"execution_count": null
+			},
+			{
+				"cell_type": "code",
+				"source": [
+					"df = run_step(\n",
+					"    \"Read raw messages from source path\",\n",
+					"    lambda: read_raw_messages(source_path=source_path, last_ingest_time=last_ingest_time)\n",
+					")\n",
 					""
 				],
 				"execution_count": null
@@ -405,7 +430,9 @@
 					"    )\n",
 					"    logInfo(f\"Watermark filter applied ({watermark_column} > {last_ingest_time})\")\n",
 					"\n",
-					"if df.count() == 0:\n",
+					"# Using head(1) instead of count() == 0 to avoid a full DataFrame scan\n",
+					"first_row = df.head(1)\n",
+					"if not first_row:\n",
 					"    logInfo(\"No new records after watermark filter — exiting gracefully.\")\n",
 					"    mssparkutils.notebook.exit(json.dumps({\n",
 					"        \"hasNewData\": False,\n",
@@ -451,6 +478,10 @@
 					"\n",
 					"    df = dedupe_dataframe(df=df)\n",
 					"\n",
+					"    # Cache the DataFrame — avoids re-reading from storage on subsequent actions\n",
+					"    # (append, anonymisation, count). Since we now read only recent files,\n",
+					"    # the cached DataFrame is small (~8,000 rows) and fits comfortably in memory.\n",
+					"    df.cache()\n",
 					"    rows_to_append = df.count()\n",
 					"    logInfo(f\"Rows to append: {rows_to_append}\")\n",
 					"\n",
@@ -521,11 +552,18 @@
 				"cell_type": "code",
 				"source": [
 					"def step_append_df_to_table():\n",
-					"    \n",
+					" \n",
 					"    logInfo(f\"Appending new rows to table {target_table}\")\n",
 					"    append_df_to_table(df=df, target_table=target_table)\n",
 					"    end_exec_time = datetime.now()\n",
 					"    logInfo(\"Done appending rows to table\")\n",
+					"\n",
+					"    # Release cached DataFrame to free Spark memory\n",
+					"    try:\n",
+					"        df.unpersist()\n",
+					"    except Exception:\n",
+					"        pass\n",
+					"\n",
 					"    return spark.table(target_table).count()\n",
 					"new_table_row_count=run_step(f\"|Append rows to table{target_table} and get new count\",step_append_df_to_table)"
 				],

--- a/workspace/notebook/py_sb_raw_to_std.json
+++ b/workspace/notebook/py_sb_raw_to_std.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "ffc04348-6376-4fa6-bc9e-17c14c712eb2"
+				"spark.autotune.trackingId": "3b71f733-4d1e-4216-9023-e3c86634728f"
 			}
 		},
 		"metadata": {
@@ -282,16 +282,15 @@
 					"            else spark.createDataFrame([], StructType())\n",
 					"        )\n",
 					"\n",
-					"    df = (\n",
-					"        df.withColumn(\"expected_from\", F.current_timestamp())\n",
-					"        .withColumn(\"expected_to\", F.expr(\"current_timestamp() + INTERVAL 1 DAY\"))\n",
-					"        .withColumn(\"ingested_datetime\", F.to_timestamp(watermark_column))\n",
-					"        .withColumn(\"input_file\", F.input_file_name())\n",
-					"    )\n",
+					"    df = df.withColumns({\n",
+					"        \"expected_from\": F.current_timestamp(),\n",
+					"        \"expected_to\": F.expr(\"current_timestamp() + INTERVAL 1 DAY\"),\n",
+					"        \"ingested_datetime\": F.to_timestamp(watermark_column),\n",
+					"        \"input_file\": F.input_file_name()\n",
+					"    })\n",
 					"\n",
 					"    logInfo(f\"Read rows from {source_path} (file-level filter active: {last_ingest_time is not None and (ENABLE_FILE_FILTER_ENTITIES is None or entity_name in ENABLE_FILE_FILTER_ENTITIES)})\")\n",
-					"    return df\n",
-					""
+					"    return df"
 				],
 				"execution_count": null
 			},


### PR DESCRIPTION
Jira:  https://pins-ds.atlassian.net/browse/THEODW-3327

Change Summary : 
update py_sb_raw_to_std to read only recent files using Spark's modifiedAfter file source option

Added last_ingest_time parameter to read_raw_messages function

Added modifiedAfter Spark option with 1-day buffer to skip historical files at storage level

Added ENABLE_FILE_FILTER_ENTITIES phased rollout guard — only appeal-document uses file filtering initially, other entities are completely unimpacted

Removed df.count() from log line — was triggering a full scan just for logging

Replaced df.rdd.isEmpty() with not df.head(1) in dedupe_dataframe — avoids expensive RDD materialisation

Swapped cell execution order so lookup runs before read_raw_messages

Replaced if df.count() == 0 with if not df.head(1) in empty check — avoids full scan

Added df.cache() after dedupe in calculate_expected_new_count — materialise once, reuse for all actions

Added df.unpersist() after append — releases cached memory

**PR Template**

Note: Run the correct ADO pipeline for this PR - check the list here:
[ODW Repositories](https://pins-ds.atlassian.net/wiki/spaces/ODW/pages/2285764637/ODW+repositories)
 1. JIRA Ticket Reference  :
         <!-- Replace with JIRA ticket number and title -->
    [ Enter JIRA ticket number and Title here]

 2.  Summary of the work : 
         <!-- Replace with a short summary of changes -->
    [ Enter Summary here]
 
 3.  New Source-to-Raw Datasets
	
	 - [ ] New source data has been added
  	    - A trigger has been attached at the appropriate frequency

 4.  New Tables in Standardised Layer

   	 - [ ] New standardised tables have been created
		 -  orchestration.json is updated and tested in Dev, and PR is open or merged to main
		 -  Schema exists in odw-config/standardised-table-definitions or is about to be PRd
 
 5.   New Tables in Harmonised or Curated Layers

      - [ ] New harmonised or curated tables have been created
 		- Script is configured in the pipeline pln_post_deployments
        - Schema exists in odw-config/harmonised-table-definitions or curated-table-definitions or is about to be PRd
 
 6.  Schema or Column Changes
    (Only new columns or columns with changed data types are in scope)

     - [ ] Changes to table structure or columns
		  - py_change_table is set to run in pln_post_deployments
	      - A script has been created to backfill or populate new column(s) in Test and Prod
			 - [ ] Avoid dropping and recreating tables unless strictly necessary

 7. Script Execution in Build
	 - [ ] Scripts have run in isolation in Build
		-  Script has been added to pln_post_deployments
	    -  Script is now part of a scheduled pipeline with correct triggers
	 - [ ] No scripts have run or no action required in Test/Prod

8. Table Creation and Schema Validation
   
  	 - [ ] All required tables have been created
  	 - [ ] Schema has been validated against the requirements

9.  Deployment and Schema Change Documentation
	
  	 - [ ] Deployment steps and rollback procedures are documented
  	 - [ ] Schema change handling is outlined and tested

10. Archiving Process Review

  	 - [ ] Automatic archiving logic has been reviewed
  	 - [ ] Archiving schedules and retention policies are validated
 
