### PR TITLE
THEODW-3424: MiPINS – add sp_update_dim_source_system to HAS & NSIP pipelines

### DIFF
--- a/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
@@ -328,7 +328,7 @@
 							"type": "Datetime"
 						},
 						"source_system": {
-							"value": "Back Office-s78",
+							"value": "BackOffice ",
 							"type": "String"
 						}
 					}

--- a/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
+++ b/workspace/pipeline/pln_copy_appeal_has_curated_mipins.json
@@ -125,7 +125,7 @@
 				"type": "SqlServerStoredProcedure",
 				"dependsOn": [
 					{
-						"activity": "copy_appeals_has_curated_mipins",
+						"activity": "SP_update dim_source_system",
 						"dependencyConditions": [
 							"Completed"
 						]
@@ -299,6 +299,43 @@
 						"value": "@utcNow()",
 						"type": "Expression"
 					}
+				}
+			},
+			{
+				"name": "SP_update dim_source_system",
+				"type": "SqlServerStoredProcedure",
+				"dependsOn": [
+					{
+						"activity": "copy_appeals_has_curated_mipins",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"storedProcedureName": "[Live].[upd_dim_source_system]",
+					"storedProcedureParameters": {
+						"refresh_date": {
+							"value": "@utcNow('yyyy-MM-ddTHH:mm:ss.fff')",
+							"type": "Datetime"
+						},
+						"source_system": {
+							"value": "Back Office-s78",
+							"type": "String"
+						}
+					}
+				},
+				"linkedServiceName": {
+					"referenceName": "ls_sql_mipins",
+					"type": "LinkedServiceReference"
 				}
 			}
 		],

--- a/workspace/pipeline/pln_copy_nsip_project_to_mipins.json
+++ b/workspace/pipeline/pln_copy_nsip_project_to_mipins.json
@@ -125,7 +125,7 @@
 				"type": "SqlServerStoredProcedure",
 				"dependsOn": [
 					{
-						"activity": "Copy NSIP Project",
+						"activity": "SP_update dim_source_system",
 						"dependencyConditions": [
 							"Completed"
 						]
@@ -299,6 +299,43 @@
 						"value": "@utcNow()",
 						"type": "Expression"
 					}
+				}
+			},
+			{
+				"name": "SP_update dim_source_system",
+				"type": "SqlServerStoredProcedure",
+				"dependsOn": [
+					{
+						"activity": "Copy NSIP Project",
+						"dependencyConditions": [
+							"Completed"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"storedProcedureName": "[Live].[upd_dim_source_system]",
+					"storedProcedureParameters": {
+						"refresh_date": {
+							"value": "@utcNow('yyyy-MM-ddTHH:mm:ss.fff')",
+							"type": "Datetime"
+						},
+						"source_system": {
+							"value": "NSIP Project",
+							"type": "String"
+						}
+					}
+				},
+				"linkedServiceName": {
+					"referenceName": "ls_sql_mipins",
+					"type": "LinkedServiceReference"
 				}
 			}
 		],


### PR DESCRIPTION
**PR link:** 

https://pins-ds.atlassian.net/browse/THEODW-3424

**Summary:**
This PR implements THEODW-3424 by adding the missing sp_update_dim_source_system step to the MiPINS HAS and NSIP Synapse pipelines so that source-system metadata is updated after each load and MiPINS Data Status can show a valid load date for these feeds.

**Changes:**

pln_copy_appeal_has_curated_mipins
Inserted a Stored Procedure activity calling sp_update_dim_source_system immediately after the copy_appeals_has_curated_mipins Copy Data activity and before Sp_log_success.


pln_copy_nsip_project_to_mipins
Inserted a Stored Procedure activity calling sp_update_dim_source_system immediately after the Copy NSIP Project Copy Data activity and before Sp_log_success.


**Before :** 
<img width="2322" height="1384" alt="image" src="https://github.com/user-attachments/assets/966421bf-be11-4d46-8d54-bdc4727daba3" />


After: 
<img width="2322" height="1384" alt="image" src="https://github.com/user-attachments/assets/e8c9c008-994a-4ea4-8366-b2eb000e1f0b" />
