### PR TITLE
Updating notebook: py_comment_type_ref

### DIFF
--- a/workspace/notebook/py_comment_type_ref.json
+++ b/workspace/notebook/py_comment_type_ref.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "7334c6f4-2e0c-483c-ad62-3f3de63a3c94"
+				"spark.autotune.trackingId": "5f6c1eb8-8c83-4ffc-be81-83aedbced1ff"
 			}
 		},
 		"metadata": {
@@ -97,8 +97,8 @@
 			{
 				"cell_type": "code",
 				"source": [
-					"spark_table_final = \"odw_harmonised_db.comment_state_ref\"\n",
-					"source_table = \"odw_standardised_db.casestatementreference\"\n",
+					"spark_table_final = \"odw_harmonised_db.comment_type_ref\"\n",
+					"source_table = \"odw_standardised_db.commenttypereference\"\n",
 					"\n",
 					"start_exec_time = datetime.now()\n",
 					"insert_count = 0\n",


### PR DESCRIPTION
Comment type reference - table is empty because name has given incorrect 


<img width="374" height="265" alt="image" src="https://github.com/user-attachments/assets/bd56a3ed-6812-4c65-97b7-57c7e735856d" />

<img width="715" height="540" alt="image" src="https://github.com/user-attachments/assets/9d74cd46-87e4-4790-9155-ac1f24c94054" />
